### PR TITLE
refactor(core)!: drop raw wire-byte fields from DateCodeField/InlinePageNumber (E6 slice C)

### DIFF
--- a/crates/hwpforge-core/src/control/fields.rs
+++ b/crates/hwpforge-core/src/control/fields.rs
@@ -103,29 +103,7 @@ pub enum InlinePageKind {
     CurrentPage,
     /// Flag `0x06` — total page count.
     TotalPages,
-    /// Any other flag value, carried verbatim via
-    /// [`Control::InlinePageNumber::raw_flag`].
+    /// Any other flag value, surfaced when the HWP5 wire flag is neither
+    /// `0x00` nor `0x06`.
     Unknown,
-}
-
-impl InlinePageKind {
-    /// Returns the canonical raw flag value for typed variants.
-    /// For [`Self::Unknown`], callers must use the
-    /// [`Control::InlinePageNumber::raw_flag`] field directly.
-    pub fn raw_flag(self) -> Option<u32> {
-        match self {
-            Self::CurrentPage => Some(0x00),
-            Self::TotalPages => Some(0x06),
-            Self::Unknown => None,
-        }
-    }
-
-    /// Maps an observed raw flag value to a typed variant.
-    pub fn from_raw_flag(flag: u32) -> Self {
-        match flag {
-            0x00 => Self::CurrentPage,
-            0x06 => Self::TotalPages,
-            _ => Self::Unknown,
-        }
-    }
 }

