### PR TITLE
feat(hwpx): fill 델타 API — 이름 → 값 맵으로 누름틀 채우기 (fields/fill)

### DIFF
--- a/.claude/skills/hwpforge/SKILL.md
+++ b/.claude/skills/hwpforge/SKILL.md
@@ -41,8 +41,11 @@ What does the user want?
 │
 ├─ EDIT an existing .hwpx  ── ALWAYS `inspect` first ──
 │   │
+│   ├─ Fill NAMED click-here fields (누름틀) — form-style templates
+│   │     → fields (discover names) → fill --set name=value    [DELTA, cheapest+safest]
+│   │
 │   ├─ Change only EXISTING text
-│   │   (fill a template placeholder, fix a typo, fill a table cell)
+│   │   (fill a prose placeholder, fix a typo, fill a table cell)
 │   │     → to-json (--section) → edit the Text → patch        [TEXT-ONLY, safest]
 │   │
 │   └─ ADD or REMOVE paragraphs (structural change)
@@ -78,6 +81,12 @@ hwpforge convert-hwp5 old.hwp -o out.hwpx
 
 # Inspect (ALWAYS before editing)
 hwpforge inspect doc.hwpx [--styles] [--json]
+
+# Named click-here fields (누름틀) — form templates: discover then fill
+hwpforge fields doc.hwpx [--json]                        # list name/hint/current/fillable
+hwpforge fill doc.hwpx --set 과제명="AI 문서 자동화" --set 기관명="AiScream" -o out.hwpx
+#   all-or-nothing: 하나라도 검증 실패(없는 이름/중복 이름/빈 값/모호 필드)면 아무 것도 안 씀
+#   나머지 패키지 엔트리는 바이트 그대로 보존 (preserve-first)
 
 # Export  (NOTE: -o/--output is REQUIRED — there is no stdout export)
 hwpforge to-json doc.hwpx -o full.json                  # whole document

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document formats, designed with LLM-first principles. The goal is to enable AI agents (like Claude Code) to generate Korean government proposal documents using natural language + Markdown + YAML style templates.
 
-**Current Status** (snapshot — 2026-07-02):
+**Current Status** (snapshot — 2026-07-13):
 
 - HWPX codec: read/write shipped · Markdown bridge: read/write shipped
 - HWP5 → HWPX converter path: active, style/layout fidelity line in progress
@@ -17,6 +17,7 @@ HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document 
 - Phase 12 HWP5→HWPX carry series (GSO shapes/equation/memo/dutmal/compose/indexmark/click-here·auto fields/cross-ref instId/document metadata/outline 1–10) `main` 머지 완료.
 - **E6 IR 와이어-누출 상환 완료** (`0.9.0`): Summery rename(A) · BookmarkName collapse(B) · raw wire 필드 제거(C) · `inst_id`/`SystemId`→공유 `ObjectId`(M2). **H1(display_text)=Won't-do** (ADR-009 §CLOSURE, memory `e6-wire-leak-status-h1-wontdo.md`).
 - **0.10.0 릴리스** (2026-07-02): colLine(다단 구분선) HWPX+HWP5 carry(breaking) + rmcp 2.0 보안(GHSA-89vp-x53w-74fx)·quick-xml 0.41 + 문서 정합.
+- **AI 편집 Wave 1** (2026-07-12~13): 누름틀(ClickHere) 채우기 — PR #97 머지 (`feat!:` `Field::display_text` 의미 변경 → 다음 릴리스 `0.11.0`) + `fill` 델타 API·`fields` 발견 표면 (PR #99). 설계/로드맵 = `.docs/planning/2026-07-10-agent-editing-architecture.md` (남은 조각: E3 표 격자 주소 · E6 스탬핑).
 
 > **이 섹션은 짧은 상태 스냅샷으로만 유지한다 (wave-by-wave 이력을 여기 다시 쌓지 말 것).**
 > Wave별 상세 이력 + breaking change: **`CHANGELOG.md`** (canonical) 와 memory `MEMORY.md` / `phase11_wave_history.md`.
@@ -103,6 +104,11 @@ bacon test    # Auto-run tests
 - **`git push` 를 파이프에 연결 금지**(`| tail` 등) — pre-push 훅의 대량 테스트 출력이 `BlockingIOError [Errno 35]` 로 push 자체를 죽임. run_in_background(파일 리다이렉트)로 실행하고, 성공 판정은 `git ls-remote --heads origin <branch> | grep -q .` 로.
 - pre-push `cargo deny` 가 RustSec advisory DB fetch 네트워크 오류로 간헐 실패 → 재시도로 해결.
 - **전체 `cargo nextest run --workspace`는 cold 빌드 시 15분+** (foreground 한계 초과) → 변경 영향 크레이트만 `-p <crate>`로 돌리고 byte-중립 게이트만 골라 검증. **테스트 실행 중 소스 편집 금지**(rebuild 유발로 더 느려짐).
+- **nextest 통합 테스트 파일 필터**: substring 은 테스트 _이름_ 만 매칭 (파일명 안 잡힘) — 파일 단위는 `-E 'binary(<파일명>)'`.
+- **commit 출력도 `| tail` 로 자르지 말 것** — 실패한 훅 라인·exit code 가 사라져 "커밋됐다" 오판. 파일 리다이렉트 후 grep (push 파이프 금지 규칙과 동일 계열).
+- **커밋 전 touched 크레이트만 `cargo clippy --all-targets -- -D warnings` 사전 점검** — 훅 거부 1회 = 2분+ 재사이클 (nextest/build 는 clippy lint 를 안 잡음).
+- `rm` 은 대화형 alias — stale `.git/index.lock`(0바이트·git 프로세스 없음 확인 후) 등 스크립트 삭제는 `rm -f`.
+- 대용량 정리: `target/`(수백 GB 가능)·`fuzz/target`·`.docs/papers/EAAI/eval/oracle-rs/target` 은 재생성 가능 빌드 산출물. `.docs/papers`(corpus·논문)·`fuzz/corpus` 는 자산 — 삭제 금지.
 
 ### Documentation & Coverage
 
@@ -345,7 +351,7 @@ Local planning and research workspace. It may be git-excluded in this repository
 - 릴리스/기능 상태의 canonical = 상단 **Current Status** 스냅샷 (여기 중복 서술 금지).
 - Table integration gates are concentrated in `crates/hwpforge-bindings-cli/tests/cli_integration.rs`.
 - Stress or real-world table fixtures are not the same thing as committed regression gates.
