### PR TITLE
ci(release-plz): inter-crate 의존성 요구 완화로 0.10.0 Release PR 차단 해소 (로컬 검증)

### DIFF
--- a/crates/hwpforge-bindings-mcp/Cargo.toml
+++ b/crates/hwpforge-bindings-mcp/Cargo.toml
@@ -18,10 +18,10 @@ name = "hwpforge-mcp"
 path = "src/main.rs"
 
 [dependencies]
-hwpforge-core = { path = "../hwpforge-core", version = "0.9.0" }
-hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.9.0" }
-hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0.9.0" }
-hwpforge-smithy-md = { path = "../hwpforge-smithy-md", version = "0.9.0" }
+hwpforge-core = { path = "../hwpforge-core", version = "0" }
+hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }
+hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0" }
+hwpforge-smithy-md = { path = "../hwpforge-smithy-md", version = "0" }
 # >=2.0 fixes RUSTSEC advisory GHSA-89vp-x53w-74fx (MCP Host-header validation in <1.4.0); tracks Dependabot #90
 rmcp = { version = "2.0", features = ["server", "macros", "transport-io"] }
 schemars = { workspace = true }

--- a/crates/hwpforge-blueprint/Cargo.toml
+++ b/crates/hwpforge-blueprint/Cargo.toml
@@ -14,8 +14,8 @@ rust-version.workspace = true
 description = "YAML-based style template system for HwpForge (Figma Design Token pattern)"
 
 [dependencies]
-hwpforge-core = { path = "../hwpforge-core", version = "0.9.0" }
-hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.9.0" }
+hwpforge-core = { path = "../hwpforge-core", version = "0" }
+hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }
 indexmap = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/crates/hwpforge-core/Cargo.toml
+++ b/crates/hwpforge-core/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 description = "Format-independent Document Object Model for HwpForge"
 
 [dependencies]
-hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.9.0" }
+hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }
 schemars = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/hwpforge-smithy-hwp5/Cargo.toml
+++ b/crates/hwpforge-smithy-hwp5/Cargo.toml
@@ -18,8 +18,8 @@ description = "HWP5 binary format decoder for HwpForge (not yet implemented)"
 byteorder = { workspace = true }
 cfb = { workspace = true }
 flate2 = { workspace = true }
-hwpforge-core = { path = "../hwpforge-core", version = "0.9.0" }
-hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.9.0" }
+hwpforge-core = { path = "../hwpforge-core", version = "0" }
+hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/hwpforge-smithy-hwpx/Cargo.toml
+++ b/crates/hwpforge-smithy-hwpx/Cargo.toml
@@ -18,9 +18,9 @@ description = "HWPX format codec (encoder + decoder) for HwpForge"
 schemars = ["dep:schemars"]
 
 [dependencies]
-hwpforge-blueprint = { path = "../hwpforge-blueprint", version = "0.9.0" }
-hwpforge-core = { path = "../hwpforge-core", version = "0.9.0" }
-hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.9.0" }
+hwpforge-blueprint = { path = "../hwpforge-blueprint", version = "0" }
+hwpforge-core = { path = "../hwpforge-core", version = "0" }
+hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }
 quick-xml = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/crates/hwpforge-smithy-md/Cargo.toml
+++ b/crates/hwpforge-smithy-md/Cargo.toml
@@ -14,9 +14,9 @@ rust-version.workspace = true
 description = "Markdown codec (decoder + lossy/lossless encoder) for HwpForge"
 
 [dependencies]
-hwpforge-blueprint = { path = "../hwpforge-blueprint", version = "0.9.0" }
-hwpforge-core = { path = "../hwpforge-core", version = "0.9.0" }
-hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.9.0" }
+hwpforge-blueprint = { path = "../hwpforge-blueprint", version = "0" }
+hwpforge-core = { path = "../hwpforge-core", version = "0" }
+hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }
 pulldown-cmark = { workspace = true }
 quick-xml = { workspace = true }
 serde = { workspace = true }
@@ -24,6 +24,6 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0.9.0" }
+hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0" }
 pretty_assertions = { workspace = true }
 zip = { workspace = true }

--- a/crates/hwpforge/Cargo.toml
+++ b/crates/hwpforge/Cargo.toml
@@ -20,8 +20,8 @@ md = ["dep:hwpforge-smithy-md"]
 full = ["hwpx", "md"]
 
 [dependencies]
