### PR TITLE
docs(claude): v0.11.1 릴리스 완료·Nightly fuzz 복구 상태 정정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document 
 - Phase 12 HWP5→HWPX carry series (GSO shapes/equation/memo/dutmal/compose/indexmark/click-here·auto fields/cross-ref instId/document metadata/outline 1–10) `main` 머지 완료.
 - **E6 IR 와이어-누출 상환 완료** (`0.9.0`): Summery rename(A) · BookmarkName collapse(B) · raw wire 필드 제거(C) · `inst_id`/`SystemId`→공유 `ObjectId`(M2). **H1(display_text)=Won't-do** (ADR-009 §CLOSURE, memory `e6-wire-leak-status-h1-wontdo.md`).
 - **0.10.0 릴리스** (2026-07-02): colLine(다단 구분선) HWPX+HWP5 carry(breaking) + rmcp 2.0 보안(GHSA-89vp-x53w-74fx)·quick-xml 0.41 + 문서 정합.
-- **AI 편집 Wave 1** (2026-07-12~13): 누름틀(ClickHere) 채우기 — PR #97, **`0.11.0` 릴리스 완료** (crates.io+npm, `feat!:` `Field::display_text` 의미 변경) + `fill` 델타 API·`fields` 발견 표면 — PR #99 **머지 완료**, Release PR #100(`v0.11.1`) 대기. 설계/로드맵 = `.docs/planning/2026-07-10-agent-editing-architecture.md` (남은 조각: E3 표 격자 주소 · E6 스탬핑).
+- **AI 편집 Wave 1** (2026-07-12~13): 누름틀(ClickHere) 채우기 — PR #97, **`0.11.0` 릴리스 완료** (crates.io+npm, `feat!:` `Field::display_text` 의미 변경) + `fill` 델타 API·`fields` 발견 표면 — PR #99, **`0.11.1` 릴리스 완료** (2026-07-13, Release PR #100). 설계/로드맵 = `.docs/planning/2026-07-10-agent-editing-architecture.md` (남은 조각: E3 표 격자 주소 · E6 스탬핑).
 
 > **이 섹션은 짧은 상태 스냅샷으로만 유지한다 (wave-by-wave 이력을 여기 다시 쌓지 말 것).**
 > Wave별 상세 이력 + breaking change: **`CHANGELOG.md`** (canonical) 와 memory `MEMORY.md` / `phase11_wave_history.md`.
@@ -34,7 +34,7 @@ HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document 
 
 **Workspace Facts** (code-grounded — 카운트는 drift하니 인용 전 확인):
 
-- Cargo packages `11` · crates.io published `0.11.0` (누름틀 display_text `feat!:`, 2026-07-12) — E2(fill) 는 `v0.11.1`(Release PR #100) 대기 · MSRV `1.88` · Dev toolchain Rust `1.93`
+- Cargo packages `11` · crates.io published `0.11.1` (E2 fill 델타 API, 2026-07-13) · MSRV `1.88` · Dev toolchain Rust `1.93`
 - `crates/` 추적 src 파일 ~`177` · nextest ~`2,688` passed + `2` skipped · `examples/` 산출물 `68`+ (미추적 `examples/hwp5_review/` 리뷰 영역 별도 — gitignore 아님) · GitHub workflows `5`
 
 ---
@@ -352,7 +352,7 @@ Local planning and research workspace. It may be git-excluded in this repository
 - Table integration gates are concentrated in `crates/hwpforge-bindings-cli/tests/cli_integration.rs`.
 - Stress or real-world table fixtures are not the same thing as committed regression gates.
 - colLine (다단 구분선) HWPX + HWP5→HWPX legs shipped in `0.10.0` (PR #91, 2026-07-02).
-- **Nightly › Fuzz Build 는 2026-06-29부터 실패 중** (레포 변경 무관): prebuilt cargo-fuzz 가 musl 을 기본 타깃으로 골라 ASAN 과 충돌 (`sanitizer is incompatible with statically linked libc`). 수정 = `security.yml:77` 에 `--target x86_64-unknown-linux-gnu` 명시.
+- **Nightly › Fuzz Build 복구됨** (PR #101, 2026-07-19 — 2026-06-29부터 실패했었음): 원인 2겹 = ① prebuilt cargo-fuzz 가 musl 을 기본 타깃으로 골라 ASAN 과 충돌 → `security.yml` 에 `--target x86_64-unknown-linux-gnu` 명시 ② fuzz 타깃 bit-rot (`hwp5_to_hwpx_bytes` 가 convert 크레이트로 이사). fuzz/ 는 standalone 워크스페이스라 메인 CI 가 컴파일을 안 잡음 — API 이동 시 fuzz 타깃도 함께 갱신할 것.
 - Always confirm `main` state from code + manifests + git; do not trust stale branch prose.
 
 ---


### PR DESCRIPTION
## 요약

CLAUDE.md 상태 스냅샷의 stale 표기 3곳 정정 (문서만 변경, 코드 없음):

1. **Current Status**: "Release PR #100(`v0.11.1`) 대기" → **`0.11.1` 릴리스 완료 (2026-07-13)** — E2 `fill` 델타 API가 crates.io+npm에 배포된 상태 반영
2. **Workspace Facts**: crates.io published `0.11.0` → **`0.11.1`**
3. **Engineering State**: "Nightly › Fuzz Build 실패 중" → **PR #101(2026-07-19)로 복구** — 2겹 원인(musl 기본 타깃 + fuzz 타깃 bit-rot) 기록 + 재발 방지 메모: `fuzz/`는 standalone 워크스페이스라 메인 CI가 컴파일을 안 잡음, API 이동 시 fuzz 타깃 동반 갱신 필요

## 검증

- `dprint fmt CLAUDE.md` 통과 (한글 표 재정렬 없음)
- `docs:` 타입 — release-plz 버전 bump 미유발

Claude-Session: https://claude.ai/code/session_01V8tqPiAvBmfWTNTK5HHfCR