### PR TITLE
refactor(foundation)!: collapse RefContentType::BookmarkName into Contents (E6 slice B)

### DIFF
--- a/crates/hwpforge-foundation/src/enums/reference.rs
+++ b/crates/hwpforge-foundation/src/enums/reference.rs
@@ -351,9 +351,12 @@ impl schemars::JsonSchema for RefType {
 /// | 3                  | 위/아래          | `OBJECT_TYPE_UPDOWNPOS`   |
 ///
 /// (책갈피의 wire 는 OWPML spec 표 156 의 직관과 어긋남 — `CONTENTS`
-/// 가 "책갈피 이름", `NUMBER` 가 "책갈피 내용" 의미.) `BookmarkName`
-/// variant 부활 + Display 는 `OBJECT_TYPE_CONTENTS` 동일 emit (한컴
-/// wire 일치) 하되 boundary 의 wire code 매핑은 분리.
+/// 가 "책갈피 이름", `NUMBER` 가 "책갈피 내용" 의미.)
+///
+/// E6 슬라이스 B (2026-06-28): 한때 분리됐던 `BookmarkName` variant 를
+/// `Contents` 로 흡수 — wire(N2=2)·Display(`OBJECT_TYPE_CONTENTS`) 가
+/// 동일하고, Bookmark vs caption 구분은 동반 [`RefType`] 가 carry
+/// (gotcha #27 — wire 모호성을 content variant 에 prebake 하지 않음).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub enum RefContentType {
@@ -364,16 +367,15 @@ pub enum RefContentType {
     /// - Footnote/Endnote/Caption/Outline: "주 번호" / "표 번호" / "그림 번호" / "개요 번호" (N2=1)
     /// - Bookmark: **책갈피 본문 / 번호 텍스트** (N2=1, 한컴 wire 특이성)
     Number,
-    /// Show the target's content. 의미는 RefType-상대적:
+    /// Show the target's content. 의미는 RefType-상대적 (gotcha #27 —
+    /// disambiguation 은 동반 [`RefType`] 가 carry, content variant 가 아님):
     /// - Figure/Table/Equation: "캡션 내용" (N2=2)
     /// - Outline: "개요 내용" (N2=2)
-    /// - Bookmark 에서는 *사용 안 함* — 책갈피의 "내용" 의미는
-    ///   `RefContentType::Number` 가 carry (N2=1).
+    /// - Bookmark: **책갈피 이름** "bookmark name" (N2=2). E6 슬라이스 B 에서
+    ///   이전 `BookmarkName` variant 를 흡수 — wire(N2=2)·Display
+    ///   (`OBJECT_TYPE_CONTENTS`) 가 동일하므로 별도 variant 불필요.
+    ///   (책갈피의 "본문/번호" 의미는 [`RefContentType::Number`] 가 carry, N2=1.)
     Contents,
-    /// Show the bookmark's NAME. 한컴: "책갈피 이름" (Bookmark+N2=2 전용).
-    /// HWPX wire 의 `OBJECT_TYPE_CONTENTS` 와 동일 문자열로 emit
-    /// (RefType=TARGET_BOOKMARK 컨텍스트에서 한컴이 의미 결정).
-    BookmarkName,
     /// Show relative position ("위" / "아래"). 한컴: "위/아래" (N2=3).
     UpDownPos,
     /// Unrecognized ContentType code preserved from wire for forward
@@ -386,11 +388,11 @@ impl fmt::Display for RefContentType {
         match self {
             Self::Page => f.write_str("OBJECT_TYPE_PAGE"),
             Self::Number => f.write_str("OBJECT_TYPE_NUMBER"),
-            // Wave 12p pre-fix: `Contents` 와 `BookmarkName` 모두 한컴
-            // wire 의 `OBJECT_TYPE_CONTENTS` 로 emit. 의미 구분은
-            // RefType + Command 의 N2 wire code 에서 (Bookmark N2=2 =
-            // 책갈피 이름, Figure/Table/Eq/Outline N2=2 = 캡션 내용).
-            Self::Contents | Self::BookmarkName => f.write_str("OBJECT_TYPE_CONTENTS"),
+            // `Contents` → `OBJECT_TYPE_CONTENTS`. 의미 구분(Bookmark N2=2
+            // = 책갈피 이름 vs Figure/Table/Eq/Outline N2=2 = 캡션 내용)은
+            // 동반 RefType 가 carry (gotcha #27). E6 슬라이스 B 에서
+            // `BookmarkName` variant 를 `Contents` 로 흡수 (wire 동일).
+            Self::Contents => f.write_str("OBJECT_TYPE_CONTENTS"),
             Self::UpDownPos => f.write_str("OBJECT_TYPE_UPDOWNPOS"),
             Self::Unknown(code) => write!(f, "OBJECT_TYPE_UNKNOWN({code})"),
         }
@@ -404,13 +406,10 @@ impl std::str::FromStr for RefContentType {
         match s {
             "OBJECT_TYPE_PAGE" | "Page" | "page" => Ok(Self::Page),
             "OBJECT_TYPE_NUMBER" | "Number" | "number" => Ok(Self::Number),
-            // Wave 12p pre-fix: `OBJECT_TYPE_CONTENTS` 는 caller 의 추가
-            // 컨텍스트 (RefType + N2 wire code) 없이는 `Contents` 와
-            // `BookmarkName` 을 구분할 수 없으므로 default 로 `Contents`
-            // 를 반환. boundary 함수 `decode_hwp5_crossref_content_type`
-            // 가 Bookmark N2=2 인 경우만 `BookmarkName` 으로 재매핑.
+            // `OBJECT_TYPE_CONTENTS` → `Contents`. Bookmark N2=2(책갈피
+            // 이름) vs caption-content 구분은 동반 RefType 가 carry
+            // (gotcha #27) — content variant 는 단일 `Contents`.
             "OBJECT_TYPE_CONTENTS" | "Contents" | "contents" => Ok(Self::Contents),
-            "BookmarkName" | "bookmark_name" => Ok(Self::BookmarkName),
             "OBJECT_TYPE_UPDOWNPOS" | "UpDownPos" | "updownpos" => Ok(Self::UpDownPos),
             _ => Err(FoundationError::ParseError {
                 type_name: "RefContentType".to_string(),

--- a/crates/hwpforge-smithy-hwp5/src/projection/mod.rs
+++ b/crates/hwpforge-smithy-hwp5/src/projection/mod.rs
@@ -1921,20 +1921,27 @@ fn decode_hwp5_crossref_ref_type(code: u8) -> RefType {
 /// Wave 12p pre-fix boundary: HWP5 `%xrf` N2 (ContentType) is
 /// RefType-relative. 한컴 native wire 분석 결과:
 ///
-/// | RefType        | N2=0 | N2=1   | N2=2          | N2=3      |
-/// |----------------|------|--------|---------------|-----------|
-/// | Bookmark       | Page | Number | BookmarkName  | UpDownPos |
-/// | 그 외 (T/F/Eq/…) | Page | Number | Contents      | UpDownPos |
+/// | RefType        | N2=0 | N2=1   | N2=2       | N2=3      |
+/// |----------------|------|--------|------------|-----------|
+/// | Bookmark       | Page | Number | Contents¹  | UpDownPos |
+/// | 그 외 (T/F/Eq/…) | Page | Number | Contents   | UpDownPos |
 ///
 /// 책갈피 N2=1 은 한컴에서 "책갈피 본문/번호" 의미 (OBJECT_TYPE_NUMBER
 /// emit), N2=2 는 "책갈피 이름" (OBJECT_TYPE_CONTENTS emit). spec 외
-/// 의미이지만 native wire 와 일치. Wave 12m fixup 의 (Bookmark, 2) →
-/// Contents 통일은 잘못이었고 본 fix 에서 보정.
+/// 의미이지만 native wire 와 일치.
+///
+/// ¹ E6 슬라이스 B (2026-06-28): Bookmark N2=2 = "책갈피 이름" 은
+/// `Contents` variant 로 carry (이전 분리됐던 `BookmarkName` 흡수).
+/// wire(N2=2)·Display(`OBJECT_TYPE_CONTENTS`) 가 caption-content 와
+/// 동일하고, 구분은 동반 RefType 가 보유 (gotcha #27).
 fn decode_hwp5_crossref_content_type(ref_type_code: u8, code: u8) -> RefContentType {
     match (ref_type_code, code) {
         (_, 0) => RefContentType::Page,
         (HWP5_CROSSREF_REF_TYPE_BOOKMARK, 1) => RefContentType::Number,
-        (HWP5_CROSSREF_REF_TYPE_BOOKMARK, 2) => RefContentType::BookmarkName,
+        // (Bookmark, 2) = "책갈피 이름" → `Contents` (OBJECT_TYPE_CONTENTS,
+        // N2=2). E6 슬라이스 B: 이전 `BookmarkName` variant 를 흡수 — wire/
+        // Display 가 동일하고 RefType 컨텍스트가 의미를 carry (gotcha #27)
+        // 하므로 아래 `(_, 2) => Contents` 와 동일. 명시 arm 불필요.
         (_, 1) => RefContentType::Number,
         (_, 2) => RefContentType::Contents,
         (_, 3) => RefContentType::UpDownPos,
@@ -2908,6 +2915,25 @@ fn page_def_to_settings(pd: &Hwp5PageDef) -> PageSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bookmark_n2_2_collapses_to_contents_not_separate_variant() {
+        // E6 슬라이스 B 회귀 잠금: (Bookmark, 2) = "책갈피 이름" 은 이전
+        // `BookmarkName` variant 가 아니라 `Contents` 로 carry — wire/Display
+        // 가 caption-content 와 동일하고 구분은 동반 RefType 가 보유 (gotcha #27).
+        assert_eq!(
+            decode_hwp5_crossref_content_type(HWP5_CROSSREF_REF_TYPE_BOOKMARK, 2),
+            RefContentType::Contents,
+            "Bookmark N2=2 must collapse to Contents (BookmarkName absorbed)"
+        );
+        // 비-Bookmark N2=2 도 동일하게 Contents (대칭 확인).
+        assert_eq!(
+            decode_hwp5_crossref_content_type(HWP5_CROSSREF_REF_TYPE_BOOKMARK + 1, 2),
+            RefContentType::Contents
+        );
+        // Display byte 불변: Contents → OBJECT_TYPE_CONTENTS.
+        assert_eq!(RefContentType::Contents.to_string(), "OBJECT_TYPE_CONTENTS");
+    }
 
     #[test]
     fn shape_vertical_align_extracts_bits_5_6() {

--- a/crates/hwpforge-smithy-hwp5/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwp5/src/schema/section.rs
@@ -2298,8 +2298,9 @@ const MAX_CROSSREF_COMMAND_UNITS: usize = 1024;
 /// The Command's semicolon-separated suffix encodes:
 /// - `N1` = RefType (Table=0, Figure=1, Equation=2, Footnote=3,
 ///   Endnote=4, Outline=5, Bookmark=6)
-/// - `N2` = ContentType (RefType-relative; Page=0, Number/Contents=1,
-///   Contents/BookmarkName=2, UpDownPos=3)
+/// - `N2` = ContentType (RefType-relative; Page=0, Number=1,
+///   Contents=2, UpDownPos=3 — Bookmark N2=2 "책갈피 이름" 도 Contents,
+///   E6 슬라이스 B 에서 BookmarkName variant 흡수)
 /// - `N3` = as_hyperlink (0 / 1)
 /// - `N4` = currently unidentified (all observed = 0)
 ///

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/field.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/field.rs
@@ -486,13 +486,12 @@ pub(super) fn ref_content_type_wire_code(
         Page => 0,
         UpDownPos => 3,
         Number => 1,
-        // Wave 12p pre-fix: native wire 일치. 모든 RefType 에서
-        // `Contents` 의 N2 wire code 는 2 (Figure/Table/Eq/Outline =
-        // "캡션 내용"). 별도로 `BookmarkName` variant (한컴 "책갈피
-        // 이름") 도 N2=2 로 emit — RefType=TARGET_BOOKMARK 컨텍스트에서
-        // 한컴이 의미를 결정. (Bookmark+Number=N2=1 = 책갈피 본문/번호
-        // 는 위 `Number => 1` arm 이 처리.)
-        Contents | BookmarkName => 2,
+        // `Contents` → N2 wire code 2. Figure/Table/Eq/Outline 의 "캡션
+        // 내용" 과 Bookmark 의 "책갈피 이름" 둘 다 N2=2 로 emit — 의미
+        // 구분은 동반 RefType 가 carry (gotcha #27). E6 슬라이스 B 에서
+        // `BookmarkName` variant 를 `Contents` 로 흡수. (Bookmark+N2=1 =
+        // 책갈피 본문/번호 는 위 `Number => 1` arm 이 처리.)
+        Contents => 2,
         Unknown(other) => *other,
         // Foundation RefContentType is `#[non_exhaustive]`; future
         // variants default to Page (slot 0).
@@ -683,4 +682,32 @@ pub(super) fn unix_to_ymdhms(secs: u64) -> (i64, u32, u32, u32, u32, u32) {
     let month_civil = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
     let year_civil = if month_civil <= 2 { y0 + 1 } else { y0 };
     (year_civil, month_civil, day, hour, minute, second)
+}
+
+#[cfg(test)]
+mod bookmarkname_collapse_tests {
+    use super::*;
+    use hwpforge_foundation::{RefContentType, RefType};
+
+    /// E6 슬라이스 B byte-불변 게이트: `BookmarkName` 흡수 후에도 Bookmark
+    /// 의 "책갈피 이름"(`Contents`) 은 N2 wire code `2` 로 emit — 이전
+    /// 분리됐던 variant 와 동일. golden 12-fixture 매트릭스는 content-type
+    /// 출력을 단언하지 않으므로 이 직접 단언이 진짜 byte-중립 게이트다.
+    #[test]
+    fn bookmark_contents_emits_n2_wire_code_2() {
+        assert_eq!(
+            ref_content_type_wire_code(&RefType::Bookmark, &RefContentType::Contents),
+            2,
+            "Bookmark Contents (책갈피 이름) must emit N2=2"
+        );
+        // caption-content (Figure/Table/Eq/Outline) 도 동일 N2=2 — 의미
+        // 구분은 RefType 가 carry (gotcha #27), wire 는 동일.
+        assert_eq!(
+            ref_content_type_wire_code(&RefType::Figure, &RefContentType::Contents),
+            2,
+            "Figure caption Contents must also emit N2=2"
+        );
+        // Display 불변도 함께 잠금.
+        assert_eq!(RefContentType::Contents.to_string(), "OBJECT_TYPE_CONTENTS");
+    }
 }


### PR DESCRIPTION
## E6 cheap-wins 슬라이스 B — H2 `RefContentType::BookmarkName` collapse

E6(IR 와이어-누출 상환)의 두 번째 cheap-win. `ADR-007` H2.

HWPX cross-reference 의 "N2" wire 모호성이 전용 `RefContentType::BookmarkName` variant 로 포맷-무관 enum 에 prebake 돼 있었습니다. 그러나 **책갈피 이름**과 **캡션 내용**은 wire 출력이 동일(N2=`2` + Display `OBJECT_TYPE_CONTENTS`)하고, 둘의 구분은 **동반 `RefType` 가 이미 carry**합니다(gotcha #27). 따라서 BookmarkName 은 중복된 wire 지식 누출 → `Contents` 로 흡수합니다.

### 변경 (byte-중립 — emitted HWPX 무변화)
| 위치 | 변경 |
|---|---|
| `foundation/reference.rs` | `BookmarkName` variant 제거 + Display/FromStr arm 에서 제거 (`Contents` 가 `OBJECT_TYPE_CONTENTS` 커버) |
| `smithy-hwp5/projection/mod.rs` | `(Bookmark, 2)` → `(_, 2) => Contents` fall-through (책갈피 이름은 `Contents`로 carry, RefType=Bookmark 가 의미 보유) |
| `smithy-hwpx/encoder/section/field.rs` | `Contents \| BookmarkName => 2` → `Contents => 2` |
| doc | reference / projection / schema 주석 갱신 |

### ⚠️ Breaking
- `hwpforge_foundation::RefContentType::BookmarkName` variant 제거 (→ `Contents` 흡수)
- `RefContentType::from_str` 가 `"BookmarkName"`/`"bookmark_name"` 더 이상 수용 안 함 (→ `Err`); serde `"BookmarkName"` 태그 역직렬화 실패
- **emitted HWPX wire 출력 불변**. HWPX 디코더는 BookmarkName 을 애초에 생성 안 했으므로 round-trip 무영향
- `#[non_exhaustive]` 라 외부 exhaustive match 는 안 깨짐 — 위 FromStr/serde 입력·`::BookmarkName` 직접 참조만 영향
- → release-plz 가 다음 마이너 `0.9.0` (슬라이스 C 와 배치)

### Verification
- `cargo build --workspace --all-features` 0 warnings · clippy `-D warnings` GREEN
- `cargo nextest run --workspace --all-features` — **2673 passed / 2 skipped** (회귀 0)
- **신규 byte-불변 테스트 2개** (golden 12-fixture 매트릭스는 content-type 출력을 단언 안 하므로 직접 게이트 추가):
  - `bookmark_n2_2_collapses_to_contents_not_separate_variant` — `(Bookmark,2)→Contents` + Display `OBJECT_TYPE_CONTENTS`
  - `bookmark_contents_emits_n2_wire_code_2` — `ref_content_type_wire_code(Bookmark, Contents)==2` + Figure 대칭 + Display
- 독립 **code-reviewer audit: SHIP** (7개 항목 전부 CLEAN/VERIFIED)
- 한컴 시각 검증용 변환 실측: `sample-bookmark-name` → `RefType=TARGET_BOOKMARK` + `RefContentType=OBJECT_TYPE_CONTENTS` (이전 BookmarkName 경로와 동일)

### 후속 (E6 잔여)
- 슬라이스 **C** (H3 raw 필드 제거) → 동일 `0.9.0` 배치
- H1(display_text)/M2(inst_id)는 고위험 별도 슬라이스

https://claude.ai/code/session_0199NBUj9VUZmSfqxEysxudD