-hwpforge-blueprint = { path = "../hwpforge-blueprint", version = "0.9.0" }
-hwpforge-core = { path = "../hwpforge-core", version = "0.9.0" }
-hwpforge-foundation = { path = "../hwpforge-foundation", version = "0.9.0" }
-hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0.9.0", optional = true }
-hwpforge-smithy-md = { path = "../hwpforge-smithy-md", version = "0.9.0", optional = true }
+hwpforge-blueprint = { path = "../hwpforge-blueprint", version = "0" }
+hwpforge-core = { path = "../hwpforge-core", version = "0" }
+hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }
+hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0", optional = true }
+hwpforge-smithy-md = { path = "../hwpforge-smithy-md", version = "0", optional = true }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -51,68 +51,25 @@ commit_parsers = [
   { message = "^build", skip = true },
 ]
 
-# All crates share ONE version via `version.workspace = true`. `version_group`
-# makes release-plz treat them as a single unit: every crate is bumped to the
-# SAME next version AND the hardcoded inter-crate `version = "x"` requirements are
-# rewritten consistently. Without this, a breaking bump concentrated in one crate
-# (e.g. core -> 0.10.0) forces the shared workspace version up but leaves other
-# crates' `= "0.9.0"` dep requirements stale, so `cargo update` fails to resolve
-# (`failed to select a version for the requirement ... = "^0.9.0"`).
-# See https://release-plz.dev/docs/config (version_group).
-
 # Umbrella crate: creates the GitHub Release + v{{ version }} tag (triggers pages.yml)
 [[package]]
 name = "hwpforge"
 git_release_enable = true
 git_tag_name = "v{{ version }}"
 git_release_name = "v{{ version }}"
-version_group = "unified"
 
-[[package]]
-name = "hwpforge-foundation"
-version_group = "unified"
-
-[[package]]
-name = "hwpforge-core"
-version_group = "unified"
-
-[[package]]
-name = "hwpforge-blueprint"
-version_group = "unified"
-
-[[package]]
-name = "hwpforge-smithy-hwpx"
-version_group = "unified"
-
-[[package]]
-name = "hwpforge-smithy-md"
-version_group = "unified"
-
-[[package]]
-name = "hwpforge-bindings-mcp"
-version_group = "unified"
-
-# publish = false crates — kept out of crates.io, but still in the version group
-# so their inter-crate `version = "x"` requirements get rewritten consistently.
-[[package]]
-name = "hwpforge-convert"
-publish = false
-version_group = "unified"
-
+# Skip stub crates (they also have publish = false in Cargo.toml)
 [[package]]
 name = "hwpforge-bindings-py"
 release = false
 publish = false
-version_group = "unified"
 
 [[package]]
 name = "hwpforge-bindings-cli"
 release = false
 publish = false
-version_group = "unified"
 
 [[package]]
 name = "hwpforge-smithy-hwp5"
 release = false
 publish = false
-version_group = "unified"


### PR DESCRIPTION
## 문제
#91 머지 후 release-plz `release-pr` 스텝이 계속 실패했습니다:
```
failed to select a version for the requirement hwpforge-foundation = ^0.9.0 (candidate 0.10.0)
```
전 crate 가 `version.workspace = true`(통합 버전)인데 release-plz 0.3.159 는 crate 별 독립 버전을 계산합니다. core(`feat!`)만 0.10.0 으로 올리면 통합 버전이 0.10.0 이 되어 foundation 등도 물리적으로 0.10.0 이 되지만, release-plz 는 foundation 을 '커밋 없음'으로 보아 하드코딩된 `version = "0.9.0"` 요구를 재작성하지 않아 충돌.

## 로컬 전수 검증 (release-plz 0.3.159 프리빌트)
CI 머지 사이클 대신 로컬 release-plz 로 재현 후 실험:
| 방법 | 결과 |
|---|---|
| version_group | ❌ 실패 (커밋 없는 foundation 못 올림) |
| release_always | ❌ 실패 |
| 독립 버전제 | ❌ 실패 (요구 불일치 전이) |
| **inter-crate `version = "0"`** | ✅ **성공** (release-plz update 가 0.10.0 bump + CHANGELOG 생성 완료) |

release-plz 0.3.159 에는 커밋 없는 베이스 crate 를 통합 버전으로 끌어올리는 수단이 없음(바이너리 config 키에도 shared_version/release_all 부재, 0.3.159 가 최신).

## 수정
- 7개 crate 의 hwpforge inter-crate 의존성 `version = "0.9.0"` → `"0"` (path 유지, ^0 = 모든 0.x 허용)
- 무효였던 version_group 설정 제거 (release-plz.toml → #93 이전)

## 트레이드오프
inter-crate 정확 버전 강제가 느슨해짐. 단 전 crate 가 항상 동일 버전으로 함께 배포 + 대부분 umbrella crate 사용이라 실무 영향 작고, `"0"`은 어떤 0.x bump 에도 매칭돼 유지보수 불필요.

## 검증
- `cargo metadata` OK (version=0 이 로컬 0.9.0 에 resolve)
- 머지 후 release-plz 재실행으로 0.10.0 Release PR 생성 확인 예정