--- a/crates/hwpforge-core/src/control/mod.rs
+++ b/crates/hwpforge-core/src/control/mod.rs
@@ -631,19 +631,13 @@ pub enum Control {
     /// `입력 → 날짜/시간/파일 이름 → 날짜/시간 코드` menu. Unlike SUMMERY
     /// (which carries semantic tokens like `$createtime`), `%dte` carries
     /// a raw format pattern string (e.g. `"\:1년 2월 3일 (6);0;"` for date,
-    /// `"T\:;0;"` for time-only). The grammar is under-measured so the
-    /// raw command is preserved verbatim; `is_time_mode` is a derived
-    /// helper based on the `T` prefix.
+    /// `"T\:;0;"` for time-only). The HWP5 wire format pattern is
+    /// smithy-internal; the format-agnostic core retains only the derived
+    /// `is_time_mode` helper (was based on the `T` prefix at projection time).
     DateCodeField {
-        /// Full Command string from the wire, including the `T` prefix
-        /// for time mode and the `\:format;options;` body.
-        raw_command: String,
-        /// Helper view: `true` when [`Self::DateCodeField::raw_command`]
-        /// starts with `T` (time-only format).
+        /// Helper view: `true` for a time-only (`T`-prefixed) format,
+        /// `false` for a date format. Derived at HWP5 projection time.
         is_time_mode: bool,
-        /// Opaque 8-byte trailer (instance ID + flags) carried for
-        /// round-trip fidelity. The semantics are not pinned down.
-        raw_trailer: [u8; 8],
         /// Cached resolved value rendered between `fieldBegin`/`fieldEnd`
         /// (the locale-formatted date/time string). Same semantics as
         /// [`Self::Field::display_text`]; empty = none.
@@ -675,12 +669,11 @@ pub enum Control {
     /// `<hp:autoNum>` inside a `<hp:run>`.
     ///
     /// The 16-byte wire envelope carries a single 4-byte flag that
-    /// distinguishes current-page from total-pages.
+    /// distinguishes current-page from total-pages; the HWP5 projection
+    /// maps it to [`InlinePageKind`].
     InlinePageNumber {
         /// Typed variant of the observed `flag` byte.
         kind: InlinePageKind,
-        /// Raw `flag` bytes (LE u32) carried for unknown values.
-        raw_flag: u32,
     },
 
     /// An unrecognized control element preserved for round-trip fidelity.
@@ -1687,19 +1680,17 @@ impl std::fmt::Display for Control {
             Self::UnknownSummary { token, .. } => {
                 write!(f, "UnknownSummary({token})")
             }
-            Self::DateCodeField { raw_command, is_time_mode, .. } => {
+            Self::DateCodeField { is_time_mode, .. } => {
                 let mode = if *is_time_mode { "time" } else { "date" };
-                write!(f, "DateCodeField({mode}, \"{raw_command}\")")
+                write!(f, "DateCodeField({mode})")
             }
             Self::PathField { command, .. } => {
                 write!(f, "PathField({})", command.wire_command())
             }
-            Self::InlinePageNumber { kind, raw_flag } => match kind {
+            Self::InlinePageNumber { kind } => match kind {
                 InlinePageKind::CurrentPage => write!(f, "InlinePageNumber(current)"),
                 InlinePageKind::TotalPages => write!(f, "InlinePageNumber(total)"),
-                InlinePageKind::Unknown => {
-                    write!(f, "InlinePageNumber(unknown, raw=0x{raw_flag:08X})")
-                }
+                InlinePageKind::Unknown => write!(f, "InlinePageNumber(unknown)"),
             },
             Self::Unknown { tag, .. } => {
                 write!(f, "Unknown({tag})")

--- a/crates/hwpforge-core/src/error.rs
+++ b/crates/hwpforge-core/src/error.rs
@@ -304,42 +304,6 @@ pub enum ValidationError {
         /// The offending token.
         token: String,
     },
-
-    /// `DateCodeField.is_time_mode` does not match the `T` prefix convention
-    /// of the raw command, or the raw command is empty (Wave 12n).
-    #[error("DateCodeField mismatch: is_time_mode={is_time_mode}, raw_command={raw_command:?} (section {section_index}, paragraph {paragraph_index}, run {run_index})")]
-    DateCodeFieldMismatch {
-        /// Zero-based section index.
-        section_index: usize,
-        /// Zero-based paragraph index.
-        paragraph_index: usize,
-        /// Zero-based run index.
-        run_index: usize,
-        /// The claimed time-mode flag.
-        is_time_mode: bool,
-        /// The raw HWP5 command string.
-        raw_command: String,
-    },
-
-    /// `Control::InlinePageNumber` carries a known `kind` whose canonical
-    /// wire `raw_flag` does not match the actual `raw_flag` field. The
-    /// encoder ignores `raw_flag` for known kinds, so a mismatch is silent
-    /// drift that validation must catch (Wave 12n architect review).
-    #[error("InlinePageNumber mismatch: kind {kind} expects raw_flag {expected:#X}, found {actual:#X} (section {section_index}, paragraph {paragraph_index}, run {run_index})")]
-    InlinePageNumberMismatch {
-        /// Zero-based section index.
-        section_index: usize,
-        /// Zero-based paragraph index.
-        paragraph_index: usize,
-        /// Zero-based run index.
-        run_index: usize,
-        /// Display name of the typed kind variant (e.g. `"CurrentPage"`).
-        kind: &'static str,
-        /// The canonical wire flag for the typed kind.
-        expected: u32,
-        /// The actual `raw_flag` value carried by the control.
-        actual: u32,
-    },
 }
 
 // ---------------------------------------------------------------------------
@@ -396,10 +360,8 @@ pub enum CoreErrorCode {
     NonLeadingTableHeaderRow = 2016,
     /// Invalid SUMMERY `$token` (Wave 12n).
     InvalidSummaryToken = 2017,
-    /// `DateCodeField.is_time_mode` ↔ raw command `T`-prefix mismatch (Wave 12n).
-    DateCodeFieldMismatch = 2018,
-    /// `InlinePageNumber.kind` ↔ `raw_flag` mismatch (Wave 12n).
-    InlinePageNumberMismatch = 2019,
+    // 2018 (was DateCodeFieldMismatch) and 2019 (was InlinePageNumberMismatch)
+    // are retired (E6 slice C); the gap is intentional — do NOT renumber.
     /// A Group control has a non-shape child.
     InvalidGroupChild = 2020,
     /// Invalid document structure.
@@ -435,8 +397,6 @@ impl ValidationError {
             Self::MismatchedSeriesLengths { .. } => CoreErrorCode::MismatchedSeriesLengths,
             Self::EmptyEquation { .. } => CoreErrorCode::EmptyEquation,
             Self::InvalidSummaryToken { .. } => CoreErrorCode::InvalidSummaryToken,
-            Self::DateCodeFieldMismatch { .. } => CoreErrorCode::DateCodeFieldMismatch,
-            Self::InlinePageNumberMismatch { .. } => CoreErrorCode::InlinePageNumberMismatch,
         }
     }
 }

--- a/crates/hwpforge-core/src/validate.rs
+++ b/crates/hwpforge-core/src/validate.rs
@@ -241,13 +241,9 @@ fn validate_control_run(
         // Wave 12n: targeted invariant checks for new variants. Architect review
         // medium: do not let new variants slide through with a blanket `Ok(())`.
         Control::UnknownSummary { token, .. } => validate_unknown_summary(token, ctx),
-        Control::DateCodeField { raw_command, is_time_mode, .. } => {
-            validate_date_code_field(raw_command, *is_time_mode, ctx)
-        }
-        Control::InlinePageNumber { kind, raw_flag } => {
-            validate_inline_page_number(*kind, *raw_flag, ctx)
-        }
-        Control::PathField { .. } => Ok(()),
+        Control::DateCodeField { .. }
+        | Control::InlinePageNumber { .. }
+        | Control::PathField { .. } => Ok(()),
         // Group (묶음 객체): recursively validate each child (nested groups +
         // per-child dimension/empty checks at the same chokepoint). Only
         // shape-family controls are legitimate children; non-shape variants
@@ -304,54 +300,6 @@ fn validate_unknown_summary(token: &str, ctx: RunValidationContext) -> Result<()
         })
     } else {
         Ok(())
-    }
-}
-
-/// Rejects a `DateCodeField` whose `is_time_mode` claim contradicts the
-/// `T`-prefix convention of the raw command (Wave 12n architect review:
-/// keep the derived helper and the raw bytes from drifting apart).
-fn validate_date_code_field(
-    raw_command: &str,
-    is_time_mode: bool,
-    ctx: RunValidationContext,
-) -> Result<(), ValidationError> {
-    if raw_command.is_empty() || is_time_mode != raw_command.starts_with('T') {
-        Err(ValidationError::DateCodeFieldMismatch {
-            section_index: ctx.section_index,
-            paragraph_index: ctx.paragraph_index,
-            run_index: ctx.run_index,
-            is_time_mode,
-            raw_command: raw_command.to_string(),
-        })
-    } else {
-        Ok(())
-    }
-}
-
-/// Rejects an `InlinePageNumber` whose typed `kind` has a canonical
-/// `raw_flag` that does not match the actual `raw_flag` field
-/// (Wave 12n architect review: the encoder ignores `raw_flag` for known
-/// kinds, so a mismatch is silent drift).
-fn validate_inline_page_number(
-    kind: crate::control::InlinePageKind,
-    raw_flag: u32,
-    ctx: RunValidationContext,
-) -> Result<(), ValidationError> {
-    use crate::control::InlinePageKind;
-    match kind.raw_flag() {
-        Some(expected) if expected != raw_flag => Err(ValidationError::InlinePageNumberMismatch {
-            section_index: ctx.section_index,
-            paragraph_index: ctx.paragraph_index,
-            run_index: ctx.run_index,
-            kind: match kind {
-                InlinePageKind::CurrentPage => "CurrentPage",
-                InlinePageKind::TotalPages => "TotalPages",
-                InlinePageKind::Unknown => "Unknown",
-            },
-            expected,
-            actual: raw_flag,
-        }),
-        _ => Ok(()),
     }
 }
 

--- a/crates/hwpforge-smithy-hwp5/src/decoder/section/model.rs
+++ b/crates/hwpforge-smithy-hwp5/src/decoder/section/model.rs
@@ -99,10 +99,10 @@ pub(crate) enum Hwp5Control {
     SummaryField(crate::schema::section::Hwp5SummaryControl),
     /// `%dte` date/time format-code field — carries a raw format pattern
     /// (e.g. `"\:1년 2월 3일 (6);0;"` or `"T\:;0;"`). The projection
-    /// layer surfaces it as `Control::DateCodeField` with `raw_command`,
-    /// `is_time_mode` (derived from `T` prefix), and the 8-byte trailer
-    /// preserved verbatim. See `schema::section::Hwp5DateCodeControl`.
-    /// (Wave 12n.)
+    /// layer surfaces it as `Control::DateCodeField` with only the derived
+    /// `is_time_mode` (from the `T` prefix); the raw wire pattern and trailer
+    /// are smithy-internal and not carried into the core IR (E6 slice C).
+    /// See `schema::section::Hwp5DateCodeControl`. (Wave 12n.)
     DateCodeField(crate::schema::section::Hwp5DateCodeControl),
     /// `%pat` path/file-name field — carries a path format-code
     /// Command (`"$P"`, `"$F"`, `"$P$F"`). See

--- a/crates/hwpforge-smithy-hwp5/src/projection/mod.rs
+++ b/crates/hwpforge-smithy-hwp5/src/projection/mod.rs
@@ -218,14 +218,13 @@ enum ActiveField {
         display_text: String,
     },
     /// `%dte` date/time format-code field (Wave 12n). Carries the raw
-    /// Command pattern + 8-byte trailer for round-trip fidelity. On
-    /// `FieldEnd` the projection emits `Control::DateCodeField` with
+    /// Command pattern (smithy-internal) used only to derive `is_time_mode`.
+    /// On `FieldEnd` the projection emits `Control::DateCodeField` with
     /// `is_time_mode` derived from the `T` prefix. `display_text`
     /// accumulates the cached resolved value (see [`Self::SummaryField`]).
     DateCodeField {
         start_utf16: u32,
         raw_command: String,
-        raw_trailer: [u8; 8],
         display_text: String,
     },
     /// `%pat` path/file-name field (Wave 12n). On `FieldEnd` the
@@ -1383,7 +1382,6 @@ fn start_active_field(
                 ActiveField::DateCodeField {
                     start_utf16,
                     raw_command: date_code.raw_command,
-                    raw_trailer: date_code.raw_trailer,
                     display_text: String::new(),
                 }
             } else {
@@ -1564,10 +1562,10 @@ fn finish_active_field(
             };
             runs.push(Run::control(control, char_shape_id));
         }
-        ActiveField::DateCodeField { start_utf16, raw_command, raw_trailer, display_text } => {
+        ActiveField::DateCodeField { start_utf16, raw_command, display_text } => {
             // Emit Control::DateCodeField with `is_time_mode` derived
-            // from the `T` prefix convention. The 8-byte trailer is
-            // preserved verbatim for future round-trip fidelity.
+            // from the `T` prefix convention. The raw HWP5 command pattern
+            // is smithy-internal and not carried into the core IR (E6 slice C).
             // `display_text` is the cached resolved date/time (#120/#136).
             let char_shape_id = CharShapeIndex::new(char_shape_id_for_visible_position(
                 &hwp_para.char_shape_runs,
@@ -1576,7 +1574,7 @@ fn finish_active_field(
             let _ = end_utf16;
             let is_time_mode = raw_command.starts_with('T');
             runs.push(Run::control(
-                Control::DateCodeField { raw_command, is_time_mode, raw_trailer, display_text },
+                Control::DateCodeField { is_time_mode, display_text },
                 char_shape_id,
             ));
         }
@@ -2119,11 +2117,15 @@ fn project_control_run(
         // emission flows through the object-control queue, not an
         // ActiveField/FieldBegin pair.
         Hwp5Control::InlinePageNumber(atno) => {
-            let kind = hwpforge_core::control::InlinePageKind::from_raw_flag(atno.raw_flag);
-            Some(Run::control(
-                Control::InlinePageNumber { kind, raw_flag: atno.raw_flag },
-                CharShapeIndex::new(0),
-            ))
+            use hwpforge_core::control::InlinePageKind;
+            // Inline the wire-flag → kind mapping (E6 slice C: the raw flag
+            // is smithy-internal and no longer carried into the core IR).
+            let kind = match atno.raw_flag {
+                0x00 => InlinePageKind::CurrentPage,
+                0x06 => InlinePageKind::TotalPages,
+                _ => InlinePageKind::Unknown,
+            };
+            Some(Run::control(Control::InlinePageNumber { kind }, CharShapeIndex::new(0)))
         }
         Hwp5Control::OleObject(ole) => project_ole_object_run(ole, projection_images),
         // %xrf cross-reference fields (Wave 12m) flow through the
@@ -4389,5 +4391,81 @@ mod tests {
                 if *subject == "table.page_break"
                     && reason == "unknown_hwp5_table_page_break_raw=3; defaulting_to=cell"
         )));
+    }
+
+    // E6 slice C: the HWP5 wire bytes (`raw_command`/`raw_trailer`/`raw_flag`)
+    // were removed from the core IR. These tests lock that the *derivation*
+    // (DateCodeField.is_time_mode, InlinePageNumber.kind) survives that
+    // removal by re-running the exact projection logic.
+
+    /// `project_control_run` maps an `atno` wire flag to the right
+    /// `InlinePageKind` without carrying the raw flag into the core IR.
+    #[test]
+    fn project_inline_pagenumber_maps_raw_flag_to_kind() {
+        use crate::schema::section::Hwp5InlinePageNumberControl;
+        use hwpforge_core::control::{Control, InlinePageKind};
+
+        let project = |raw_flag: u32| -> Control {
+            let ctrl = Hwp5Control::InlinePageNumber(Hwp5InlinePageNumberControl {
+                ctrl_id: 0x6174_6E6F,
+                raw_flag,
+            });
+            let mut images = ProjectionImageState::new(None, None);
+            let run = project_control_run(
+                &ctrl,
+                &mut images,
+                ImageProjectionContext::Flow,
+                CharShapeIndex::new(0),
+            )
+            .expect("atno control must project to a run");
+            match run.content {
+                RunContent::Control(boxed) => *boxed,
+                other => panic!("expected control run, got {other:?}"),
+            }
+        };
+
+        assert_eq!(
+            project(0x06),
+            Control::InlinePageNumber { kind: InlinePageKind::TotalPages },
+            "raw flag 0x06 → TotalPages",
+        );
+        assert_eq!(
+            project(0x00),
+            Control::InlinePageNumber { kind: InlinePageKind::CurrentPage },
+            "raw flag 0x00 → CurrentPage",
+        );
+        assert_eq!(
+            project(0xABCD_1234),
+            Control::InlinePageNumber { kind: InlinePageKind::Unknown },
+            "unknown raw flag → Unknown (no fabricated kind)",
+        );
+    }
+
+    /// The `%dte` time-mode derivation (`raw_command` `T`-prefix →
+    /// `is_time_mode`) survives the removal of `raw_command` from the core
+    /// IR. The emission path is private + stateful, so we assert the exact
+    /// derivation rule the projection applies in `emit_active_field`.
+    #[test]
+    fn datecodefield_time_mode_derived_from_t_prefix() {
+        use hwpforge_core::control::Control;
+
+        let derive = |raw_command: &str| -> Control {
+            Control::DateCodeField {
+                is_time_mode: raw_command.starts_with('T'),
+                display_text: String::new(),
+            }
+        };
+
+        assert!(
+            matches!(derive("T\\:H:mm;0;"), Control::DateCodeField { is_time_mode: true, .. }),
+            "`T`-prefixed command → time mode",
+        );
+        assert!(
+            matches!(
+                derive("\\:1년 2월 3일;0;"),
+                Control::DateCodeField { is_time_mode: false, .. }
+            ),
+            "date command → not time mode",
+        );
     }
 }

--- a/crates/hwpforge-smithy-hwp5/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwp5/src/schema/section.rs
@@ -2086,7 +2086,10 @@ pub(crate) struct Hwp5DateCodeControl {
     pub ctrl_id: u32,
     /// Raw Command string as recovered from the wire.
     pub raw_command: String,
-    /// 8-byte trailer carried verbatim for round-trip fidelity.
+    /// 8-byte trailer carried verbatim for round-trip fidelity. Parsed from
+    /// the wire and asserted by the `datecode_parse_*_preserves_raw` tests;
+    /// no longer consumed by projection (E6 slice C dropped it from the IR).
+    #[allow(dead_code)]
     pub raw_trailer: [u8; 8],
 }
 
@@ -2176,8 +2179,7 @@ impl Hwp5PathFieldControl {
 /// Unlike the SUMMERY-family controls, `atno` is a fixed 16-byte record
 /// with no Command string and no 8-byte trailer. The single 4-byte flag
 /// at `body[0..4]` distinguishes current-page (`0x00`) from total-page
-/// (`0x06`); other values are preserved verbatim via
-/// [`Control::InlinePageNumber::raw_flag`].
+/// (`0x06`); other values map to `InlinePageKind::Unknown` at projection.
 ///
 /// Wire layout:
 ///

--- a/crates/hwpforge-smithy-hwpx/examples/gen_field_auto_visual.rs
+++ b/crates/hwpforge-smithy-hwpx/examples/gen_field_auto_visual.rs
@@ -60,12 +60,12 @@ fn summary_section(label: &str, field_type: FieldType, cached_value: &str) -> Se
 }
 
 /// 단일 InlinePageNumber 컨트롤을 라벨과 함께 담은 Section.
-fn inline_page_section(label: &str, kind: InlinePageKind, raw_flag: u32) -> Section {
+fn inline_page_section(label: &str, kind: InlinePageKind) -> Section {
     let title = Paragraph::with_runs(
         vec![Run::text(label, CharShapeIndex::new(0))],
         ParaShapeIndex::new(0),
     );
-    let ctrl = Control::InlinePageNumber { kind, raw_flag };
+    let ctrl = Control::InlinePageNumber { kind };
     let body = Paragraph::with_runs(
         vec![Run::control(ctrl, CharShapeIndex::new(0))],
         ParaShapeIndex::new(0),
@@ -110,20 +110,17 @@ fn wave12n_all_section() -> Section {
         ));
     }
 
-    let page_cases: &[(&str, InlinePageKind, u32)] = &[
-        ("[InlinePageNumber CurrentPage 현재 페이지]", InlinePageKind::CurrentPage, 0),
-        ("[InlinePageNumber TotalPages 전체 페이지]", InlinePageKind::TotalPages, 0x06),
+    let page_cases: &[(&str, InlinePageKind)] = &[
+        ("[InlinePageNumber CurrentPage 현재 페이지]", InlinePageKind::CurrentPage),
+        ("[InlinePageNumber TotalPages 전체 페이지]", InlinePageKind::TotalPages),
     ];
-    for (label, kind, flag) in page_cases {
+    for (label, kind) in page_cases {
         paras.push(Paragraph::with_runs(
             vec![Run::text(*label, CharShapeIndex::new(0))],
             ParaShapeIndex::new(0),
         ));
         paras.push(Paragraph::with_runs(
-            vec![Run::control(
-                Control::InlinePageNumber { kind: *kind, raw_flag: *flag },
-                CharShapeIndex::new(0),
-            )],
+            vec![Run::control(Control::InlinePageNumber { kind: *kind }, CharShapeIndex::new(0))],
             ParaShapeIndex::new(0),
         ));
     }
@@ -180,7 +177,6 @@ fn main() {
         inline_page_section(
             "[현재 페이지 번호 InlinePageNumber CurrentPage]",
             InlinePageKind::CurrentPage,
-            0,
         ),
     );
     write_one(
@@ -189,7 +185,6 @@ fn main() {
         inline_page_section(
             "[전체 페이지 수 InlinePageNumber TotalPages]",
             InlinePageKind::TotalPages,
-            0x06,
         ),
     );
     write_one(

--- a/crates/hwpforge-smithy-hwpx/examples/hwpx_complete_guide_parts/section2.rs
+++ b/crates/hwpforge-smithy-hwpx/examples/hwpx_complete_guide_parts/section2.rs
@@ -133,7 +133,6 @@ pub(crate) fn section2_text_formatting() -> Section {
             Run::control(
                 Control::InlinePageNumber {
                     kind: hwpforge_core::control::InlinePageKind::CurrentPage,
-                    raw_flag: 0,
                 },
                 csi(CS_BLUE),
             ),

--- a/crates/hwpforge-smithy-hwpx/examples/shapes_and_references.rs
+++ b/crates/hwpforge-smithy-hwpx/examples/shapes_and_references.rs
@@ -593,10 +593,8 @@ fn section_bookmarks_refs_fields() -> Section {
     };
 
     // Field: PageNumber (쪽번호) — Wave 12n: moved out of Control::Field
-    let field_page = Control::InlinePageNumber {
-        kind: hwpforge_core::control::InlinePageKind::CurrentPage,
-        raw_flag: 0,
-    };
+    let field_page =
+        Control::InlinePageNumber { kind: hwpforge_core::control::InlinePageKind::CurrentPage };
 
     Section::with_paragraphs(
         vec![

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -419,17 +419,14 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
         // current-page (`PAGE`) and total-page (`TOTAL_PAGE`) distinct;
         // collapsing them would lose user-visible semantics.
         if let Some(an) = &ctrl.auto_num {
-            let kind_and_flag = match an.num_type.as_str() {
-                "PAGE" => Some((hwpforge_core::control::InlinePageKind::CurrentPage, 0)),
-                "TOTAL_PAGE" => Some((hwpforge_core::control::InlinePageKind::TotalPages, 0x06)),
+            let kind = match an.num_type.as_str() {
+                "PAGE" => Some(hwpforge_core::control::InlinePageKind::CurrentPage),
+                "TOTAL_PAGE" => Some(hwpforge_core::control::InlinePageKind::TotalPages),
                 _ => None,
             };
-            if let Some((kind, raw_flag)) = kind_and_flag {
+            if let Some(kind) = kind {
                 runs.push(Run {
-                    content: RunContent::Control(Box::new(Control::InlinePageNumber {
-                        kind,
-                        raw_flag,
-                    })),
+                    content: RunContent::Control(Box::new(Control::InlinePageNumber { kind })),
                     char_shape_id,
                 });
             }
@@ -2926,8 +2923,8 @@ mod tests {
     #[test]
     fn serde_field_autonum_total_page() {
         // Wave 12n architect review CRITICAL gate: numType="TOTAL_PAGE"
-        // must NOT collapse to CurrentPage. raw_flag mirrors the
-        // hardcoded mapping (0x06) so encoder→decoder lossless tests
+        // must NOT collapse to CurrentPage. The decoder maps it back to
+        // InlinePageKind::TotalPages so encoder→decoder lossless tests
         // can pin equality.
         let xml = r#"<sec>
             <p paraPrIDRef="0">

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -2787,7 +2787,7 @@ mod tests {
     fn field_pagenum_produces_autonum() {
         // Wave 12n: PageNum moved from FieldType::PageNum to Control::InlinePageNumber.
         use hwpforge_core::control::{Control, InlinePageKind};
-        let ctrl = Control::InlinePageNumber { kind: InlinePageKind::CurrentPage, raw_flag: 0 };
+        let ctrl = Control::InlinePageNumber { kind: InlinePageKind::CurrentPage };
         let section = Section::with_paragraphs(
             vec![Paragraph::with_runs(
                 vec![Run::control(ctrl, CharShapeIndex::new(0))],
@@ -2995,12 +2995,7 @@ mod tests {
     fn lossy_datecodefield_emits_summary_token() {
         // %dte time-mode → $createtime SUMMERY (lossy; raw_command kept as display).
         use hwpforge_core::control::Control;
-        let ctrl = Control::DateCodeField {
-            raw_command: "T\\:H:mm;0;".to_string(),
-            is_time_mode: true,
-            raw_trailer: [0; 8],
-            display_text: String::new(),
-        };
+        let ctrl = Control::DateCodeField { is_time_mode: true, display_text: String::new() };
         let section = Section::with_paragraphs(
             vec![Paragraph::with_runs(
                 vec![Run::control(ctrl, CharShapeIndex::new(0))],
@@ -3105,12 +3100,7 @@ mod tests {
     #[test]
     fn lossy_roundtrip_datecodefield_time_becomes_createdtime() {
         use hwpforge_core::control::Control;
-        let ctrl = Control::DateCodeField {
-            raw_command: "T\\:H:mm;0;".to_string(),
-            is_time_mode: true,
-            raw_trailer: [0; 8],
-            display_text: String::new(),
-        };
+        let ctrl = Control::DateCodeField { is_time_mode: true, display_text: String::new() };
         let decoded = lossy_roundtrip_decode_first_control(ctrl);
         match decoded {
             Control::Field { field_type, .. } => {
@@ -3127,12 +3117,7 @@ mod tests {
     #[test]
     fn lossy_roundtrip_datecodefield_date_becomes_modifiedtime() {
         use hwpforge_core::control::Control;
-        let ctrl = Control::DateCodeField {
-            raw_command: "\\:1년 2월 3일;0;".to_string(),
-            is_time_mode: false,
-            raw_trailer: [0; 8],
-            display_text: String::new(),
-        };
+        let ctrl = Control::DateCodeField { is_time_mode: false, display_text: String::new() };
         let decoded = lossy_roundtrip_decode_first_control(ctrl);
         match decoded {
             Control::Field { field_type, .. } => {
@@ -3215,11 +3200,10 @@ mod tests {
     // numType="TOTAL_PAGE" to the wrong kind), one of these flips
     // before the encoder/decoder ship as a pair.
     //
-    // `raw_flag` values mirror the decoder's hardcoded mapping
-    // (PAGE → 0, TOTAL_PAGE → 0x06 — see decoder/section.rs around
-    // line 423). The encoder discards `raw_flag` on emission, so the
-    // round-trip is lossless only when the input matches what the
-    // decoder fabricates on parse.
+    // The kind ↔ numType mapping (CurrentPage → PAGE, TotalPages →
+    // TOTAL_PAGE) is symmetric across encoder/decoder, so a known kind
+    // round-trips losslessly (the wire flag is no longer part of the
+    // core IR — E6 slice C).
 
     #[test]
     fn roundtrip_summary_author_lossless() {
@@ -3302,7 +3286,7 @@ mod tests {
     #[test]
     fn roundtrip_inline_pagenumber_currentpage_lossless() {
         use hwpforge_core::control::{Control, InlinePageKind};
-        let ctrl = Control::InlinePageNumber { kind: InlinePageKind::CurrentPage, raw_flag: 0 };
+        let ctrl = Control::InlinePageNumber { kind: InlinePageKind::CurrentPage };
         let decoded = lossy_roundtrip_decode_first_control(ctrl.clone());
         assert_eq!(decoded, ctrl, "autoNum PAGE must round-trip lossless");
     }
@@ -3312,9 +3296,9 @@ mod tests {
         // Wave 12n architect review CRITICAL gate: TotalPages must not
         // collapse to CurrentPage in either direction. Encoder emits
         // numType="TOTAL_PAGE"; decoder maps it back to TotalPages
-        // with raw_flag 0x06.
+        // (kind preserved through the autoNum numType attribute).
         use hwpforge_core::control::{Control, InlinePageKind};
-        let ctrl = Control::InlinePageNumber { kind: InlinePageKind::TotalPages, raw_flag: 0x06 };
+        let ctrl = Control::InlinePageNumber { kind: InlinePageKind::TotalPages };
         let decoded = lossy_roundtrip_decode_first_control(ctrl.clone());
         assert_eq!(decoded, ctrl, "autoNum TOTAL_PAGE must round-trip lossless");
     }
@@ -3325,7 +3309,7 @@ mod tests {
         // fabricate an autoNum. Decoder therefore sees no control.
         // If anyone collapses Unknown → CurrentPage, this flips.
         use hwpforge_core::control::{Control, InlinePageKind};
-        let ctrl = Control::InlinePageNumber { kind: InlinePageKind::Unknown, raw_flag: 0 };
+        let ctrl = Control::InlinePageNumber { kind: InlinePageKind::Unknown };
         let section = Section::with_paragraphs(
             vec![Paragraph::with_runs(
                 vec![Run::control(ctrl, CharShapeIndex::new(0))],


### PR DESCRIPTION
## E6 cheap-wins 슬라이스 C — H3 raw wire-byte 필드 제거

E6(IR 와이어-누출 상환)의 세 번째이자 마지막 cheap-win. `ADR-007` H3.

HWP5 wire 바이트가 포맷-무관 core IR에 누출돼 있던 것을 제거합니다. **byte-중립** — HWPX 인코더는 이미 이 필드들을 `..`로 버리고 typed 필드만 사용했습니다.

### 변경
| 위치 | 변경 |
|---|---|
| `Control::DateCodeField` | `raw_command`/`raw_trailer` 제거 (`is_time_mode`·`display_text` 유지). T-접두 is_time_mode 파생은 이미 smithy-hwp5 projection에서 수행; raw 패턴은 smithy-내부(`Hwp5DateCodeControl`)로 유지 |
| `Control::InlinePageNumber` | `raw_flag` 제거 (`kind` 유지). 0x00/0x06→kind를 projection 단일 호출부에 inline |
| `InlinePageKind` | `raw_flag()` + `from_raw_flag()` 제거 (wire 테이블 core에서 제거) |
| `validate.rs` | `validate_date_code_field`/`validate_inline_page_number` 제거 (raw 제거로 dead) |
| `error.rs` | `ValidationError::{DateCodeFieldMismatch,InlinePageNumberMismatch}` + `CoreErrorCode 2018/2019` 제거 (gap 유지, 재번호 안 함) |
| `Control` Display | raw_command / `raw=0x..` 출력 제거 |
| smithy-hwpx decoder | InlinePageNumber 리터럴에서 raw_flag drop (num_type→kind 직접 매핑 유지) |

### 확정된 사용자 결정 (2026-06-28)
- **① raw_command/raw_trailer 영구 폐기** — HWP5→HWP5 재인코딩 경로가 없어 무해 (Option B의 전제인 안정 control-id는 미뤄둔 H1/M2 인프라)
- **② from_raw_flag 완전 제거** — 유일 호출자(projection 1곳)라 중복 없이 inline

### ⚠️ Breaking
- `Control::DateCodeField`에서 `raw_command`/`raw_trailer`, `Control::InlinePageNumber`에서 `raw_flag` 제거
- `InlinePageKind::raw_flag()`/`from_raw_flag()` 제거
- `ValidationError::{DateCodeFieldMismatch,InlinePageNumberMismatch}` + 대응 `CoreErrorCode` 제거
- 이 control들의 **JSON shape 변화**. **emitted HWPX 출력 불변**
- → release-plz가 슬라이스 A(머지됨)·B(#85) 이후 다음 마이너 `0.9.0`로 배치

### Verification
- `cargo build --workspace --all-features` 0 errors · clippy `--all-targets -D warnings` 0 warnings
- `cargo nextest run --workspace --all-features` — **2673 passed / 2 skipped** (회귀 0)
- byte-중립 게이트 GREEN: `lossy_roundtrip_datecodefield_*`, `roundtrip_inline_pagenumber_*`, `build_autonum_run_xml_*`, `serde_field_autonum_*`
- **신규 projection 테스트**: `project_inline_pagenumber_maps_raw_flag_to_kind` (실제 projection 경로로 0x06→TotalPages/0x00→CurrentPage/unknown→Unknown), `datecodefield_time_mode_derived_from_t_prefix`
- **검토**: critic 플랜 리뷰 **APPROVE-WITH-CHANGES** (Display impl 누락 사이트 + rustdoc 링크 + 예제 unused 발견 → 전부 반영)
- residue 확인: core/foundation에 `raw_command`/`raw_trailer`/`raw_flag` 0건 (smithy schema의 wire-parse 필드만 잔존)

### E6 진행 상황
- 슬라이스 A (L2 Summery rename) ✅ 머지·0.8.0 릴리스
- 슬라이스 B (H2 BookmarkName collapse) — PR #85
- **슬라이스 C (H3 raw 필드) — 본 PR** ← cheap-wins 완료
- 후속 고위험: H1(display_text sidecar)/M2(inst_id ObjectId) 별도 슬라이스

https://claude.ai/code/session_0199NBUj9VUZmSfqxEysxudD
