### PR TITLE
feat(hwp5): Phase 11 Wave 0 — audit infrastructure

### DIFF
--- a/.audit/hwp5_baseline.json
+++ b/.audit/hwp5_baseline.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "fixtures_scanned": 79,
+  "fixtures_decoded": 79,
+  "fixtures_failed": 0,
+  "total_warnings": 9,
+  "categories": {
+    "DroppedControl:ole_object": {
+      "count": 8,
+      "fixtures": {
+        "tests/fixtures/charts/chart_01_single_column.hwp": 1,
+        "tests/fixtures/charts/chart_02_single_pie.hwp": 1,
+        "tests/fixtures/charts/chart_03_line_or_scatter.hwp": 1,
+        "tests/fixtures/mixed/full_report.hwp": 4,
+        "tests/fixtures/mixed/mixed_01_image_and_chart_same_doc.hwp": 1
+      }
+    },
+    "DroppedControl:rect": {
+      "count": 1,
+      "fixtures": {
+        "tests/fixtures/shapes/rect_simple.hwp": 1
+      }
+    }
+  },
+  "failures": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,20 @@ jobs:
       - name: cargo nextest run (all features, ci profile)
         run: cargo nextest run --workspace --all-features --profile ci
 
+  audit-hwp5:
+    name: "Verify › HWP5 Audit Gate"
+    needs: [plan, lint-format, lint-clippy]
+    if: always() && !failure() && !cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2
+      - name: Run audit gate
+        run: make audit-hwp5-gate
+
   coverage:
     name: "Verify › Coverage (≥ 90%)"
     needs: [plan, lint-format, lint-clippy]

--- a/.gitignore
+++ b/.gitignore
@@ -413,7 +413,13 @@ tags
 [Ll]ib64
 [Ll]ocal
 [Ss]cripts
+!scripts/
 pyvenv.cfg
