### PR TITLE
fix(convert): drop version pin on path deps so release-plz can bump

### DIFF
--- a/crates/hwpforge-convert/Cargo.toml
+++ b/crates/hwpforge-convert/Cargo.toml
@@ -15,10 +15,14 @@ rust-version.workspace = true
 description = "Cross-format conversion orchestrator for HwpForge (HWP5 -> HWPX)"
 
 [dependencies]
-hwpforge-core = { path = "../hwpforge-core", version = "0.7.0" }
-hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.7.0" }
-hwpforge-smithy-hwp5 = { path = "../hwpforge-smithy-hwp5", version = "0.7.0" }
-hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0.7.0" }
+# publish = false: path-only deps (no version pin) so release-plz can bump
+# the workspace version without convert's `^x` requirement failing to resolve
+# against an already-bumped publish=false sibling (e.g. smithy-hwp5). Matches
+# the bindings-cli / bindings-py convention.
+hwpforge-core = { path = "../hwpforge-core" }
+hwpforge-foundation = { path = "../hwpforge-foundation" }
+hwpforge-smithy-hwp5 = { path = "../hwpforge-smithy-hwp5" }
+hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx" }
 quick-xml = { workspace = true }
 serde = { workspace = true }
 zip = { workspace = true }


### PR DESCRIPTION
## 문제
`Release / Release PR` 워크플로가 #81(E5) 머지 이후 **main push마다 실패**.

```
error: failed to select a version for `hwpforge-smithy-hwp5 = "^0.7.0"`
candidate versions found which didn't match: 0.8.0
required by package `hwpforge-convert v0.8.0`
```

## 원인
`hwpforge-convert`(publish=false)가 intra-workspace path dep에 `version = "0.7.0"`를 핀. release-plz가 publish=false 형제(`smithy-hwp5`)를 0.8.0으로 올리면 convert의 `^0.7.0`이 해소 불가 → `cargo update` abort.

## 수정
convert의 4개 path dep에서 `version` 제거 → path-only (이미 `bindings-cli`/`bindings-py`가 쓰는 컨벤션). publish=false라 버전 제약 무의미. **빌드/동작 변화 없음**.

## 검증
- `cargo metadata` 해소 OK · `cargo check -p hwpforge-convert` green · pre-push `make ci` GREEN

https://claude.ai/code/session_0199NBUj9VUZmSfqxEysxudD