-- colLine (다단 구분선) HWPX + HWP5→HWPX legs shipped in `0.10.0` (PR #91, 2026-07-02). No active feature branch.
+- colLine (다단 구분선) HWPX + HWP5→HWPX legs shipped in `0.10.0` (PR #91, 2026-07-02).
 - Always confirm `main` state from code + manifests + git; do not trust stale branch prose.
 
 ---
@@ -427,6 +433,7 @@ Local planning and research workspace. It may be git-excluded in this repository
 27. ContentType 의미는 RefType-상대적 (Bookmark+Contents = 책갈피 이름, Figure+Contents = 캡션 본문) — invented enum 금지
 28. 도형/글상자 텍스트 **세로정렬 = HWP5 ListHeader 속성 bits 5-6** (`(props>>5)&0x03`, 0/1/2=Top/Center/Bottom). 표 셀 디코드(`smithy-hwp5/src/decoder/section/mod.rs`)가 ground truth — openhwp `(props>>2)`는 우리 wire와 불일치
 29. 도형 drawText `<hp:subList textWidth/textHeight>` = **`0`이 Hancom-정답** (렌더러는 `<hp:sz>`−`<hp:textMargin>`(기본 283)으로 텍스트 영역 계산). 계산값으로 "고치지" 말 것 — 한컴 fixture·KS X 6101 샘플 141 확인
+30. 누름틀(ClickHere) 본문 = `fieldBegin`~`fieldEnd` 사이 평범한 `<hp:t>` (미채움 = 힌트와 동일 문자열). `display_text` 빈 문자열 = 미채움/모호 sentinel — patch 슬롯·redact·fill 이 전부 ClickHere-gated 로 이 불변식 공유. 한컴 재저장은 라벨 run 을 필드 run 에 병합 → run 에 `<hp:t>` 1개일 때만 본문 무모호 귀속 (HxRun 은 자식 순서 미보존)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document 
 - Phase 12 HWP5→HWPX carry series (GSO shapes/equation/memo/dutmal/compose/indexmark/click-here·auto fields/cross-ref instId/document metadata/outline 1–10) `main` 머지 완료.
 - **E6 IR 와이어-누출 상환 완료** (`0.9.0`): Summery rename(A) · BookmarkName collapse(B) · raw wire 필드 제거(C) · `inst_id`/`SystemId`→공유 `ObjectId`(M2). **H1(display_text)=Won't-do** (ADR-009 §CLOSURE, memory `e6-wire-leak-status-h1-wontdo.md`).
 - **0.10.0 릴리스** (2026-07-02): colLine(다단 구분선) HWPX+HWP5 carry(breaking) + rmcp 2.0 보안(GHSA-89vp-x53w-74fx)·quick-xml 0.41 + 문서 정합.
-- **AI 편집 Wave 1** (2026-07-12~13): 누름틀(ClickHere) 채우기 — PR #97 머지 (`feat!:` `Field::display_text` 의미 변경 → 다음 릴리스 `0.11.0`) + `fill` 델타 API·`fields` 발견 표면 (PR #99). 설계/로드맵 = `.docs/planning/2026-07-10-agent-editing-architecture.md` (남은 조각: E3 표 격자 주소 · E6 스탬핑).
+- **AI 편집 Wave 1** (2026-07-12~13): 누름틀(ClickHere) 채우기 — PR #97, **`0.11.0` 릴리스 완료** (2026-07-12, `feat!:` `Field::display_text` 의미 변경) + `fill` 델타 API·`fields` 발견 표면 (PR #99 → `0.12.0` 예정). 설계/로드맵 = `.docs/planning/2026-07-10-agent-editing-architecture.md` (남은 조각: E3 표 격자 주소 · E6 스탬핑).
 
 > **이 섹션은 짧은 상태 스냅샷으로만 유지한다 (wave-by-wave 이력을 여기 다시 쌓지 말 것).**
 > Wave별 상세 이력 + breaking change: **`CHANGELOG.md`** (canonical) 와 memory `MEMORY.md` / `phase11_wave_history.md`.
@@ -34,7 +34,7 @@ HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document 
 
 **Workspace Facts** (code-grounded — 카운트는 drift하니 인용 전 확인):
 
-- Cargo packages `11` · crates.io published `0.10.0` (colLine+rmcp2.0; 다음 breaking → `0.11.0`) · MSRV `1.88` · Dev toolchain Rust `1.93`
+- Cargo packages `11` · crates.io published `0.11.0` (누름틀 display_text `feat!:`, 2026-07-12) — E2(fill) 는 `0.12.0` 예정 · MSRV `1.88` · Dev toolchain Rust `1.93`
 - `crates/` 추적 src 파일 ~`177` · nextest ~`2,688` passed + `2` skipped · `examples/` 산출물 `68`+ (미추적 `examples/hwp5_review/` 리뷰 영역 별도 — gitignore 아님) · GitHub workflows `5`
 
 ---

--- a/crates/hwpforge-bindings-cli/src/commands/fields.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/fields.rs
@@ -1,0 +1,51 @@
+//! List named click-here fields in an HWPX document (fill discoverability).
+
+use std::path::PathBuf;
+
+use hwpforge_smithy_hwpx::HwpxFiller;
+
+use crate::error::{check_file_size, CliError};
+
+/// Run the fields command.
+pub fn run(file: &PathBuf, json_mode: bool) {
+    check_file_size(file, json_mode);
+    let bytes = match std::fs::read(file) {
+        Ok(b) => b,
+        Err(e) => {
+            CliError::new("FILE_READ_FAILED", format!("Cannot read '{}': {e}", file.display()))
+                .exit(json_mode, 1);
+        }
+    };
+
+    let fields = match HwpxFiller::list_fields(&bytes) {
+        Ok(fields) => fields,
+        Err(e) => {
+            CliError::new("DECODE_FAILED", format!("Cannot decode '{}': {e}", file.display()))
+                .exit(json_mode, 2);
+        }
+    };
+
+    if json_mode {
+        let result = serde_json::json!({ "status": "ok", "fields": fields });
+        println!("{}", serde_json::to_string(&result).unwrap());
+        return;
+    }
+
+    if fields.is_empty() {
+        println!("No click-here fields found in {}", file.display());
+        return;
+    }
+    println!("{} field(s) in {}:", fields.len(), file.display());
+    for f in &fields {
+        let name = f.name.as_deref().unwrap_or("(이름 없음)");
+        let fillable = if f.fillable { "fillable" } else { "NOT fillable" };
+        println!(
+            "  [{}] {} = {:?} ({}; hint: {})",
+            f.section,
+            name,
+            f.current,
+            fillable,
+            f.hint.as_deref().unwrap_or("-"),
+        );
+    }
+}

--- a/crates/hwpforge-bindings-cli/src/commands/fill.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/fill.rs
@@ -1,0 +1,105 @@
+//! Fill named click-here fields with values (delta edit, preserve-first).
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use hwpforge_smithy_hwpx::{FillError, HwpxFiller};
+
+use crate::error::{check_file_size, CliError};
+
+/// Run the fill command.
+pub fn run(file: &PathBuf, sets: &[String], output: &PathBuf, json_mode: bool) {
+    let values = parse_sets(sets, json_mode);
+    if values.is_empty() {
+        CliError::new("NO_VALUES", "no --set name=value pairs given")
+            .with_hint("예: hwpforge fill doc.hwpx --set 과제명=\"AI 문서 자동화\" -o out.hwpx")
+            .exit(json_mode, 1);
+    }
+
+    check_file_size(file, json_mode);
+    let bytes = match std::fs::read(file) {
+        Ok(b) => b,
+        Err(e) => {
+            CliError::new("FILE_READ_FAILED", format!("Cannot read '{}': {e}", file.display()))
+                .exit(json_mode, 1);
+        }
+    };
+
+    let outcome = match HwpxFiller::fill(&bytes, &values) {
+        Ok(outcome) => outcome,
+        Err(error) => exit_fill_error(error, json_mode),
+    };
+
+    if let Err(e) = std::fs::write(output, &outcome.bytes) {
+        CliError::new("FILE_WRITE_FAILED", format!("Cannot write '{}': {e}", output.display()))
+            .exit(json_mode, 1);
+    }
+
+    if json_mode {
+        let result = serde_json::json!({
+            "status": "ok",
+            "output": output.display().to_string(),
+            "filled": outcome.filled,
+            "size_bytes": outcome.bytes.len(),
+        });
+        println!("{}", serde_json::to_string(&result).unwrap());
+    } else {
+        println!("Filled {} field(s) -> {}", outcome.filled.len(), output.display());
+        for f in &outcome.filled {
+            println!("  [{}] {}: {:?} -> filled", f.section, f.name, f.previous);
+        }
+    }
+}
+
+/// `name=value` 인자 목록을 맵으로 파싱한다. `=` 누락·중복 이름은 거부.
+fn parse_sets(sets: &[String], json_mode: bool) -> BTreeMap<String, String> {
+    let mut values = BTreeMap::new();
+    for set in sets {
+        let Some((name, value)) = set.split_once('=') else {
+            CliError::new("INVALID_SET", format!("'--set {set}' is not name=value"))
+                .with_hint("--set 이름=값 형식으로 지정하세요 (값에 공백이 있으면 따옴표)")
+                .exit(json_mode, 1);
+        };
+        if values.insert(name.to_string(), value.to_string()).is_some() {
+            CliError::new("DUPLICATE_SET", format!("'--set {name}=…' given more than once"))
+                .exit(json_mode, 1);
+        }
+    }
+    values
+}
+
+fn exit_fill_error(error: FillError, json_mode: bool) -> ! {
+    match error {
+        FillError::EmptyValue { name } => {
+            CliError::new("EMPTY_FIELD_VALUE", format!("field '{name}': empty value"))
+                .with_hint("빈 값 채우기는 미지원 — 값을 지우려면 한컴에서 편집하세요")
+                .exit(json_mode, 1)
+        }
+        FillError::UnknownField { name, available } => CliError::new(
+            "FIELD_NOT_FOUND",
+            format!("field '{name}' not found in document"),
+        )
+        .with_hint(format!(
+            "사용 가능한 필드: [{}] — `hwpforge fields <file>` 로 확인",
+            available.join(", ")
+        ))
+        .exit(json_mode, 1),
+        FillError::DuplicateFieldName { name, count } => CliError::new(
+            "FIELD_NAME_AMBIGUOUS",
+            format!("field '{name}' appears {count} times"),
+        )
+        .with_hint("같은 이름의 누름틀이 여러 개라 대상이 모호합니다 — 문서에서 이름을 유일하게 하세요")
+        .exit(json_mode, 1),
+        FillError::UnfillableField { name, section } => CliError::new(
+            "FIELD_NOT_FILLABLE",
+            format!("field '{name}' in section {section} has no patchable body"),
+        )
+        .with_hint(
+            "병합-run 모호 필드 또는 빈 본문 — 한컴에서 재저장하거나 from-json --base 로 재생성하세요",
+        )
+        .exit(json_mode, 1),
+        FillError::Workflow(e) => {
+            CliError::new("FILL_FAILED", format!("fill workflow error: {e}")).exit(json_mode, 2)
+        }
+    }
+}

--- a/crates/hwpforge-bindings-cli/src/commands/mod.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/mod.rs
@@ -2,6 +2,8 @@ pub mod audit_hwp5;
 pub mod census_hwp5;
 pub mod convert;
 pub mod convert_hwp5;
+pub mod fields;
+pub mod fill;
 pub mod from_json;
 pub mod inspect;
 pub mod patch;

--- a/crates/hwpforge-bindings-cli/src/main.rs
+++ b/crates/hwpforge-bindings-cli/src/main.rs
@@ -128,6 +128,29 @@ enum Commands {
         base: Option<PathBuf>,
     },
 
+    /// List named click-here fields (누름틀) and whether each is fillable.
+    Fields {
+        /// HWPX file to inspect.
+        file: PathBuf,
+    },
+
+    /// Fill named click-here fields (누름틀) with values, preserving everything else.
+    #[command(
+        long_about = "Fill named click-here fields (누름틀) by name, byte-preserving every untouched package entry.\n\nAll requested values are validated first (unknown/duplicate/unfillable names, empty values) and nothing is written unless every one passes. Use `fields` to discover names."
+    )]
+    Fill {
+        /// HWPX file to fill.
+        file: PathBuf,
+
+        /// name=value pair to fill (repeatable).
+        #[arg(long = "set", value_name = "NAME=VALUE")]
+        sets: Vec<String>,
+
+        /// Output HWPX file path.
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+
     /// Patch a section in an existing HWPX file.
     Patch {
         /// Base HWPX file.
@@ -218,6 +241,12 @@ fn main() {
         }
         Commands::FromJson { input, output, base } => {
             commands::from_json::run(&input, &output, &base, cli.json);
+        }
+        Commands::Fields { file } => {
+            commands::fields::run(&file, cli.json);
+        }
+        Commands::Fill { file, sets, output } => {
+            commands::fill::run(&file, &sets, &output, cli.json);
         }
         Commands::Patch { base, section, section_json, output } => {
             commands::patch::run(&base, section, &section_json, &output, cli.json);

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -3046,3 +3046,79 @@ fn bad_output_directory() {
         run(&["convert", md.to_str().unwrap(), "-o", "/nonexistent/dir/output.hwpx"]);
     assert_eq!(code, 1, "writing to nonexistent directory should fail");
 }
+
+// ═══════════════════════════════════════════════════════════════
+// fields / fill — E2 누름틀 델타 API 게이트
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn fields_lists_named_clickhere_with_fillability() {
+    let f = fixture("clickhere_named.hwpx");
+    let (value, _, code) = run_json(&["fields", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert_eq!(value["status"], "ok");
+    assert_eq!(value["fields"][0]["name"], "user_email");
+    assert_eq!(value["fields"][0]["fillable"], true);
+}
+
+#[test]
+fn fill_named_field_end_to_end() {
+    let f = fixture("clickhere_named.hwpx");
+    let tmp = test_tmp();
+    let out = tmp.join("filled.hwpx");
+    let (value, _, code) = run_json(&[
+        "fill",
+        f.to_str().unwrap(),
+        "--set",
+        "user_email=e2e@gate.io",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    assert_eq!(value["filled"][0]["name"], "user_email");
+
+    // 채워진 값이 재조회에서 살아있어야 한다.
+    let (again, _, code2) = run_json(&["fields", out.to_str().unwrap()]);
+    assert_eq!(code2, 0);
+    assert_eq!(again["fields"][0]["current"], "e2e@gate.io");
+}
+
+#[test]
+fn fill_unknown_name_reports_available_fields() {
+    let f = fixture("clickhere_named.hwpx");
+    let tmp = test_tmp();
+    let out = tmp.join("never.hwpx");
+    let (value, _, code) = run_json(&[
+        "fill",
+        f.to_str().unwrap(),
+        "--set",
+        "없는필드=x",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 1);
+    assert_eq!(value["code"], "FIELD_NOT_FOUND");
+    assert!(
+        value["hint"].as_str().unwrap_or("").contains("user_email"),
+        "hint 에 사용 가능한 필드 목록이 있어야 한다: {value}"
+    );
+    assert!(!out.exists(), "preflight 실패 시 산출물이 없어야 한다 (all-or-nothing)");
+}
+
+#[test]
+fn fill_merged_run_field_rejected_as_not_fillable() {
+    let f = fixture("clickhere_filled.hwpx");
+    let tmp = test_tmp();
+    let out = tmp.join("never2.hwpx");
+    let (value, _, code) = run_json(&[
+        "fill",
+        f.to_str().unwrap(),
+        "--set",
+        "user_email=x@y.z",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 1);
+    assert_eq!(value["code"], "FIELD_NOT_FILLABLE");
+    assert!(!out.exists());
+}

--- a/crates/hwpforge-bindings-mcp/src/server.rs
+++ b/crates/hwpforge-bindings-mcp/src/server.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use crate::output::{ToolErrorInfo, ToolOutput};
 use crate::tools::{
-    convert, from_json, inspect, patch, restyle, templates, to_json, to_md, validate,
+    convert, fields, fill, from_json, inspect, patch, restyle, templates, to_json, to_md, validate,
 };
 use crate::{prompts, resources};
 
@@ -74,6 +74,25 @@ pub struct PatchRequest {
     /// Path to the JSON file containing the replacement section.
     pub section_json_path: String,
     /// Output HWPX file path.
+    pub output_path: String,
+}
+
+/// Request parameters for `hwpforge_fields`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FieldsRequest {
+    /// Path to the HWPX file to inspect.
+    pub file_path: String,
+}
+
+/// Request parameters for `hwpforge_fill`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FillRequest {
+    /// Path to the HWPX file to fill.
+    pub file_path: String,
+    /// Field name → value map. All values are validated before anything is
+    /// written (all-or-nothing). Use hwpforge_fields to discover names.
+    pub values: std::collections::BTreeMap<String, String>,
+    /// Output HWPX file path. Must end with `.hwpx`.
     pub output_path: String,
 }
 
@@ -335,6 +354,66 @@ impl HwpForgeServer {
                         data.patched_section, data.output_path, data.size_bytes, data.sections,
                     ),
                     vec!["Use hwpforge_inspect to verify the patched output"],
+                );
+                Ok(CallToolResult::success(vec![ContentBlock::text(output.to_json_string())]))
+            }
+            Err(err) => Ok(tool_error_response(err)),
+        }
+    }
+
+    /// List named click-here fields (누름틀) for fill discoverability.
+    #[tool(
+        name = "hwpforge_fields",
+        description = "List named click-here fields (누름틀) in an HWPX document: name, hint, current value, and whether each is fillable. Use before hwpforge_fill to discover field names."
+    )]
+    async fn hwpforge_fields(
+        &self,
+        Parameters(req): Parameters<FieldsRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let result = tokio::task::spawn_blocking(move || fields::run_fields(&req.file_path))
+            .await
+            .map_err(|e| McpError::internal_error(format!("Task join error: {e}"), None))?;
+
+        match result {
+            Ok(data) => {
+                let output = ToolOutput::new(
+                    &data,
+                    format!("{} field(s), {} fillable", data.fields.len(), data.fillable_count),
+                    vec!["Use hwpforge_fill with values {name: value} to fill fields"],
+                );
+                Ok(CallToolResult::success(vec![ContentBlock::text(output.to_json_string())]))
+            }
+            Err(err) => Ok(tool_error_response(err)),
+        }
+    }
+
+    /// Fill named click-here fields (누름틀) with values — delta edit that
+    /// byte-preserves every untouched package entry.
+    #[tool(
+        name = "hwpforge_fill",
+        description = "Fill named click-here fields (누름틀) by name→value map, byte-preserving everything else. All values are validated first (all-or-nothing). Much cheaper than to_json+patch for template filling. Use hwpforge_fields to discover names."
+    )]
+    async fn hwpforge_fill(
+        &self,
+        Parameters(req): Parameters<FillRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let result = tokio::task::spawn_blocking(move || {
+            fill::run_fill(&req.file_path, &req.values, &req.output_path)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("Task join error: {e}"), None))?;
+
+        match result {
+            Ok(data) => {
+                let output = ToolOutput::new(
+                    &data,
+                    format!(
+                        "Filled {} field(s) → {} ({} bytes)",
+                        data.filled.len(),
+                        data.output_path,
+                        data.size_bytes,
+                    ),
+                    vec!["Use hwpforge_inspect or hwpforge_to_md to verify the filled output"],
                 );
                 Ok(CallToolResult::success(vec![ContentBlock::text(output.to_json_string())]))
             }

--- a/crates/hwpforge-bindings-mcp/src/tools/fields.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/fields.rs
@@ -1,0 +1,30 @@
+//! `hwpforge_fields` — 누름틀(ClickHere) 목록 조회 (fill 발견가능성 표면).
+
+use serde::Serialize;
+
+use hwpforge_smithy_hwpx::{FieldInfo, HwpxFiller};
+
+use crate::output::{read_file_bytes, ToolErrorInfo};
+
+/// Output data from a fields listing.
+#[derive(Debug, Serialize)]
+pub struct FieldsData {
+    /// All click-here fields in document order.
+    pub fields: Vec<FieldInfo>,
+    /// How many of them are fillable via `hwpforge_fill`.
+    pub fillable_count: usize,
+}
+
+/// List named click-here fields in an HWPX document.
+pub fn run_fields(file_path: &str) -> Result<FieldsData, ToolErrorInfo> {
+    let bytes = read_file_bytes(file_path)?;
+    let fields = HwpxFiller::list_fields(&bytes).map_err(|e| {
+        ToolErrorInfo::new(
+            "DECODE_ERROR",
+            format!("HWPX decode failed: {e}"),
+            "Check that the file is valid HWPX. For .hwp files, convert with hwpforge_convert first.",
+        )
+    })?;
+    let fillable_count = fields.iter().filter(|f| f.fillable).count();
+    Ok(FieldsData { fields, fillable_count })
+}

--- a/crates/hwpforge-bindings-mcp/src/tools/fill.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/fill.rs
@@ -1,0 +1,86 @@
+//! `hwpforge_fill` — 이름 붙은 누름틀(ClickHere) 채우기 (delta edit).
+//!
+//! 섹션 JSON 왕복 없이 `이름 → 값` 맵만으로 문서를 채운다. 전량 preflight
+//! 후 전량 적용(all-or-nothing)이며, 채워진 섹션 XML 외의 패키지 엔트리는
+//! 바이트 그대로 보존된다.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use hwpforge_smithy_hwpx::{FillError, FilledField, HwpxFiller};
+
+use crate::output::{read_file_bytes, write_output_file, ToolErrorInfo};
+
+/// Output data from a successful fill operation.
+#[derive(Debug, Serialize)]
+pub struct FillData {
+    /// Path to the generated HWPX file.
+    pub output_path: String,
+    /// Fields that were filled (document order).
+    pub filled: Vec<FilledField>,
+    /// Size of the output file in bytes.
+    pub size_bytes: u64,
+}
+
+/// Fill named click-here fields with values.
+pub fn run_fill(
+    file_path: &str,
+    values: &BTreeMap<String, String>,
+    output_path: &str,
+) -> Result<FillData, ToolErrorInfo> {
+    if !output_path.ends_with(".hwpx") {
+        return Err(ToolErrorInfo::new(
+            "INVALID_EXTENSION",
+            format!("Output path must end with .hwpx: {output_path}"),
+            "Use a .hwpx extension for the output file.",
+        ));
+    }
+    if values.is_empty() {
+        return Err(ToolErrorInfo::new(
+            "NO_VALUES",
+            "values map is empty",
+            "Pass at least one name→value pair. Use hwpforge_fields to discover names.",
+        ));
+    }
+
+    let bytes = read_file_bytes(file_path)?;
+    let outcome = HwpxFiller::fill(&bytes, values).map_err(map_fill_error)?;
+    write_output_file(output_path, &outcome.bytes)?;
+
+    let size_bytes = outcome.bytes.len() as u64;
+    Ok(FillData { output_path: output_path.to_string(), filled: outcome.filled, size_bytes })
+}
+
+fn map_fill_error(error: FillError) -> ToolErrorInfo {
+    match error {
+        FillError::EmptyValue { name } => ToolErrorInfo::new(
+            "EMPTY_FIELD_VALUE",
+            format!("field '{name}': empty value is not fillable"),
+            "빈 값 채우기는 미지원 — 값을 지우려면 한컴에서 편집하세요.",
+        ),
+        FillError::UnknownField { name, available } => ToolErrorInfo::new(
+            "FIELD_NOT_FOUND",
+            format!("field '{name}' not found in document"),
+            format!(
+                "Available fields: [{}]. Use hwpforge_fields to list them.",
+                available.join(", ")
+            ),
+        ),
+        FillError::DuplicateFieldName { name, count } => ToolErrorInfo::new(
+            "FIELD_NAME_AMBIGUOUS",
+            format!("field '{name}' appears {count} times"),
+            "같은 이름의 누름틀이 여러 개라 대상이 모호합니다 — 문서에서 이름을 유일하게 하세요.",
+        ),
+        FillError::UnfillableField { name, section } => ToolErrorInfo::new(
+            "FIELD_NOT_FILLABLE",
+            format!("field '{name}' in section {section} has no patchable body"),
+            "병합-run 모호 필드 또는 빈 본문 — 한컴 재저장 또는 from-json --base 재생성이 필요합니다.",
+        ),
+        FillError::Workflow(e) => ToolErrorInfo::new(
+            "FILL_ERROR",
+            format!("fill workflow error: {e}"),
+            "Check that the file is valid HWPX.",
+        ),
+    }
+}

--- a/crates/hwpforge-bindings-mcp/src/tools/mod.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/mod.rs
@@ -12,6 +12,8 @@
 //! - `to_md`: Export (HWPX → Markdown)
 
 pub mod convert;
+pub mod fields;
+pub mod fill;
 pub mod from_json;
 pub mod inspect;
 pub mod patch;

--- a/crates/hwpforge-smithy-hwpx/src/fill.rs
+++ b/crates/hwpforge-smithy-hwpx/src/fill.rs
@@ -1,0 +1,357 @@
+//! E2 `fill` 델타 API — 이름 붙은 누름틀(ClickHere)을 값 맵으로 채운다.
+//!
+//! 에이전트가 섹션 JSON 전체를 왕복하지 않고 `이름 → 값` 델타만으로
+//! 문서를 채우는 상위 API. 내부적으로 preserve-first 패처
+//! ([`crate::HwpxPatcher`])를 사용하므로 채워진 섹션 XML 외의 모든 ZIP
+//! 엔트리는 바이트 그대로 보존된다.
+//!
+//! # 정책 (설계 토론 확정 — `.docs/planning/2026-07-10-agent-editing-architecture.md`)
+//!
+//! - **전량 preflight 후 전량 적용** (all-or-nothing): 요청 값 중 하나라도
+//!   검증에 실패하면 아무 것도 쓰지 않는다.
+//! - **이름 중복 거부**: 같은 `name` 의 누름틀이 여러 개면
+//!   [`FillError::DuplicateFieldName`] — 자동으로 전부 채우지 않는다.
+//! - **빈 값 거부**: 빈 `display_text` 는 힌트-폴백·모호-다운그레이드
+//!   sentinel 로 이미 과적되어 있으므로 [`FillError::EmptyValue`].
+//! - **미채움/모호 필드 거부**: `display_text` 가 빈 필드는 patch 텍스트
+//!   슬롯이 없어(슬롯 거울 불변식) 채울 수 없다 —
+//!   [`FillError::UnfillableField`]. 병합-run(한컴 재저장) 필드가 여기
+//!   해당한다.
+
+use std::collections::BTreeMap;
+
+use hwpforge_core::control::Control;
+use hwpforge_core::paragraph::Paragraph;
+use hwpforge_core::run::RunContent;
+use hwpforge_core::section::Section;
+use hwpforge_foundation::FieldType;
+
+use crate::error::{HwpxError, HwpxResult};
+use crate::{HwpxDecoder, HwpxPatcher};
+
+/// 문서 안의 누름틀 한 개에 대한 발견가능성 정보 (`fields` CLI/MCP 표면).
+#[derive(Debug, Clone, serde::Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct FieldInfo {
+    /// 필드 이름 (`fieldBegin name="…"`). 이름 없는 누름틀은 `None` —
+    /// 이름으로 지정할 수 없으므로 fill 대상이 아니다.
+    pub name: Option<String>,
+    /// 힌트(placeholder) 텍스트 (`Direction` 파라미터).
+    pub hint: Option<String>,
+    /// 현재 본문 값. 미채움 네이티브 필드는 힌트와 동일한 문자열이다.
+    pub current: String,
+    /// 필드가 속한 섹션 인덱스.
+    pub section: usize,
+    /// `fill` 로 채울 수 있는지. `false` = 본문이 비어 patch 슬롯이 없는
+    /// 상태(병합-run 모호 필드 또는 빈 본문) — 한컴에서 재저장하거나
+    /// `from-json --base` 재생성 경로가 필요하다.
+    pub fillable: bool,
+}
+
+/// `fill` 로 실제 채워진 필드 하나의 기록.
+#[derive(Debug, Clone, serde::Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct FilledField {
+    /// 필드 이름.
+    pub name: String,
+    /// 필드가 속한 섹션 인덱스.
+    pub section: usize,
+    /// 채우기 전 본문 (힌트 또는 이전 값) — 감사/롤백 참고용.
+    pub previous: String,
+}
+
+/// [`HwpxFiller::fill`] 의 성공 결과.
+#[derive(Debug, Clone)]
+pub struct FillOutcome {
+    /// 채워진 HWPX 패키지 바이트. 건드리지 않은 엔트리는 원본과 동일하다.
+    pub bytes: Vec<u8>,
+    /// 채워진 필드 목록 (요청 순서가 아니라 문서 순서).
+    pub filled: Vec<FilledField>,
+}
+
+/// `fill` preflight/적용 실패.
+#[derive(Debug)]
+pub enum FillError {
+    /// 빈 값은 채울 수 없다 — 빈 `display_text` 는 힌트-폴백 sentinel.
+    EmptyValue {
+        /// 문제의 필드 이름.
+        name: String,
+    },
+    /// 요청한 이름의 누름틀이 문서에 없다.
+    UnknownField {
+        /// 요청한 이름.
+        name: String,
+        /// 문서에 존재하는 이름 붙은 누름틀 목록 (문서 순서, 중복 제거).
+        available: Vec<String>,
+    },
+    /// 같은 이름의 누름틀이 여러 개 — 모호하므로 거부.
+    DuplicateFieldName {
+        /// 중복된 이름.
+        name: String,
+        /// 발견된 개수.
+        count: usize,
+    },
+    /// 본문이 비어 patch 슬롯이 없는 필드 (병합-run 모호 또는 빈 본문).
+    UnfillableField {
+        /// 필드 이름.
+        name: String,
+        /// 필드가 속한 섹션.
+        section: usize,
+    },
+    /// 디코드/패치 하위 오류.
+    Workflow(HwpxError),
+}
+
+impl std::fmt::Display for FillError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyValue { name } => {
+                write!(f, "field '{name}': empty value is not fillable (빈 값 채우기 미지원 — 비우기는 별도 연산)")
+            }
+            Self::UnknownField { name, available } => {
+                write!(f, "field '{name}' not found; available: [{}]", available.join(", "))
+            }
+            Self::DuplicateFieldName { name, count } => {
+                write!(f, "field '{name}' appears {count} times; ambiguous target (이름 중복 — 문서에서 이름을 유일하게 하세요)")
+            }
+            Self::UnfillableField { name, section } => {
+                write!(
+                    f,
+                    "field '{name}' in section {section} has no patchable body (병합-run 모호 필드 또는 빈 본문 — 한컴 재저장 또는 from-json --base 필요)"
+                )
+            }
+            Self::Workflow(error) => write!(f, "fill workflow error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for FillError {}
+
+impl From<HwpxError> for FillError {
+    fn from(error: HwpxError) -> Self {
+        Self::Workflow(error)
+    }
+}
+
+/// 이름 기반 누름틀 채우기 상위 API.
+#[derive(Debug, Clone, Copy)]
+pub struct HwpxFiller;
+
+/// 순회 중 발견한 필드의 가변 참조와 위치.
+struct FieldSlot<'a> {
+    section: usize,
+    control: &'a mut Control,
+}
+
+impl HwpxFiller {
+    /// 문서의 모든 누름틀을 문서 순서로 나열한다 (발견가능성 표면).
+    ///
+    /// # Errors
+    ///
+    /// 패키지 디코드에 실패하면 [`HwpxError`] 를 반환한다.
+    pub fn list_fields(base: &[u8]) -> HwpxResult<Vec<FieldInfo>> {
+        let mut decoded = HwpxDecoder::decode(base)?;
+        let mut fields = Vec::new();
+        for (section_idx, section) in decoded.document.sections_mut().iter_mut().enumerate() {
+            visit_section_fields(section, section_idx, &mut |slot| {
+                if let Control::Field {
+                    field_type: FieldType::ClickHere,
+                    hint_text,
+                    name,
+                    display_text,
+                    ..
+                } = &*slot.control
+                {
+                    fields.push(FieldInfo {
+                        name: name.clone(),
+                        hint: hint_text.clone(),
+                        current: display_text.clone(),
+                        section: slot.section,
+                        fillable: name.is_some() && !display_text.is_empty(),
+                    });
+                }
+            });
+        }
+        Ok(fields)
+    }
+
+    /// 이름 → 값 맵으로 누름틀을 채운 새 패키지 바이트를 만든다.
+    ///
+    /// 전량 preflight 후 전량 적용 — 어느 하나라도 실패하면 아무 것도
+    /// 쓰지 않고 [`FillError`] 를 반환한다.
+    ///
+    /// # Errors
+    ///
+    /// [`FillError`] 의 각 variant 문서를 참조.
+    pub fn fill(base: &[u8], values: &BTreeMap<String, String>) -> Result<FillOutcome, FillError> {
+        // ── preflight 1: 값 자체 검증 ──
+        for (name, value) in values {
+            if value.is_empty() {
+                return Err(FillError::EmptyValue { name: name.clone() });
+            }
+        }
+
+        let mut decoded = HwpxDecoder::decode(base)?;
+
+        // ── preflight 2: 이름 해석 (개수·채움가능성) ──
+        let mut inventory: Vec<(String, usize, String)> = Vec::new(); // (name, section, display)
+        for (section_idx, section) in decoded.document.sections_mut().iter_mut().enumerate() {
+            visit_section_fields(section, section_idx, &mut |slot| {
+                if let Control::Field {
+                    field_type: FieldType::ClickHere,
+                    name: Some(name),
+                    display_text,
+                    ..
+                } = &*slot.control
+                {
+                    inventory.push((name.clone(), slot.section, display_text.clone()));
+                }
+            });
+        }
+
+        for name in values.keys() {
+            let matches: Vec<&(String, usize, String)> =
+                inventory.iter().filter(|(n, _, _)| n == name).collect();
+            match matches.len() {
+                0 => {
+                    let mut available: Vec<String> = Vec::new();
+                    for (n, _, _) in &inventory {
+                        if !available.contains(n) {
+                            available.push(n.clone());
+                        }
+                    }
+                    return Err(FillError::UnknownField { name: name.clone(), available });
+                }
+                1 => {
+                    let (_, section, display) = matches[0];
+                    if display.is_empty() {
+                        return Err(FillError::UnfillableField {
+                            name: name.clone(),
+                            section: *section,
+                        });
+                    }
+                }
+                count => return Err(FillError::DuplicateFieldName { name: name.clone(), count }),
+            }
+        }
+
+        // ── 적용: 대상 필드 mutate + 섹션별 preserve-first patch 체이닝 ──
+        let original_sections: Vec<Section> = decoded.document.sections().to_vec();
+        let mut filled: Vec<FilledField> = Vec::new();
+        let mut touched: Vec<usize> = Vec::new();
+        for (section_idx, section) in decoded.document.sections_mut().iter_mut().enumerate() {
+            visit_section_fields(section, section_idx, &mut |slot| {
+                if let Control::Field {
+                    field_type: FieldType::ClickHere,
+                    name: Some(name),
+                    display_text,
+                    ..
+                } = &mut *slot.control
+                {
+                    if let Some(value) = values.get(name.as_str()) {
+                        filled.push(FilledField {
+                            name: name.clone(),
+                            section: slot.section,
+                            previous: std::mem::replace(display_text, value.clone()),
+                        });
+                        if !touched.contains(&slot.section) {
+                            touched.push(slot.section);
+                        }
+                    }
+                }
+            });
+        }
+
+        let mut bytes = base.to_vec();
+        for section_idx in touched {
+            // preservation 은 원본 섹션 상태로 export 해야 sha/슬롯이 맞는다.
+            // 앞선 patch 는 다른 섹션 파일만 바꾸므로 현재 bytes 의 이 섹션
+            // XML 은 base 와 동일하다 — 체이닝이 안전한 근거.
+            let preservation = HwpxPatcher::export_section_preservation(
+                &bytes,
+                section_idx,
+                &original_sections[section_idx],
+            )?;
+            bytes = HwpxPatcher::patch_section_preserving(
+                &bytes,
+                section_idx,
+                &decoded.document.sections()[section_idx],
+                None,
+                Some(&preservation),
+            )?;
+        }
+
+        Ok(FillOutcome { bytes, filled })
+    }
+}
+
+/// 섹션 안의 모든 [`Control`] 을 patch 텍스트-슬롯 순회와 동일한 커버리지로
+/// 방문한다 (`collect_semantic_control_slots` / `redact_control` 의 거울 —
+/// 여기 없는 컨테이너(예: `Group`)의 필드는 슬롯도 없으므로 fill 대상이
+/// 아니어야 일관된다).
+fn visit_section_fields(
+    section: &mut Section,
+    section_idx: usize,
+    f: &mut impl FnMut(&mut FieldSlot<'_>),
+) {
+    visit_paragraphs(&mut section.paragraphs, section_idx, f);
+}
+
+fn visit_paragraphs(
+    paragraphs: &mut [Paragraph],
+    section_idx: usize,
+    f: &mut impl FnMut(&mut FieldSlot<'_>),
+) {
+    for paragraph in paragraphs {
+        for run in &mut paragraph.runs {
+            match &mut run.content {
+                RunContent::Control(control) => visit_control(control, section_idx, f),
+                RunContent::Table(table) => {
+                    if let Some(caption) = table.caption.as_mut() {
+                        visit_paragraphs(&mut caption.paragraphs, section_idx, f);
+                    }
+                    for row in &mut table.rows {
+                        for cell in &mut row.cells {
+                            visit_paragraphs(&mut cell.paragraphs, section_idx, f);
+                        }
+                    }
+                }
+                RunContent::Image(image) => {
+                    if let Some(caption) = image.caption.as_mut() {
+                        visit_paragraphs(&mut caption.paragraphs, section_idx, f);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn visit_control(
+    control: &mut Control,
+    section_idx: usize,
+    f: &mut impl FnMut(&mut FieldSlot<'_>),
+) {
+    f(&mut FieldSlot { section: section_idx, control });
+    match control {
+        Control::TextBox { paragraphs, caption, .. }
+        | Control::Ellipse { paragraphs, caption, .. }
+        | Control::Polygon { paragraphs, caption, .. } => {
+            visit_paragraphs(paragraphs, section_idx, f);
+            if let Some(caption) = caption.as_mut() {
+                visit_paragraphs(&mut caption.paragraphs, section_idx, f);
+            }
+        }
+        Control::Footnote { paragraphs, .. } | Control::Endnote { paragraphs, .. } => {
+            visit_paragraphs(paragraphs, section_idx, f);
+        }
+        Control::Rect { caption: Some(caption), .. }
+        | Control::Line { caption: Some(caption), .. }
+        | Control::Arc { caption: Some(caption), .. }
+        | Control::Curve { caption: Some(caption), .. }
+        | Control::ConnectLine { caption: Some(caption), .. } => {
+            visit_paragraphs(&mut caption.paragraphs, section_idx, f);
+        }
+        _ => {}
+    }
+}

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -55,6 +55,7 @@ pub mod default_styles;
 mod encoder;
 pub mod error;
 pub mod exchange;
+mod fill;
 mod inline_text;
 mod list_bridge;
 mod patch;
@@ -74,6 +75,7 @@ pub use exchange::{
     ExportedDocument, ExportedSection, PreservedTextSlot, SectionPreservation, TextLocator,
     SECTION_PRESERVATION_VERSION,
 };
+pub use fill::{FieldInfo, FillError, FillOutcome, FilledField, HwpxFiller};
 pub use patch::HwpxPatcher;
 pub use presets::{builtin_presets, style_store_for_preset, PresetInfo};
 pub use registry_bridge::HwpxRegistryBridge;

--- a/crates/hwpforge-smithy-hwpx/tests/fill_api.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/fill_api.rs
@@ -1,0 +1,192 @@
+//! E2 `fill` 델타 API 통합 테스트.
+//!
+//! 설계 (Codex 토론 확정, `.docs/planning/2026-07-10-agent-editing-architecture.md`):
+//! - 이름 중복 → 기본 거부 · 미채움/모호(display_text 빈 값) → preflight 거부
+//! - 빈 값 fill → 거부 · 전량 preflight 후 전량 적용 (all-or-nothing)
+//! - `list_fields` 는 발견가능성 표면 (`fields` CLI/MCP 의 토대)
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use hwpforge_core::control::Control;
+use hwpforge_core::document::Document;
+use hwpforge_core::image::ImageStore;
+use hwpforge_core::paragraph::Paragraph;
+use hwpforge_core::run::{Run, RunContent};
+use hwpforge_core::section::Section;
+use hwpforge_core::PageSettings;
+use hwpforge_foundation::{CharShapeIndex, FieldType, ParaShapeIndex};
+use hwpforge_smithy_hwpx::{FillError, HwpxDecoder, HwpxEncoder, HwpxFiller};
+
+fn fixture_bytes(name: &str) -> Vec<u8> {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path.push("tests/fixtures/fields");
+    path.push(name);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("fixture {}: {e}", path.display()))
+}
+
+fn named_field(name: &str, hint: &str) -> Control {
+    Control::Field {
+        field_type: FieldType::ClickHere,
+        hint_text: Some(hint.to_string()),
+        help_text: None,
+        name: Some(name.to_string()),
+        display_text: String::new(),
+    }
+}
+
+fn field_paragraph(control: Control) -> Paragraph {
+    let mut para = Paragraph::new(ParaShapeIndex::new(0));
+    para.runs.push(Run::control(control, CharShapeIndex::new(0)));
+    para
+}
+
+/// 이름 붙은 누름틀 N개를 섹션별로 배치한 HWPX 바이트를 만든다.
+fn build_hwpx(sections: &[Vec<Control>]) -> Vec<u8> {
+    let mut doc = Document::new();
+    for controls in sections {
+        let mut section = Section::new(PageSettings::default());
+        for control in controls {
+            section.paragraphs.push(field_paragraph(control.clone()));
+        }
+        doc.add_section(section);
+    }
+    let validated = doc.validate().expect("validate");
+    let styles = hwpforge_smithy_hwpx::style_store_for_preset("default").expect("preset");
+    HwpxEncoder::encode(&validated, &styles, &ImageStore::default()).expect("encode")
+}
+
+fn values(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+}
+
+fn field_display(bytes: &[u8], section: usize, name: &str) -> String {
+    let decoded = HwpxDecoder::decode(bytes).expect("decode");
+    decoded.document.sections()[section]
+        .paragraphs
+        .iter()
+        .flat_map(|p| p.runs.iter())
+        .find_map(|r| match &r.content {
+            RunContent::Control(c) => match c.as_ref() {
+                Control::Field { name: n, display_text, .. } if n.as_deref() == Some(name) => {
+                    Some(display_text.clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("field '{name}' not found in section {section}"))
+}
+
+// ── list_fields ─────────────────────────────────────────────────
+
+#[test]
+fn list_fields_reports_name_hint_current_and_fillable() {
+    let bytes = fixture_bytes("clickhere_named.hwpx");
+    let fields = HwpxFiller::list_fields(&bytes).expect("list");
+    assert_eq!(fields.len(), 1);
+    let f = &fields[0];
+    assert_eq!(f.name.as_deref(), Some("user_email"));
+    assert_eq!(f.hint.as_deref(), Some("회사 이메일을 입력하세요"));
+    assert_eq!(f.current, "회사 이메일을 입력하세요");
+    assert_eq!(f.section, 0);
+    assert!(f.fillable, "네이티브 미채움 필드(본문=힌트)는 채움 가능");
+}
+
+#[test]
+fn list_fields_marks_merged_run_field_unfillable() {
+    // 한컴 재저장 병합-run fixture — display_text 가 미채움("")으로
+    // 다운그레이드되므로 fillable=false 로 보고되어야 한다.
+    let bytes = fixture_bytes("clickhere_filled.hwpx");
+    let fields = HwpxFiller::list_fields(&bytes).expect("list");
+    let f = fields.iter().find(|f| f.name.as_deref() == Some("user_email")).expect("field");
+    assert!(!f.fillable, "병합-run 모호 필드는 fillable=false");
+}
+
+// ── fill 성공 경로 ───────────────────────────────────────────────
+
+#[test]
+fn fill_replaces_named_field_body() {
+    let bytes = fixture_bytes("clickhere_named.hwpx");
+    let outcome =
+        HwpxFiller::fill(&bytes, &values(&[("user_email", "hanyul@example.com")])).expect("fill");
+    assert_eq!(outcome.filled.len(), 1);
+    assert_eq!(outcome.filled[0].name, "user_email");
+    assert_eq!(outcome.filled[0].previous, "회사 이메일을 입력하세요");
+    assert_eq!(field_display(&outcome.bytes, 0, "user_email"), "hanyul@example.com");
+}
+
+#[test]
+fn fill_spans_multiple_sections_atomically() {
+    let bytes = build_hwpx(&[
+        vec![named_field("과제명", "과제명을 입력하세요")],
+        vec![named_field("총연구비", "금액을 입력하세요")],
+    ]);
+    let outcome = HwpxFiller::fill(
+        &bytes,
+        &values(&[("과제명", "AI 문서 자동화"), ("총연구비", "300,000천원")]),
+    )
+    .expect("fill");
+    assert_eq!(outcome.filled.len(), 2);
+    assert_eq!(field_display(&outcome.bytes, 0, "과제명"), "AI 문서 자동화");
+    assert_eq!(field_display(&outcome.bytes, 1, "총연구비"), "300,000천원");
+}
+
+// ── preflight 거부 정책 ─────────────────────────────────────────
+
+#[test]
+fn fill_rejects_unknown_name_and_lists_available() {
+    let bytes = fixture_bytes("clickhere_named.hwpx");
+    let err = HwpxFiller::fill(&bytes, &values(&[("없는이름", "x")])).unwrap_err();
+    match err {
+        FillError::UnknownField { name, available } => {
+            assert_eq!(name, "없는이름");
+            assert_eq!(available, vec!["user_email".to_string()]);
+        }
+        other => panic!("expected UnknownField, got {other:?}"),
+    }
+}
+
+#[test]
+fn fill_rejects_duplicate_field_name() {
+    let bytes =
+        build_hwpx(&[vec![named_field("이름", "성명 입력"), named_field("이름", "성명 입력")]]);
+    let err = HwpxFiller::fill(&bytes, &values(&[("이름", "류한율")])).unwrap_err();
+    match err {
+        FillError::DuplicateFieldName { name, count } => {
+            assert_eq!(name, "이름");
+            assert_eq!(count, 2);
+        }
+        other => panic!("expected DuplicateFieldName, got {other:?}"),
+    }
+}
+
+#[test]
+fn fill_rejects_empty_value() {
+    let bytes = fixture_bytes("clickhere_named.hwpx");
+    let err = HwpxFiller::fill(&bytes, &values(&[("user_email", "")])).unwrap_err();
+    assert!(matches!(err, FillError::EmptyValue { name } if name == "user_email"));
+}
+
+#[test]
+fn fill_rejects_unfillable_merged_run_field() {
+    let bytes = fixture_bytes("clickhere_filled.hwpx");
+    let err = HwpxFiller::fill(&bytes, &values(&[("user_email", "x@y.z")])).unwrap_err();
+    assert!(
+        matches!(err, FillError::UnfillableField { ref name, .. } if name == "user_email"),
+        "병합-run 모호 필드는 명확한 에러로 거부: {err:?}"
+    );
+}
+
+#[test]
+fn fill_is_all_or_nothing_when_one_target_fails_preflight() {
+    // 두 값 중 하나(없는 이름)가 preflight 에서 실패하면 나머지도 적용되지
+    // 않아야 한다 — 원본 바이트가 그대로임을 확인할 방법: fill 이 Err 를
+    // 반환하므로 산출물 자체가 없다.
+    let bytes = build_hwpx(&[vec![named_field("과제명", "입력")]]);
+    let err =
+        HwpxFiller::fill(&bytes, &values(&[("과제명", "값"), ("없는필드", "값2")])).unwrap_err();
+    assert!(matches!(err, FillError::UnknownField { .. }));
+}


### PR DESCRIPTION
## 요약

Epic 2 — **`fill` 델타 API**. 에이전트가 섹션 JSON 전체를 왕복하지 않고 **이름 → 값 맵만으로** 누름틀을 채운다. #97(Epic 1, 누름틀 채우기 토대) 위에 얹히는 상위 API이며, preserve-first 패처를 그대로 사용하므로 **채워진 섹션 XML 외의 모든 패키지 엔트리는 바이트 동일**하다.

```bash
hwpforge fields 제안서.hwpx --json                 # 이름·힌트·현재값·fillable 발견
hwpforge fill 제안서.hwpx --set 과제명="AI 문서 자동화" --set 기관명="AiScream" -o 제출본.hwpx
```

## 설계 

| 쟁점 | 결정 |
| --- | --- |
| 이름 중복 | **기본 거부** (`FIELD_NAME_AMBIGUOUS`) — 자동 전부-채움 없음 |
| 모호(병합-run)/미채움 필드 | preflight 거부 (`FIELD_NOT_FILLABLE`) + 복구 힌트 |
| 빈 값 | 거부 (`EMPTY_FIELD_VALUE`) — 빈 문자열은 힌트-폴백·다운그레이드 sentinel 로 과적 |
| 발견가능성 | **별도 `fields` 표면** (CLI 명령 + MCP 툴) |
| 다중 섹션 | 전량 preflight → 전량 적용 (**all-or-nothing**), 섹션별 patch 체이닝 |

권고에서 한 가지 의도적 이탈: 모호 필드 검출에 raw-XML preflight 대신 **`display_text.is_empty()` Core-only 판정** — Epic 1 의 슬롯 거울 불변식(semantic 슬롯 ⇔ base 본문 비어있지 않음 ⇔ raw 슬롯)이 동치를 보장하고, patch 적용측 게이트는 Core 데이터만으로 계산 가능해야 두 순회가 일관된다.

## 커밋 구성

| 커밋 | 내용 |
| --- | --- |
| `03c7eed` | feat(hwpx): `HwpxFiller::{list_fields, fill}` + `FieldInfo`/`FillOutcome`/`FillError`. 필드 워커는 patch 슬롯 순회와 동일 커버리지(표 셀·캡션·글상자·각주·미주·도형) |
| `af983f3` | feat(mcp): CLI `fields`/`fill --set` + MCP `hwpforge_fields`/`hwpforge_fill` + cli_integration 게이트 4종 + 스킬 결정 트리 DELTA 경로 |

Semver: 추가 전용 (신규 public 타입/명령) — breaking 없음.

## 검증

- 코어 `fill_api` 통합 테스트 **9종**: 성공 경로(단일/다중 섹션 원자성) + 거부 4종(없는 이름·중복 이름·빈 값·병합-run 모호) + all-or-nothing
- CLI 게이트 **4종**: 발견 / E2E 채움(재조회 생존) / 없는 이름(available 힌트 + **산출물 무생성** 확인) / 병합-run 거부
- MCP 50 · CLI 128 · `make ci` 전체 통과
- E2E 실측: 채움 후 ZIP 엔트리 중 **section0.xml 만 변경**, preflight 실패 시 파일 미생성

fixture 는 Epic 1 의 유산을 재사용: `clickhere_named.hwpx`(채움 가능) · `clickhere_filled.hwpx`(한컴 재저장 병합-run — 모호 거부 게이트).

## 후속 (범위 밖)

- E3 표 격자 주소 · E6 템플릿 스탬핑(`(작성)` → 이름 붙은 누름틀) — end-to-end 국가과제 시나리오의 나머지 조각
- `FillOp::Reset`(값 비우기 = 힌트 복원) — 빈 값 sentinel 분리 후
