### PR TITLE
fix: examples/hwp5_review/ gitignore 충돌로 인한 release-plz 차단 해소

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -494,9 +494,10 @@ temp/
 .mcpregistry_*
 .docs/
 
-# HWP5→HWPX review artifacts (regenerated review area — never version-controlled;
-# CLAUDE.md warns against `git add -A` here)
-examples/hwp5_review/
+# NOTE: examples/hwp5_review/ is NOT ignored — it holds 39 tracked review samples
+# (README.md + chart_*/mixed_*/sample-*.hwpx). A blanket ignore there makes cargo/
+# release-plz fail ("files both committed and in .gitignore"). Beware `git add -A`
+# (per CLAUDE.md) instead of ignoring the whole dir.
 
 # Stray HWP5→HWPX conversion outputs dropped next to .hwp inputs. The .hwp inputs
 # are tracked and tests convert them in-memory; these .hwpx are regenerable byproducts,


### PR DESCRIPTION
## 문제
#91 의 gitignore 커밋(`52cc29d`)이 `examples/hwp5_review/` 를 blanket ignore 했으나, 이 디렉터리엔 **39개 tracked 리뷰 샘플**(README.md + `chart_*`/`mixed_*`/`sample-*.hwpx`)이 있어 cargo/release-plz 가 `files both committed and in .gitignore` 로 실패했습니다 (Release PR 스텝, run 28498167186). → **main 의 release-plz 파이프라인 차단, 0.10.0 Release PR 미생성.**

## 수정
- `examples/hwp5_review/` blanket 규칙 제거 + 사유 주석 추가
- `tests/fixtures/hwp5/crossref/*.hwpx` 규칙 유지 (tracked 충돌 0)

## 검증
- 커밋된 `.gitignore` 기준 tracked-and-ignored 파일 **0**. 머지 후 release-plz 재실행 시 #91 의 `feat!` 반영한 0.10.0 Release PR 생성 예상.