### PR TITLE
ci(release-plz): version_group 으로 통합 버전 정합 (0.10.0 Release PR 차단 해소)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -51,25 +51,68 @@ commit_parsers = [
   { message = "^build", skip = true },
 ]
 
+# All crates share ONE version via `version.workspace = true`. `version_group`
+# makes release-plz treat them as a single unit: every crate is bumped to the
+# SAME next version AND the hardcoded inter-crate `version = "x"` requirements are
+# rewritten consistently. Without this, a breaking bump concentrated in one crate
+# (e.g. core -> 0.10.0) forces the shared workspace version up but leaves other
+# crates' `= "0.9.0"` dep requirements stale, so `cargo update` fails to resolve
+# (`failed to select a version for the requirement ... = "^0.9.0"`).
+# See https://release-plz.dev/docs/config (version_group).
+
 # Umbrella crate: creates the GitHub Release + v{{ version }} tag (triggers pages.yml)
 [[package]]
 name = "hwpforge"
 git_release_enable = true
 git_tag_name = "v{{ version }}"
 git_release_name = "v{{ version }}"
+version_group = "unified"
 
-# Skip stub crates (they also have publish = false in Cargo.toml)
+[[package]]
+name = "hwpforge-foundation"
+version_group = "unified"
+
+[[package]]
+name = "hwpforge-core"
+version_group = "unified"
+
+[[package]]
+name = "hwpforge-blueprint"
+version_group = "unified"
+
+[[package]]
+name = "hwpforge-smithy-hwpx"
+version_group = "unified"
+
+[[package]]
+name = "hwpforge-smithy-md"
+version_group = "unified"
+
+[[package]]
+name = "hwpforge-bindings-mcp"
+version_group = "unified"
+
+# publish = false crates — kept out of crates.io, but still in the version group
+# so their inter-crate `version = "x"` requirements get rewritten consistently.
+[[package]]
+name = "hwpforge-convert"
+publish = false
+version_group = "unified"
+
 [[package]]
 name = "hwpforge-bindings-py"
 release = false
 publish = false
+version_group = "unified"
 
 [[package]]
 name = "hwpforge-bindings-cli"
 release = false
 publish = false
+version_group = "unified"
 
 [[package]]
 name = "hwpforge-smithy-hwp5"
 release = false
 publish = false
+version_group = "unified"


### PR DESCRIPTION
## 문제
#91 머지 후 release-plz 의 `release-pr` 스텝이 실패 (run 28504169874):
```
failed to select a version for the requirement `hwpforge-foundation = ^0.9.0`
candidate versions found which didn't match: 0.10.0
```
모든 crate 가 `version.workspace = true`(통합 버전)인데 release-plz 는 crate 별 독립 버전을 계산합니다. core(`feat!`)를 0.10.0 으로 올리면 통합 워크스페이스 버전이 올라가 foundation 등도 0.10.0 이 되지만, 하드코딩된 inter-crate `version = "0.9.0"` 요구가 재작성되지 않아 cargo resolve 가 실패했습니다.

## 수정
- `release-plz.toml`: 11개 crate 전부에 `version_group = "unified"` 추가
- release-plz 가 이들을 한 버전 그룹으로 다뤄 **같은 버전으로 함께 bump + inter-crate 버전 요구 일괄 재작성**
- Cargo.toml / 버전 / 태그 불변. 공식 config (release-plz.dev/docs/config)

## 검증
- TOML 유효성 확인, 11 crate 모두 version_group 적용
- 로컬 재현 불가(CI 전용 동작) → **머지 후 release-plz 재실행으로 0.10.0 Release PR 생성 확인 예정**