### PR TITLE
chore(deps): resolve dependabot updates (README fix, GH Actions v3, rmcp 1.2)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup show
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
@@ -94,7 +94,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup show
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Claude Code, Codex CLI, Claude, ChatGPT, Cursor, Antigravity 등 [MCP](https://m
 한 줄이면 설치 + 등록이 끝납니다. npm은 `npx -y`가 자동으로 바이너리를 다운로드합니다.
 
 <details>
-<summary>&amp;amp;amp;amp;amp;amp;lt;strong&amp;amp;amp;amp;amp;amp;gt;Claude Code&amp;amp;amp;amp;amp;amp;lt;/strong&amp;amp;amp;amp;amp;amp;gt; (터미널)</summary>
+<summary><strong>Claude Code</strong> (터미널)</summary>
 
 ```
 # npm (권장 — Rust 툴체인 불필요)
@@ -143,7 +143,7 @@ claude mcp add --global hwpforge -- npx -y @hwpforge/mcp
 </details>
 
 <details>
-<summary>&amp;amp;amp;amp;amp;amp;lt;strong&amp;amp;amp;amp;amp;amp;gt;Codex CLI&amp;amp;amp;amp;amp;amp;lt;/strong&amp;amp;amp;amp;amp;amp;gt; (터미널)</summary>
+<summary><strong>Codex CLI</strong> (터미널)</summary>
 
 `~/.codex/config.toml`에 추가:
 
@@ -162,7 +162,7 @@ codex mcp add hwpforge -- npx -y @hwpforge/mcp
 </details>
 
 <details>
-<summary>&amp;amp;amp;amp;amp;amp;lt;strong&amp;amp;amp;amp;amp;amp;gt;Claude Desktop&amp;amp;amp;amp;amp;amp;lt;/strong&amp;amp;amp;amp;amp;amp;gt; (앱)</summary>
+<summary><strong>Claude Desktop</strong> (앱)</summary>
 
 설정 파일을 편집합니다:
 
@@ -183,7 +183,7 @@ codex mcp add hwpforge -- npx -y @hwpforge/mcp
 </details>
 
 <details>
-<summary>&amp;amp;amp;amp;amp;amp;lt;strong&amp;amp;amp;amp;amp;amp;gt;ChatGPT Desktop&amp;amp;amp;amp;amp;amp;lt;/strong&amp;amp;amp;amp;amp;amp;gt; (앱)</summary>
+<summary><strong>ChatGPT Desktop</strong> (앱)</summary>
 
 Settings → Tools → Add MCP Server에서:
 
@@ -206,7 +206,7 @@ Settings → Tools → Add MCP Server에서:
 </details>
 
 <details>
-<summary>&amp;amp;amp;amp;amp;amp;lt;strong&amp;amp;amp;amp;amp;amp;gt;Cursor&amp;amp;amp;amp;amp;amp;lt;/strong&amp;amp;amp;amp;amp;amp;gt; (에디터)</summary>
+<summary><strong>Cursor</strong> (에디터)</summary>
 
 프로젝트 루트에 `.cursor/mcp.json` 생성:
 
@@ -224,7 +224,7 @@ Settings → Tools → Add MCP Server에서:
 </details>
 
 <details>
-<summary>&amp;amp;amp;amp;amp;amp;lt;strong&amp;amp;amp;amp;amp;amp;gt;Antigravity&amp;amp;amp;amp;amp;amp;lt;/strong&amp;amp;amp;amp;amp;amp;gt; (에디터)</summary>
+<summary><strong>Antigravity</strong> (에디터)</summary>
 
 `...` 드롭다운 → MCP Store → Manage MCP Servers → View raw config (`mcp_config.json`)에 추가:
 

--- a/crates/hwpforge-bindings-mcp/Cargo.toml
+++ b/crates/hwpforge-bindings-mcp/Cargo.toml
@@ -22,7 +22,7 @@ hwpforge-core = { path = "../hwpforge-core", version = "0.2.0" }
 hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.2.0" }
 hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0.2.0" }
 hwpforge-smithy-md = { path = "../hwpforge-smithy-md", version = "0.2.0" }
-rmcp = { version = "0.16", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "1.2", features = ["server", "macros", "transport-io"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hwpforge-bindings-mcp/src/prompts/convert_review.rs
+++ b/crates/hwpforge-bindings-mcp/src/prompts/convert_review.rs
@@ -52,8 +52,6 @@ hwpforge_validate({{ file_path: "result.hwpx" }})
 - 큰 변경은 섹션 단위로 분할 편집 권장"#
     );
 
-    Ok(GetPromptResult {
-        description: Some("HWPX 문서 JSON round-trip 편집 워크플로우".into()),
-        messages: vec![PromptMessage::new_text(PromptMessageRole::User, text)],
-    })
+    Ok(GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, text)])
+        .with_description("HWPX 문서 JSON round-trip 편집 워크플로우"))
 }

--- a/crates/hwpforge-bindings-mcp/src/prompts/mod.rs
+++ b/crates/hwpforge-bindings-mcp/src/prompts/mod.rs
@@ -14,91 +14,61 @@ mod report;
 pub fn list_prompts() -> Result<ListPromptsResult, McpError> {
     Ok(ListPromptsResult {
         prompts: vec![
-            Prompt {
-                name: "generate_proposal".into(),
-                title: Some("정부 제안서 생성".into()),
-                description: Some(
-                    "한국 정부 RFP 제안서를 마크다운으로 작성하고 HWPX로 변환하는 워크플로우"
-                        .into(),
-                ),
-                arguments: Some(vec![
-                    PromptArgument {
-                        name: "topic".into(),
-                        title: Some("제안서 주제".into()),
-                        description: Some("제안서의 주제 또는 사업명".into()),
-                        required: Some(true),
-                    },
-                    PromptArgument {
-                        name: "organization".into(),
-                        title: Some("제안 기관".into()),
-                        description: Some("제안 기관/회사명 (선택)".into()),
-                        required: Some(false),
-                    },
-                    PromptArgument {
-                        name: "deadline".into(),
-                        title: Some("제출 기한".into()),
-                        description: Some("제출 기한 (YYYY-MM-DD, 선택)".into()),
-                        required: Some(false),
-                    },
+            Prompt::new(
+                "generate_proposal",
+                Some("한국 정부 RFP 제안서를 마크다운으로 작성하고 HWPX로 변환하는 워크플로우"),
+                Some(vec![
+                    PromptArgument::new("topic")
+                        .with_title("제안서 주제")
+                        .with_description("제안서의 주제 또는 사업명")
+                        .with_required(true),
+                    PromptArgument::new("organization")
+                        .with_title("제안 기관")
+                        .with_description("제안 기관/회사명 (선택)")
+                        .with_required(false),
+                    PromptArgument::new("deadline")
+                        .with_title("제출 기한")
+                        .with_description("제출 기한 (YYYY-MM-DD, 선택)")
+                        .with_required(false),
                 ]),
-                icons: None,
-                meta: None,
-            },
-            Prompt {
-                name: "generate_report".into(),
-                title: Some("보고서 생성".into()),
-                description: Some(
-                    "연구/진행/분석 보고서를 마크다운으로 작성하고 HWPX로 변환하는 워크플로우"
-                        .into(),
-                ),
-                arguments: Some(vec![
-                    PromptArgument {
-                        name: "topic".into(),
-                        title: Some("보고서 주제".into()),
-                        description: Some("보고서의 주제".into()),
-                        required: Some(true),
-                    },
-                    PromptArgument {
-                        name: "author".into(),
-                        title: Some("저자".into()),
-                        description: Some("보고서 저자 (선택)".into()),
-                        required: Some(false),
-                    },
-                    PromptArgument {
-                        name: "report_type".into(),
-                        title: Some("보고서 유형".into()),
-                        description: Some(
-                            "보고서 종류: research/progress/analysis (선택, 기본: research)".into(),
-                        ),
-                        required: Some(false),
-                    },
+            )
+            .with_title("정부 제안서 생성"),
+            Prompt::new(
+                "generate_report",
+                Some("연구/진행/분석 보고서를 마크다운으로 작성하고 HWPX로 변환하는 워크플로우"),
+                Some(vec![
+                    PromptArgument::new("topic")
+                        .with_title("보고서 주제")
+                        .with_description("보고서의 주제")
+                        .with_required(true),
+                    PromptArgument::new("author")
+                        .with_title("저자")
+                        .with_description("보고서 저자 (선택)")
+                        .with_required(false),
+                    PromptArgument::new("report_type")
+                        .with_title("보고서 유형")
+                        .with_description(
+                            "보고서 종류: research/progress/analysis (선택, 기본: research)",
+                        )
+                        .with_required(false),
                 ]),
-                icons: None,
-                meta: None,
-            },
-            Prompt {
-                name: "convert_and_review".into(),
-                title: Some("문서 편집 워크플로우".into()),
-                description: Some(
-                    "기존 HWPX 문서를 JSON round-trip으로 편집하는 단계별 가이드".into(),
-                ),
-                arguments: Some(vec![
-                    PromptArgument {
-                        name: "file_path".into(),
-                        title: Some("HWPX 파일 경로".into()),
-                        description: Some("편집할 HWPX 파일의 경로".into()),
-                        required: Some(true),
-                    },
-                    PromptArgument {
-                        name: "edit_instructions".into(),
-                        title: Some("편집 지침".into()),
-                        description: Some("구체적인 편집 지침 (선택)".into()),
-                        required: Some(false),
-                    },
+            )
+            .with_title("보고서 생성"),
+            Prompt::new(
+                "convert_and_review",
+                Some("기존 HWPX 문서를 JSON round-trip으로 편집하는 단계별 가이드"),
+                Some(vec![
+                    PromptArgument::new("file_path")
+                        .with_title("HWPX 파일 경로")
+                        .with_description("편집할 HWPX 파일의 경로")
+                        .with_required(true),
+                    PromptArgument::new("edit_instructions")
+                        .with_title("편집 지침")
+                        .with_description("구체적인 편집 지침 (선택)")
+                        .with_required(false),
                 ]),
-                icons: None,
-                meta: None,
-            },
+            )
+            .with_title("문서 편집 워크플로우"),
         ],
         next_cursor: None,
         meta: None,

--- a/crates/hwpforge-bindings-mcp/src/prompts/proposal.rs
+++ b/crates/hwpforge-bindings-mcp/src/prompts/proposal.rs
@@ -46,8 +46,6 @@ pub fn get_prompt(
 hwpforge_convert({{ markdown: "<작성한_마크다운>", is_file: false, output_path: "proposal.hwpx", preset: "default" }})"#
     );
 
-    Ok(GetPromptResult {
-        description: Some("한국 정부 RFP 제안서 작성 워크플로우".into()),
-        messages: vec![PromptMessage::new_text(PromptMessageRole::User, text)],
-    })
+    Ok(GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, text)])
+        .with_description("한국 정부 RFP 제안서 작성 워크플로우"))
 }

--- a/crates/hwpforge-bindings-mcp/src/prompts/report.rs
+++ b/crates/hwpforge-bindings-mcp/src/prompts/report.rs
@@ -52,8 +52,6 @@ pub fn get_prompt(
 hwpforge_convert({{ markdown: "<작성한_마크다운>", is_file: false, output_path: "report.hwpx", preset: "default" }})"#
     );
 
-    Ok(GetPromptResult {
-        description: Some("보고서 작성 워크플로우".into()),
-        messages: vec![PromptMessage::new_text(PromptMessageRole::User, text)],
-    })
+    Ok(GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, text)])
+        .with_description("보고서 작성 워크플로우"))
 }

--- a/crates/hwpforge-bindings-mcp/src/resources/mod.rs
+++ b/crates/hwpforge-bindings-mcp/src/resources/mod.rs
@@ -160,7 +160,7 @@ pub fn read_resource(uri: &str) -> Result<ReadResourceResult, McpError> {
         _ => return Err(McpError::resource_not_found(format!("Unknown resource: {uri}"), None)),
     };
 
-    Ok(ReadResourceResult { contents: vec![ResourceContents::text(content, uri)] })
+    Ok(ReadResourceResult::new(vec![ResourceContents::text(content, uri)]))
 }
 
 #[cfg(test)]

--- a/crates/hwpforge-bindings-mcp/src/server.rs
+++ b/crates/hwpforge-bindings-mcp/src/server.rs
@@ -487,32 +487,27 @@ impl HwpForgeServer {
 #[tool_handler]
 impl ServerHandler for HwpForgeServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::LATEST,
-            capabilities: ServerCapabilities::builder()
+        ServerInfo::new(
+            ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()
                 .enable_prompts()
                 .build(),
-            server_info: Implementation {
-                name: "hwpforge-mcp".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                title: Some("HwpForge MCP Server".into()),
-                description: Some(
-                    "AI-first Korean HWPX document generation and editing tools".into(),
-                ),
-                icons: None,
-                website_url: Some("https://github.com/ai-screams/HwpForge".into()),
-            },
-            instructions: Some(
-                "HwpForge MCP server for Korean HWPX document generation and editing. \
-                 Converts Markdown to HWPX, inspects document structure, and supports \
-                 JSON round-trip editing. Use hwpforge_templates to discover available \
-                 style templates before creating documents. Resources provide style template \
-                 details. Prompts guide document creation workflows."
-                    .into(),
-            ),
-        }
+        )
+        .with_protocol_version(ProtocolVersion::LATEST)
+        .with_server_info(
+            Implementation::new("hwpforge-mcp", env!("CARGO_PKG_VERSION"))
+                .with_title("HwpForge MCP Server")
+                .with_description("AI-first Korean HWPX document generation and editing tools")
+                .with_website_url("https://github.com/ai-screams/HwpForge"),
+        )
+        .with_instructions(
+            "HwpForge MCP server for Korean HWPX document generation and editing. \
+             Converts Markdown to HWPX, inspects document structure, and supports \
+             JSON round-trip editing. Use hwpforge_templates to discover available \
+             style templates before creating documents. Resources provide style template \
+             details. Prompts guide document creation workflows.",
+        )
     }
 
     async fn list_resources(


### PR DESCRIPTION
## Summary

- **README fix**: `<details>/<summary>` 태그에서 6중 인코딩된 HTML 엔티티 수정 (`&amp;amp;...lt;` → `<strong>`)
- **GitHub Actions**: `actions/create-github-app-token` v2 → v3 (Node 24 지원, `release-plz.yml` 2곳)
- **rmcp 1.2**: 0.16 → 1.2 메이저 버전 업그레이드, `#[non_exhaustive]` 모델 타입 생성자 API 마이그레이션

## Migration Details (rmcp 0.16 → 1.2)

rmcp 1.2에서 model 타입들이 `#[non_exhaustive]`로 변경됨. 새 생성자 API 적용:
- `GetPromptResult::new(messages).with_description(...)`
- `Prompt::new(name, description, arguments).with_title(...)`
- `PromptArgument::new(name).with_title(...).with_description(...).with_required(...)`
- `ReadResourceResult::new(contents)`
- `ServerInfo` / `Implementation` 생성자 패턴

## Test plan

- [x] `cargo build -p hwpforge-bindings-mcp` 통과
- [x] `cargo test -p hwpforge-bindings-mcp` 37개 전체 통과
- [x] `make ci` (pre-push hook) 통과
- [x] 코드 리뷰 완료 (이상 없음)

Closes #47, Closes #48