+
+# HWP5 audit gate
+/.audit/hwp5_current.json
+/.audit/*.stderr
+/.audit/*.tmp
 pip-selfcheck.json
 
 ### VisualStudioCode ###

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: help install-tools check test test-ci clippy fmt fmt-fix lint-md lint-md-fix doc cov deny machete msrv ci ci-fast ci-full clean
+.PHONY: help install-tools check test test-ci clippy fmt fmt-fix lint-md lint-md-fix doc cov deny machete msrv ci ci-fast ci-full clean audit-hwp5 audit-hwp5-baseline audit-hwp5-gate
+
+AUDIT_HWP5_FIXTURE_DIRS ?= tests/fixtures crates/hwpforge-smithy-hwp5/tests/fixtures crates/hwpforge-smithy-hwpx/tests/fixtures
+AUDIT_HWP5_BASELINE   ?= .audit/hwp5_baseline.json
+AUDIT_HWP5_CURRENT    ?= .audit/hwp5_current.json
 
 MDBOOK_VERSION ?= 0.4.52
 MDBOOK_ADMONISH_VERSION ?= 1.20.0
@@ -111,6 +115,18 @@ ci-full: ci-fast cov msrv
 
 ci: ci-fast
 	@echo "✅ CI checks passed!"
+
+audit-hwp5:
+	@mkdir -p .audit
+	cargo run -q -p hwpforge-smithy-hwp5 --example audit_batch -- $(AUDIT_HWP5_FIXTURE_DIRS) > $(AUDIT_HWP5_CURRENT)
+	@echo "audit-hwp5 → $(AUDIT_HWP5_CURRENT)"
+
+audit-hwp5-baseline: audit-hwp5
+	cp $(AUDIT_HWP5_CURRENT) $(AUDIT_HWP5_BASELINE)
+	@echo "audit-hwp5 baseline refreshed → $(AUDIT_HWP5_BASELINE)"
+
+audit-hwp5-gate: audit-hwp5
+	python3 scripts/audit_hwp5_gate.py --baseline $(AUDIT_HWP5_BASELINE) --current $(AUDIT_HWP5_CURRENT)
 
 clean:
 	cargo clean

--- a/crates/hwpforge-smithy-hwp5/Cargo.toml
+++ b/crates/hwpforge-smithy-hwp5/Cargo.toml
@@ -27,3 +27,6 @@ quick-xml = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 zip = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/hwpforge-smithy-hwp5/examples/audit_batch.rs
+++ b/crates/hwpforge-smithy-hwp5/examples/audit_batch.rs
@@ -1,0 +1,173 @@
+//! Batch audit tool for Phase 11 Wave 0.
+//!
+//! Walks one or more directories for `.hwp` fixtures, runs `hwp5_to_hwpx_bytes`
+//! on each, and aggregates warnings into a JSON report grouped by semantic
+//! category. The output is used both as a one-time gap inventory and as the
+//! CI fidelity baseline (`.audit/hwp5_baseline.json`).
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run -p hwpforge-smithy-hwp5 --example audit_batch -- <dir> [<dir> ...]
+//! ```
+//!
+//! The JSON schema is intentionally simple so a small `jq` / diff step in CI
+//! can detect regressions without pulling additional dependencies.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use hwpforge_smithy_hwp5::{hwp5_to_hwpx_bytes, Hwp5Warning};
+use serde::Serialize;
+
+#[derive(Default, Serialize)]
+struct CategoryStats {
+    count: usize,
+    fixtures: BTreeMap<String, usize>,
+}
+
+#[derive(Default, Serialize)]
+struct FixtureFailure {
+    fixture: String,
+    error: String,
+}
+
+#[derive(Serialize)]
+struct AuditReport {
+    schema_version: u32,
+    fixtures_scanned: usize,
+    fixtures_decoded: usize,
+    fixtures_failed: usize,
+    total_warnings: usize,
+    categories: BTreeMap<String, CategoryStats>,
+    failures: Vec<FixtureFailure>,
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: audit_batch <dir> [<dir> ...]");
+        return ExitCode::from(2);
+    }
+
+    let mut hwp_paths: Vec<PathBuf> = Vec::new();
+    for arg in &args {
+        let root = PathBuf::from(arg);
+        if !root.exists() {
+            eprintln!("warning: skipping nonexistent path: {}", root.display());
+            continue;
+        }
+        collect_hwp_files(&root, &mut hwp_paths);
+    }
+    hwp_paths.sort();
+
+    let mut report = AuditReport {
+        schema_version: 1,
+        fixtures_scanned: hwp_paths.len(),
+        fixtures_decoded: 0,
+        fixtures_failed: 0,
+        total_warnings: 0,
+        categories: BTreeMap::new(),
+        failures: Vec::new(),
+    };
+
+    for path in &hwp_paths {
+        let bytes = match fs::read(path) {
+            Ok(b) => b,
+            Err(err) => {
+                report.fixtures_failed += 1;
+                report.failures.push(FixtureFailure {
+                    fixture: relative_label(path),
+                    error: format!("io: {err}"),
+                });
+                continue;
+            }
+        };
+
+        match hwp5_to_hwpx_bytes(&bytes) {
+            Ok((_hwpx_bytes, warnings)) => {
+                report.fixtures_decoded += 1;
+                report.total_warnings += warnings.len();
+                let fixture_label = relative_label(path);
+                for warning in &warnings {
+                    let key = category_key(warning);
+                    let entry = report.categories.entry(key).or_default();
+                    entry.count += 1;
+                    *entry.fixtures.entry(fixture_label.clone()).or_insert(0) += 1;
+                }
+            }
+            Err(err) => {
+                report.fixtures_failed += 1;
+                report.failures.push(FixtureFailure {
+                    fixture: relative_label(path),
+                    error: format!("{err}"),
+                });
+            }
+        }
+    }
+
+    let json = serde_json::to_string_pretty(&report).expect("audit report must serialize");
+    println!("{json}");
+    ExitCode::SUCCESS
+}
+
+fn collect_hwp_files(root: &Path, out: &mut Vec<PathBuf>) {
+    if root.is_file() {
+        if root.extension().and_then(|e| e.to_str()) == Some("hwp") {
+            out.push(root.to_path_buf());
+        }
+        return;
+    }
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_hwp_files(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("hwp") {
+            out.push(path);
+        }
+    }
+}
+
+fn category_key(warning: &Hwp5Warning) -> String {
+    match warning {
+        Hwp5Warning::UnsupportedTag { tag_id, .. } => {
+            format!("UnsupportedTag:0x{tag_id:04X}")
+        }
+        Hwp5Warning::SkippedStream { name } => {
+            format!("SkippedStream:{}", normalize_stream_name(name))
+        }
+        Hwp5Warning::DroppedControl { control, .. } => {
+            format!("DroppedControl:{control}")
+        }
+        Hwp5Warning::ProjectionFallback { subject, .. } => {
+            format!("ProjectionFallback:{subject}")
+        }
+        Hwp5Warning::ParserFallback { subject, .. } => {
+            format!("ParserFallback:{subject}")
+        }
+        _ => "Other:unknown".to_string(),
+    }
+}
+
+fn normalize_stream_name(name: &str) -> String {
+    // Section streams are numbered (Section0, Section1, ...). Collapse the
+    // numeric suffix so the category key stays stable across fixtures.
+    let trimmed = name.trim_start_matches('/');
+    if let Some(prefix) = trimmed.strip_prefix("BodyText/Section") {
+        if prefix.chars().all(|c| c.is_ascii_digit()) {
+            return "BodyText/SectionN".to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+fn relative_label(path: &Path) -> String {
+    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    path.strip_prefix(&cwd).unwrap_or(path).display().to_string()
+}

--- a/crates/hwpforge-smithy-hwp5/src/lib.rs
+++ b/crates/hwpforge-smithy-hwp5/src/lib.rs
@@ -568,8 +568,31 @@ pub fn hwp5_to_hwpx(
     output: impl AsRef<Path>,
 ) -> Hwp5Result<Vec<Hwp5Warning>> {
     let bytes = std::fs::read(input.as_ref()).map_err(Hwp5Error::Io)?;
-    let intermediate = decoder::decode_intermediate(&bytes)?;
-    let image_assets = join_hwp5_image_assets(&bytes, &intermediate)?;
+    let (hwpx_bytes, warnings) = hwp5_to_hwpx_bytes(&bytes)?;
+    std::fs::write(output.as_ref(), hwpx_bytes).map_err(Hwp5Error::Io)?;
+    Ok(warnings)
+}
+
+/// Convert HWP5 bytes to HWPX bytes in memory.
+///
+/// In-memory variant of [`hwp5_to_hwpx`]. Useful for chaining conversions
+/// (e.g. HWP5 -> HWPX -> Markdown) without touching the filesystem.
+///
+/// Returns the HWPX bytes alongside any non-fatal warnings encountered during
+/// decoding, projection, and style mapping.
+///
+/// # Examples
+///
+/// ```no_run
+/// use hwpforge_smithy_hwp5::hwp5_to_hwpx_bytes;
+///
+/// let hwp5_bytes = std::fs::read("input.hwp").unwrap();
+/// let (hwpx_bytes, warnings) = hwp5_to_hwpx_bytes(&hwp5_bytes).unwrap();
+/// println!("Produced {} bytes with {} warnings", hwpx_bytes.len(), warnings.len());
+/// ```
+pub fn hwp5_to_hwpx_bytes(bytes: &[u8]) -> Hwp5Result<(Vec<u8>, Vec<Hwp5Warning>)> {
+    let intermediate = decoder::decode_intermediate(bytes)?;
+    let image_assets = join_hwp5_image_assets(bytes, &intermediate)?;
     let layout_hints = layout_hint_patch::capture_layout_hints(&intermediate.sections);
     let mut warnings = intermediate.warnings;
 
@@ -577,7 +600,6 @@ pub fn hwp5_to_hwpx(
         project_doc_info_styles_with_warnings(&intermediate.doc_info);
     warnings.extend(style_warnings);
 
-    // Stage 4: Projection
     let (document, mut image_store, proj_warnings) =
         projection::project_to_core_with_images(intermediate.sections, &image_assets)?;
     warnings.extend(proj_warnings);
@@ -588,15 +610,13 @@ pub fn hwp5_to_hwpx(
         &mut warnings,
     );
 
-    // Stage 5: Validate + encode as HWPX
     let validated = document.validate().map_err(Hwp5Error::Core)?;
     let hwpx_bytes =
         hwpforge_smithy_hwpx::HwpxEncoder::encode(&validated, &hwpx_style_store, &image_store)
             .map_err(|e| Hwp5Error::Cfb { detail: format!("HWPX encoding failed: {e}") })?;
     let hwpx_bytes = layout_hint_patch::patch_hwpx_layout_hints(&hwpx_bytes, &layout_hints)?;
-    std::fs::write(output.as_ref(), hwpx_bytes).map_err(Hwp5Error::Io)?;
 
-    Ok(warnings)
+    Ok((hwpx_bytes, warnings))
 }
 
 fn supplement_border_fill_image_assets(
@@ -2288,5 +2308,36 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&out);
+    }
+
+    #[test]
+    fn hwp5_to_hwpx_bytes_matches_file_based_api() {
+        let source = fixture_path("sample-text-char-runs-basic.hwp");
+        if !source.exists() {
+            return;
+        }
+
+        let bytes = std::fs::read(&source).expect("source bytes should be readable");
+        let (inmem_bytes, inmem_warnings) =
+            hwp5_to_hwpx_bytes(&bytes).expect("in-memory conversion should succeed");
+
+        let file_out = unique_temp_path("inmem_compare.hwpx");
+        let file_warnings =
+            hwp5_to_hwpx(&source, &file_out).expect("file-based conversion should succeed");
+        let file_bytes = std::fs::read(&file_out).expect("file output should be readable");
+
+        assert_eq!(
+            inmem_bytes, file_bytes,
+            "in-memory and file-based hwp5_to_hwpx should produce identical bytes"
+        );
+        assert_eq!(
+            inmem_warnings.len(),
+            file_warnings.len(),
+            "in-memory and file-based variants should emit the same warning count"
+        );
+        HwpxDecoder::decode(&inmem_bytes)
+            .expect("in-memory hwpx bytes should round-trip through HwpxDecoder");
+
+        let _ = std::fs::remove_file(&file_out);
     }
 }

--- a/scripts/audit_hwp5_gate.py
+++ b/scripts/audit_hwp5_gate.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""HWP5 audit fidelity gate.
+
+Compares the current run of `cargo run --example audit_batch` against the
+committed baseline at `.audit/hwp5_baseline.json`. Exits with code 1 when a
+regression is detected.
+
+Regression rules:
+- Any baseline category that grows in count → regression.
+- Any new category that appears in the current run → regression.
+- Any new fixture failure → regression.
+
+Categories that shrink or disappear are accepted (this is the intended
+direction of travel for Phase 11). The gate prints a one-line summary plus a
+detailed diff on regression so PR authors see exactly which categories drifted.
+
+Usage:
+    python3 scripts/audit_hwp5_gate.py \\
+        --baseline .audit/hwp5_baseline.json \\
+        --current  /tmp/hwp5_audit_current.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_report(path: Path) -> dict:
+    if not path.exists():
+        sys.stderr.write(f"audit gate: missing report at {path}\n")
+        sys.exit(2)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"audit gate: invalid JSON at {path}: {exc}\n")
+        sys.exit(2)
+
+
+def diff_categories(baseline: dict, current: dict) -> list[str]:
+    regressions: list[str] = []
+    base_cats = baseline.get("categories", {})
+    cur_cats = current.get("categories", {})
+
+    for name, stats in cur_cats.items():
+        cur_count = stats.get("count", 0)
+        base_count = base_cats.get(name, {}).get("count", 0)
+        if name not in base_cats:
+            regressions.append(
+                f"new category: {name} (count={cur_count})"
+            )
+        elif cur_count > base_count:
+            regressions.append(
+                f"category {name}: {base_count} → {cur_count} (+{cur_count - base_count})"
+            )
+
+    base_failures = {f["fixture"] for f in baseline.get("failures", [])}
+    cur_failures = current.get("failures", [])
+    for failure in cur_failures:
+        if failure["fixture"] not in base_failures:
+            regressions.append(
+                f"new failure: {failure['fixture']} — {failure['error']}"
+            )
+
+    return regressions
+
+
+def summarize_improvements(baseline: dict, current: dict) -> list[str]:
+    improvements: list[str] = []
+    base_cats = baseline.get("categories", {})
+    cur_cats = current.get("categories", {})
+
+    for name, stats in base_cats.items():
+        base_count = stats.get("count", 0)
+        cur_count = cur_cats.get(name, {}).get("count", 0)
+        if cur_count < base_count:
+            improvements.append(
+                f"category {name}: {base_count} → {cur_count} (-{base_count - cur_count})"
+            )
+
+    return improvements
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        required=True,
+        help="Path to committed baseline JSON",
+    )
+    parser.add_argument(
+        "--current",
+        type=Path,
+        required=True,
+        help="Path to current audit_batch output JSON",
+    )
+    args = parser.parse_args()
+
+    baseline = load_report(args.baseline)
+    current = load_report(args.current)
+
+    regressions = diff_categories(baseline, current)
+    improvements = summarize_improvements(baseline, current)
+
+    base_total = baseline.get("total_warnings", 0)
+    cur_total = current.get("total_warnings", 0)
+    print(
+        f"HWP5 audit gate: baseline_total={base_total} current_total={cur_total} "
+        f"(Δ={cur_total - base_total:+d})"
+    )
+
+    if improvements:
+        print("Improvements:")
+        for line in improvements:
+            print(f"  ✓ {line}")
+
+    if regressions:
+        print("Regressions detected:")
+        for line in regressions:
+            print(f"  ✗ {line}")
+        print(
+            "\nIf this regression is intentional, regenerate the baseline with:\n"
+            "  make audit-hwp5-baseline"
+        )
+        return 1
+
+    print("No regressions detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 11 Wave 0 establishes the **HWP5 ↔ HWPX semantic parity** measurement floor. This PR adds an audit pipeline that:

- captures the current HWP5 reader / projection warning catalog as a committed baseline
- exposes a regression gate (`make audit-hwp5-gate`) that fails CI when warnings grow or new categories appear
- introduces `hwp5_to_hwpx_bytes()` in-memory variant so the upcoming CLI `to-md` HWP5 chain can avoid temp files

**Baseline snapshot** (committed in `.audit/hwp5_baseline.json`):

```text
fixtures_scanned : 79
fixtures_decoded : 79
fixtures_failed  : 0
total_warnings   : 9
categories       : 2
```

- `DroppedControl:ole_object` — 8 warnings across 5 fixtures (chart 3종 + full_report + mixed_01)
- `DroppedControl:rect` — 1 warning on `shapes/rect_simple.hwp`

A key finding from Wave 0: the warning catalog is small because most projection gaps are **silent losses** (no `Hwp5Warning` emitted). Future waves will need to add `ProjectionFallback` markers as they expand carry coverage so silent gaps become measurable.

## Changes

- `crates/hwpforge-smithy-hwp5/src/lib.rs` — `hwp5_to_hwpx_bytes(bytes) -> (Vec<u8>, Vec<Hwp5Warning>)` + unit test verifying byte-for-byte equivalence with file-based API
- `crates/hwpforge-smithy-hwp5/examples/audit_batch.rs` — walks fixture roots, emits categorized JSON report
- `scripts/audit_hwp5_gate.py` — regression-only comparator
- `Makefile` — `audit-hwp5`, `audit-hwp5-baseline`, `audit-hwp5-gate` targets
- `.github/workflows/ci.yml` — adds PR-blocking `Verify › HWP5 Audit Gate` job
- `.audit/hwp5_baseline.json` — committed baseline

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p hwpforge-smithy-hwp5 --lib hwp5_to_hwpx_bytes_matches_file_based_api`
- [x] `npx dprint check`
- [x] `make audit-hwp5-gate` — baseline self-compare returns Δ=0, no regressions
- [ ] CI green on this PR

## Scope

This PR is **measurement infrastructure only**. No projection logic changes, no semver impact. Wave 1 (CharShape parity) will follow as a separate PR.

## Follow-ups

- Wave 1: CharShape parity (underline / strike line families, breakLatinWord variants, char effects)
- Wave 2-5: see Phase 11 plan
- Wave 6: CLI `to-md` `.hwp` input chaining + v0.6.0 release