### PR TITLE
feat: E6 Wave 2 — 클래스-B 셀 스탬핑 (라벨 인접 빈 셀 → 누름틀 승격)

### DIFF
--- a/.claude/skills/hwpforge/SKILL.md
+++ b/.claude/skills/hwpforge/SKILL.md
@@ -101,13 +101,22 @@ hwpforge fill doc.hwpx --set 과제명="AI 문서 자동화" --set 기관명="Ai
 #   나머지 패키지 엔트리는 바이트 그대로 보존 (preserve-first)
 
 # Template stamping (E6) — promote prose placeholders (□, (   ), 년 월 일, (인), @)
-# to named 누름틀 so fields/fill work. One-time preprocessing per template.
-hwpforge stamp-plan template.hwpx --json                 # discover candidates
+# AND label-adjacent empty table cells (클래스-B) to named 누름틀 so fields/fill work.
+# One-time preprocessing per template.
+hwpforge stamp-plan template.hwpx --json                 # candidates(text) + cells + source_sha256
 #   → author a spec map: EVERY unguarded candidate gets {"action":{"field":{"name":"…"}}}
 #     or {"action":"ignore"}; guarded ones (※/【작성방법】/(예시) context) may be omitted
-hwpforge stamp template.hwpx --map specs.json -o form.hwpx   # + form.manifest.json
+#   text-only 는 legacy 배열 맵 그대로; 셀이 있으면 v2 객체 맵:
+#   {"schema_version":2, "source_sha256":"<plan 값 그대로>",
+#    "text":[…], "cells":[{"table":0,"at":{"row":5,"col":3},
+#      "label":{"at":{"row":5,"col":2},"text":"성 명"},      ← detected 후보 드리프트 재검증 (orphan 명시 스펙은 생략)
+#      "action":{"field":{"name":"성명","hint":"성명 입력"}}}]}   ← 셀 hint 는 필수 (빈 셀엔 마커가 없음)
+#   suggested_name/suggested_hint 는 제안일 뿐 — 그대로 복사 시 중복 이름은 거부됨
+hwpforge stamp template.hwpx --map specs.json -o form.hwpx   # + form.manifest.json (v2: origin text|cell)
 #   fail-closed: 무손실 왕복이 증명 안 되는 입력은 거부(INPUT_NOT_ROUNDTRIP_SAFE);
-#   무가드 후보 누락도 거부(STAMP_CANDIDATE_UNCOVERED). 이후 fields/fill 로 채움
+#   무가드 후보(양쪽 클래스) 누락 거부(STAMP_CANDIDATE_UNCOVERED); 문서 변경 후 재사용
+#   맵은 거부(STAMP_SOURCE_HASH_MISMATCH — stamp-plan 재실행); 셀 스펙은 병합 앵커 좌표만
+#   (STAMP_CELL_NOT_ANCHOR 가 앵커를 알려줌). 이후 fields/fill 로 채움
 
 # Grid cell editing (E3) — fill table cells by logical grid address.
 # to-json export annotates every cell with addr {row,col} (병합 전 논리 격자).

--- a/crates/hwpforge-bindings-cli/src/commands/stamp.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/stamp.rs
@@ -7,16 +7,18 @@
 
 use std::path::{Path, PathBuf};
 
-use hwpforge_smithy_hwpx::stamp::{HwpxStamper, StampError, StampSpec, StamperError};
+use hwpforge_smithy_hwpx::stamp::{
+    parse_stamp_map, CellStampError, HwpxStamper, StampError, StampMap, StamperError,
+};
 
 use crate::error::{check_file_size, CliError};
 
-/// Run the `stamp-plan` command (candidate discovery).
+/// Run the `stamp-plan` command (candidate discovery, both classes).
 pub fn run_plan(file: &PathBuf, json_mode: bool) {
     check_file_size(file, json_mode);
     let bytes = read_file(file, json_mode);
-    let candidates = match HwpxStamper::plan_bytes(&bytes) {
-        Ok(c) => c,
+    let plan = match HwpxStamper::plan_bytes_v2(&bytes) {
+        Ok(p) => p,
         Err(e) => exit_stamper_error(e, json_mode),
     };
 
@@ -24,14 +26,26 @@ pub fn run_plan(file: &PathBuf, json_mode: bool) {
         let result = serde_json::json!({
             "status": "ok",
             "file": file.display().to_string(),
-            "candidates": candidates,
+            "schema_version": plan.schema_version,
+            "source_sha256": plan.source_sha256,
+            "candidates": plan.text,
+            "cells": plan.cells,
+            "skipped_tables": plan.skipped_tables,
         });
         println!("{}", serde_json::to_string(&result).unwrap());
-    } else if candidates.is_empty() {
+        return;
+    }
+
+    if plan.text.is_empty() && plan.cells.is_empty() {
         println!("No stamp candidates in {}", file.display());
     } else {
-        println!("{} candidate(s) in {}:", candidates.len(), file.display());
-        for c in &candidates {
+        println!(
+            "{} text + {} cell candidate(s) in {}:",
+            plan.text.len(),
+            plan.cells.len(),
+            file.display()
+        );
+        for c in &plan.text {
             let guard = match c.guard {
                 Some(_) => " [guarded: instruction context]",
                 None => "",
@@ -47,10 +61,32 @@ pub fn run_plan(file: &PathBuf, json_mode: bool) {
                 guard
             );
         }
+        for c in &plan.cells {
+            let labels: Vec<String> = c
+                .labels
+                .iter()
+                .map(|l| format!("{:?}({},{}) {:?}", l.direction, l.at.row, l.at.col, l.normalized))
+                .collect();
+            let guard = if c.guarded { " [guarded]" } else { "" };
+            let name = c.suggested_name.as_deref().unwrap_or("-");
+            println!(
+                "  cell t{} ({},{}) suggested={name:?} labels=[{}]{guard}",
+                c.table,
+                c.at.row,
+                c.at.col,
+                labels.join(", ")
+            );
+        }
         println!(
-            "\n맵 작성: 각 후보를 {{\"action\":{{\"field\":{{\"name\":\"…\"}}}}}} 또는 \
-             \"ignore\" 로 분류한 JSON 배열을 만들어 `stamp --map` 에 전달"
+            "\n맵 작성(v2): {{\"schema_version\":2, \"source_sha256\":\"{}\", \
+             \"text\":[…], \"cells\":[{{\"table\":…, \"at\":{{…}}, \"label\":{{…}}, \
+             \"action\":{{\"field\":{{\"name\":\"…\",\"hint\":\"…\"}}}}}}]}} 를 `stamp --map` 에 전달 \
+             (셀 hint 는 필수)",
+            plan.source_sha256
         );
+    }
+    for s in &plan.skipped_tables {
+        eprintln!("경고: 표 {} 격자 무효 — 셀 탐지 제외 ({}): {}", s.table, s.path, s.error);
     }
 }
 
@@ -72,21 +108,16 @@ pub fn run(
                 .exit(json_mode, 1);
         }
     };
-    let specs: Vec<StampSpec> = match serde_json::from_str(&map_text) {
-        Ok(s) => s,
+    let parsed = match parse_stamp_map(&map_text) {
+        Ok(p) => p,
         Err(e) => {
             CliError::new("INVALID_STAMP_MAP", format!("'{}': {e}", map.display()))
                 .with_hint(
-                    "맵은 StampSpec JSON 배열 — `stamp-plan --json` 의 candidates 에 \
-                     action(field{name}/ignore)을 붙인 형태",
+                    "맵은 StampSpec JSON 배열(legacy) 또는 {schema_version:2, source_sha256, \
+                     text[], cells[]} 객체(v2) — `stamp-plan --json` 출력을 기반으로 작성",
                 )
                 .exit(json_mode, 1);
         }
-    };
-
-    let result = match HwpxStamper::stamp(&bytes, &specs) {
-        Ok(r) => r,
-        Err(e) => exit_stamper_error(e, json_mode),
     };
 
     let manifest_file: PathBuf = manifest_path
@@ -102,12 +133,94 @@ pub fn run(
         .with_hint("--manifest 경로는 -o 경로와 달라야 합니다")
         .exit(json_mode, 1);
     }
-    let manifest_json = serde_json::to_string_pretty(&result.manifest).unwrap();
-    if let Err(e) = std::fs::write(output, &result.bytes) {
+
+    match parsed {
+        StampMap::Legacy(specs) => {
+            let result = match HwpxStamper::stamp(&bytes, &specs) {
+                Ok(r) => r,
+                Err(e) => exit_stamper_error(e, json_mode),
+            };
+            let manifest_json = serde_json::to_string_pretty(&result.manifest).unwrap();
+            write_artifacts(output, &manifest_file, &result.bytes, &manifest_json, json_mode);
+
+            if json_mode {
+                let out = serde_json::json!({
+                    "status": "ok",
+                    "output": output.display().to_string(),
+                    "manifest": manifest_file.display().to_string(),
+                    "stamped": result.outcome.stamped,
+                    "ignored": result.outcome.ignored,
+                    "skipped_guarded": result.outcome.skipped_guarded.len(),
+                    "size_bytes": result.bytes.len(),
+                });
+                println!("{}", serde_json::to_string(&out).unwrap());
+            } else {
+                println!(
+                    "Stamped {} field(s) (ignored {}, guarded-skipped {}) -> {}",
+                    result.outcome.stamped.len(),
+                    result.outcome.ignored,
+                    result.outcome.skipped_guarded.len(),
+                    output.display()
+                );
+                for s in &result.outcome.stamped {
+                    println!("  + {} = {:?} ({})", s.name, s.marker, s.pattern.id());
+                }
+                println!("Manifest -> {}", manifest_file.display());
+            }
+        }
+        StampMap::V2(request) => {
+            let result = match HwpxStamper::stamp_v2(&bytes, &request) {
+                Ok(r) => r,
+                Err(e) => exit_stamper_error(e, json_mode),
+            };
+            let manifest_json = serde_json::to_string_pretty(&result.manifest).unwrap();
+            write_artifacts(output, &manifest_file, &result.bytes, &manifest_json, json_mode);
+
+            if json_mode {
+                let out = serde_json::json!({
+                    "status": "ok",
+                    "output": output.display().to_string(),
+                    "manifest": manifest_file.display().to_string(),
+                    "stamped_text": result.outcome.text.stamped,
+                    "stamped_cells": result.outcome.cells.stamped,
+                    "ignored": result.outcome.text.ignored + result.outcome.cells.ignored,
+                    "skipped_guarded": result.outcome.text.skipped_guarded.len()
+                        + result.outcome.cells.skipped_guarded.len(),
+                    "size_bytes": result.bytes.len(),
+                });
+                println!("{}", serde_json::to_string(&out).unwrap());
+            } else {
+                println!(
+                    "Stamped {} text + {} cell field(s) -> {}",
+                    result.outcome.text.stamped.len(),
+                    result.outcome.cells.stamped.len(),
+                    output.display()
+                );
+                for s in &result.outcome.text.stamped {
+                    println!("  + {} = {:?} ({})", s.name, s.marker, s.pattern.id());
+                }
+                for s in &result.outcome.cells.stamped {
+                    println!("  + {} @ t{} ({},{})", s.name, s.table, s.at.row, s.at.col);
+                }
+                println!("Manifest -> {}", manifest_file.display());
+            }
+        }
+    }
+}
+
+/// Writes the stamped output + manifest, fail-closed (no partial artifacts).
+fn write_artifacts(
+    output: &PathBuf,
+    manifest_file: &Path,
+    bytes: &[u8],
+    manifest_json: &str,
+    json_mode: bool,
+) {
+    if let Err(e) = std::fs::write(output, bytes) {
         CliError::new("FILE_WRITE_FAILED", format!("Cannot write '{}': {e}", output.display()))
             .exit(json_mode, 1);
     }
-    if let Err(e) = std::fs::write(&manifest_file, manifest_json) {
+    if let Err(e) = std::fs::write(manifest_file, manifest_json) {
         // Review L1: a stamped .hwpx without its manifest is a partial
         // artifact — remove it so a failed command leaves nothing behind.
         let _ = std::fs::remove_file(output);
@@ -117,31 +230,6 @@ pub fn run(
         )
         .with_hint("manifest 기록 실패로 산출물을 남기지 않았습니다 (fail-closed)")
         .exit(json_mode, 1);
-    }
-
-    if json_mode {
-        let out = serde_json::json!({
-            "status": "ok",
-            "output": output.display().to_string(),
-            "manifest": manifest_file.display().to_string(),
-            "stamped": result.outcome.stamped,
-            "ignored": result.outcome.ignored,
-            "skipped_guarded": result.outcome.skipped_guarded.len(),
-            "size_bytes": result.bytes.len(),
-        });
-        println!("{}", serde_json::to_string(&out).unwrap());
-    } else {
-        println!(
-            "Stamped {} field(s) (ignored {}, guarded-skipped {}) -> {}",
-            result.outcome.stamped.len(),
-            result.outcome.ignored,
-            result.outcome.skipped_guarded.len(),
-            output.display()
-        );
-        for s in &result.outcome.stamped {
-            println!("  + {} = {:?} ({})", s.name, s.marker, s.pattern.id());
-        }
-        println!("Manifest -> {}", manifest_file.display());
     }
 }
 
@@ -178,6 +266,99 @@ fn exit_stamper_error(error: StamperError, json_mode: bool) -> ! {
             CliError::new("STAMP_MANIFEST_INVARIANT", detail).exit(json_mode, 2)
         }
         StamperError::Codec(msg) => CliError::new("STAMP_CODEC_FAILED", msg).exit(json_mode, 2),
+        StamperError::SourceHashMismatch { expected, actual } => CliError::new(
+            "STAMP_SOURCE_HASH_MISMATCH",
+            format!("map is pinned to {expected}, input is {actual}"),
+        )
+        .with_hint(
+            "문서가 변경됐습니다 — `stamp-plan` 을 다시 실행해 맵의 source_sha256 을 갱신하세요",
+        )
+        .exit(json_mode, 1),
+        StamperError::CellStamp(inner) => exit_cell_stamp_error(inner, json_mode),
+        StamperError::DeltaMismatch { stage, detail } => CliError::new(
+            "STAMP_DELTA_MISMATCH",
+            format!("post-encode verification failed at {stage}: {detail}"),
+        )
+        .with_hint("산출물 검증 실패 — 코덱 버그 가능성이 있어 무출력으로 거부했습니다")
+        .exit(json_mode, 2),
+        other => CliError::new("STAMP_FAILED", other.to_string()).exit(json_mode, 2),
+    }
+}
+
+fn exit_cell_stamp_error(error: CellStampError, json_mode: bool) -> ! {
+    match error {
+        CellStampError::TableNotFound { table } => {
+            CliError::new("TABLE_NOT_FOUND", format!("table ordinal {table} does not exist"))
+                .exit(json_mode, 1)
+        }
+        CellStampError::TableGridInvalid { table, detail } => {
+            CliError::new("TABLE_GRID_INVALID", format!("table {table}: {detail}"))
+                .exit(json_mode, 1)
+        }
+        CellStampError::NotAnAnchor { table, requested, anchor } => {
+            let mut err = CliError::new(
+                "STAMP_CELL_NOT_ANCHOR",
+                format!("table {table}: ({},{}) is not an anchor", requested.row, requested.col),
+            );
+            if let Some(anchor) = anchor {
+                err = err.with_hint(format!(
+                    "이 좌표는 병합 피복 위치입니다 — anchor ({},{}) 를 지정하세요",
+                    anchor.row, anchor.col
+                ));
+            }
+            err.exit(json_mode, 1)
+        }
+        CellStampError::TargetNotStampable { table, at } => CliError::new(
+            "STAMP_CELL_NOT_EMPTY",
+            format!("table {table}: cell ({},{}) has authored content", at.row, at.col),
+        )
+        .with_hint("클래스-B 대상은 whitespace-only 빈 셀이어야 합니다")
+        .exit(json_mode, 1),
+        CellStampError::LabelDrift { table, at, claimed, found } => CliError::new(
+            "STAMP_LABEL_DRIFT",
+            format!(
+                "table {table} ({},{}): claimed label {claimed:?}, live {found:?}",
+                at.row, at.col
+            ),
+        )
+        .with_hint("문서가 변경됐습니다 — `stamp-plan` 을 다시 실행해 맵을 갱신하세요")
+        .exit(json_mode, 1),
+        CellStampError::UnknownCandidate { table, at } => CliError::new(
+            "STAMP_CELL_NOT_CANDIDATE",
+            format!("table {table}: ({},{}) is not a live candidate", at.row, at.col),
+        )
+        .exit(json_mode, 1),
+        CellStampError::DuplicateTarget { table, at } => CliError::new(
+            "STAMP_CELL_TARGET_DUPLICATE",
+            format!("table {table}: cell ({},{}) targeted twice", at.row, at.col),
+        )
+        .exit(json_mode, 1),
+        CellStampError::EmptyName => {
+            CliError::new("STAMP_NAME_EMPTY", "field name must not be empty").exit(json_mode, 1)
+        }
+        CellStampError::BlankHint { name } => {
+            CliError::new("STAMP_HINT_BLANK", format!("cell spec {name:?}: hint must not be blank"))
+                .with_hint("빈 셀엔 마커가 없어 hint 가 필수입니다 (plan 의 suggested_hint 참고)")
+                .exit(json_mode, 1)
+        }
+        CellStampError::DuplicateName { name } => {
+            CliError::new("STAMP_NAME_DUPLICATE", format!("duplicate field name {name:?}"))
+                .exit(json_mode, 1)
+        }
+        CellStampError::NameCollision { name } => CliError::new(
+            "STAMP_NAME_COLLISION",
+            format!("field name {name:?} already exists in the document"),
+        )
+        .exit(json_mode, 1),
+        CellStampError::UncoveredCandidate { table, at } => CliError::new(
+            "STAMP_CANDIDATE_UNCOVERED",
+            format!(
+                "unguarded cell candidate at table {table} ({},{}) has no spec",
+                at.row, at.col
+            ),
+        )
+        .with_hint("모든 무가드 셀 후보는 이름을 붙이거나 ignore 로 명시해야 합니다")
+        .exit(json_mode, 1),
         other => CliError::new("STAMP_FAILED", other.to_string()).exit(json_mode, 2),
     }
 }

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -3717,3 +3717,163 @@ fn set_cell_map_arg_conflicts_rejected() {
     assert_eq!(value["code"], "INVALID_SET_CELL_ARGS");
     assert!(!out.exists());
 }
+
+// ═══════════════════════════════════════════════════════════════
+// stamp v2 — E6 Wave 2 클래스-B 셀 스탬핑 게이트
+// ═══════════════════════════════════════════════════════════════
+
+/// merged_grid_form 의 셀 후보 3개(성명·비고·비고-병합경계)에 대한 v2 맵.
+fn stamp_v2_map(plan: &serde_json::Value) -> serde_json::Value {
+    let sha = plan["source_sha256"].as_str().unwrap();
+    serde_json::json!({
+        "schema_version": 2,
+        "source_sha256": sha,
+        "cells": [
+            {"table": 0, "at": {"row": 0, "col": 1},
+             "label": {"at": {"row": 0, "col": 0}, "text": "성명"},
+             "action": {"field": {"name": "성명값", "hint": "성명 입력"}}},
+            {"table": 0, "at": {"row": 1, "col": 1},
+             "action": {"field": {"name": "비고값", "hint": "비고 입력"}}},
+            {"table": 0, "at": {"row": 2, "col": 1}, "action": "ignore"},
+        ],
+    })
+}
+
+#[test]
+fn stamp_plan_v2_lists_cell_candidates_with_source_hash() {
+    let f = fixture("tables/merged_grid_form.hwpx");
+    let (value, _, code) = run_json(&["stamp-plan", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert_eq!(value["schema_version"], 2);
+    let sha = value["source_sha256"].as_str().unwrap();
+    assert_eq!(sha.len(), 64, "hex sha256: {sha}");
+    let cells = value["cells"].as_array().unwrap();
+    assert_eq!(cells.len(), 3, "성명·비고·병합경계 비고: {value}");
+    assert!(value["skipped_tables"].as_array().unwrap().is_empty());
+    // 병합 라벨(비고, rowspan 2)이 (2,1) 의 shared-boundary 라벨로 잡혀야 한다.
+    let covered_boundary = &cells[2];
+    assert_eq!(covered_boundary["at"], serde_json::json!({"row": 2, "col": 1}));
+    assert_eq!(covered_boundary["labels"][0]["normalized"], "비고");
+    // duplicate_count 는 문서 내 라벨 "텍스트" 중복 기준 — 비고 셀은 유일하므로
+    // 두 후보 모두 같은 suggested_name 을 받는다 (제안은 비구속; 그대로 복사해
+    // 쓰면 preflight DuplicateName 이 거부).
+    assert_eq!(cells[1]["suggested_name"], "비고");
+    assert_eq!(covered_boundary["suggested_name"], "비고");
+}
+
+#[test]
+fn stamp_v2_cells_end_to_end_then_fillable() {
+    let f = fixture("tables/merged_grid_form.hwpx");
+    let tmp = test_tmp();
+    let (plan, _, code) = run_json(&["stamp-plan", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+
+    let map = tmp.join("v2-map.json");
+    std::fs::write(&map, stamp_v2_map(&plan).to_string()).unwrap();
+    let out = tmp.join("v2-stamped.hwpx");
+    let (value, _, code) = run_json(&[
+        "stamp",
+        f.to_str().unwrap(),
+        "--map",
+        map.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "v2 stamp must succeed: {value}");
+    assert_eq!(value["stamped_cells"].as_array().unwrap().len(), 2);
+    assert_eq!(value["ignored"], 1);
+    let manifest_path = value["manifest"].as_str().unwrap().to_string();
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    assert_eq!(manifest["schema_version"], 2);
+    let cell_origins: Vec<_> = manifest["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|f| !f["stamp"]["cell"].is_null())
+        .collect();
+    assert_eq!(cell_origins.len(), 2, "{manifest}");
+
+    // 산출물은 즉시 fields/fill 로 소비 가능.
+    let (fields, _, code) = run_json(&["fields", out.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert_eq!(fields["fields"].as_array().unwrap().len(), 2);
+    let filled = tmp.join("v2-filled.hwpx");
+    let (fill, _, code) = run_json(&[
+        "fill",
+        out.to_str().unwrap(),
+        "--set",
+        "성명값=홍길동",
+        "-o",
+        filled.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "fill on cell-stamped output must succeed: {fill}");
+}
+
+#[test]
+fn stamp_v2_source_hash_mismatch_rejected() {
+    let f = fixture("tables/merged_grid_form.hwpx");
+    let tmp = test_tmp();
+    let (plan, _, _) = run_json(&["stamp-plan", f.to_str().unwrap()]);
+    let mut map_value = stamp_v2_map(&plan);
+    map_value["source_sha256"] = serde_json::Value::String("0".repeat(64));
+    let map = tmp.join("stale-map.json");
+    std::fs::write(&map, map_value.to_string()).unwrap();
+    let out = tmp.join("never-v2.hwpx");
+    let (value, _, code) = run_json(&[
+        "stamp",
+        f.to_str().unwrap(),
+        "--map",
+        map.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 1);
+    assert_eq!(value["code"], "STAMP_SOURCE_HASH_MISMATCH");
+    assert!(!out.exists(), "sha 불일치 시 산출물이 없어야 한다 (fail-closed)");
+}
+
+#[test]
+fn stamp_v2_uncovered_cell_and_unknown_field_rejected() {
+    let f = fixture("tables/merged_grid_form.hwpx");
+    let tmp = test_tmp();
+    let (plan, _, _) = run_json(&["stamp-plan", f.to_str().unwrap()]);
+    let sha = plan["source_sha256"].as_str().unwrap();
+
+    // 후보 3개 중 1개만 커버 → STAMP_CANDIDATE_UNCOVERED.
+    let partial = serde_json::json!({
+        "schema_version": 2, "source_sha256": sha,
+        "cells": [{"table": 0, "at": {"row": 0, "col": 1},
+                   "action": {"field": {"name": "성명값", "hint": "h"}}}],
+    });
+    let map = tmp.join("partial-v2.json");
+    std::fs::write(&map, partial.to_string()).unwrap();
+    let out = tmp.join("never-v2b.hwpx");
+    let (value, _, code) = run_json(&[
+        "stamp",
+        f.to_str().unwrap(),
+        "--map",
+        map.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 1);
+    assert_eq!(value["code"], "STAMP_CANDIDATE_UNCOVERED");
+    assert!(!out.exists());
+
+    // unknown field 가 든 v2 맵은 parse 단계에서 거부.
+    let typo = serde_json::json!({
+        "schema_version": 2, "source_sha256": sha, "cell": [],
+    });
+    std::fs::write(&map, typo.to_string()).unwrap();
+    let (value, _, code) = run_json(&[
+        "stamp",
+        f.to_str().unwrap(),
+        "--map",
+        map.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 1);
+    assert_eq!(value["code"], "INVALID_STAMP_MAP");
+}

--- a/crates/hwpforge-bindings-mcp/src/server.rs
+++ b/crates/hwpforge-bindings-mcp/src/server.rs
@@ -109,10 +109,19 @@ pub struct StampPlanRequest {
 pub struct StampRequest {
     /// Path to the HWPX file to stamp.
     pub file_path: String,
-    /// Approved specs: one per candidate from hwpforge_stamp_plan, each with
-    /// an action ({"field":{"name":"…"}} or "ignore"). Every unguarded
-    /// candidate must be covered (all-or-nothing).
+    /// Approved text specs: one per candidate from hwpforge_stamp_plan,
+    /// each with an action ({"field":{"name":"…"}} or "ignore"). Every
+    /// unguarded candidate must be covered (all-or-nothing).
+    #[serde(default)]
     pub specs: Vec<hwpforge_smithy_hwpx::stamp::StampSpec>,
+    /// Approved cell specs (class-B, from hwpforge_stamp_plan `cells`).
+    /// Field actions REQUIRE a non-blank hint; presence of any cell spec
+    /// requires `source_sha256`.
+    #[serde(default)]
+    pub cells: Vec<hwpforge_smithy_hwpx::stamp::CellStampSpec>,
+    /// SHA-256 of the input from hwpforge_stamp_plan — mandatory with
+    /// `cells` (drift pinning); selects the v2 pipeline when present.
+    pub source_sha256: Option<String>,
     /// Output HWPX file path. Must end with `.hwpx`.
     pub output_path: String,
     /// Manifest JSON path (default: `<output>.manifest.json`).
@@ -475,9 +484,14 @@ impl HwpForgeServer {
             Ok(data) => {
                 let output = ToolOutput::new(
                     &data,
-                    format!("{} stamp candidate(s) found", data.candidates.len()),
+                    format!(
+                        "{} text + {} cell stamp candidate(s) found",
+                        data.candidates.len(),
+                        data.cells.len()
+                    ),
                     vec![
                         "Author one spec per candidate: {\"field\":{\"name\":\"…\"}} or \"ignore\"",
+                        "Cell specs need a non-blank hint and the plan's source_sha256",
                         "Then call hwpforge_stamp with the full spec list (all-or-nothing)",
                     ],
                 );
@@ -500,6 +514,8 @@ impl HwpForgeServer {
             stamp::run_stamp(
                 &req.file_path,
                 &req.specs,
+                &req.cells,
+                req.source_sha256.as_deref(),
                 &req.output_path,
                 req.manifest_path.as_deref(),
             )
@@ -512,8 +528,9 @@ impl HwpForgeServer {
                 let output = ToolOutput::new(
                     &data,
                     format!(
-                        "Stamped {} field(s) (ignored {}, guarded-skipped {}) → {}",
+                        "Stamped {} text + {} cell field(s) (ignored {}, guarded-skipped {}) → {}",
                         data.stamped.len(),
+                        data.stamped_cells.len(),
                         data.ignored,
                         data.skipped_guarded,
                         data.output_path,

--- a/crates/hwpforge-bindings-mcp/src/tools/stamp.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/stamp.rs
@@ -9,7 +9,9 @@
 use serde::Serialize;
 
 use hwpforge_smithy_hwpx::stamp::{
-    HwpxStamper, StampCandidate, StampError, StampSpec, StampedField, StamperError,
+    CellStampCandidate, CellStampError, CellStampSpec, CellStampedField, HwpxStamper, SkippedTable,
+    StampCandidate, StampError, StampRequestV2, StampSpec, StampedField, StamperError,
+    STAMP_MAP_VERSION,
 };
 
 use crate::output::{read_file_bytes, write_output_file, ToolErrorInfo};
@@ -17,9 +19,17 @@ use crate::output::{read_file_bytes, write_output_file, ToolErrorInfo};
 /// Output data from a successful stamp-plan operation.
 #[derive(Debug, Serialize)]
 pub struct StampPlanData {
-    /// Discovered candidates (document order). Author one spec per
-    /// candidate: unguarded candidates MUST be named or ignored.
+    /// SHA-256 (hex) of the input — pass back verbatim as `source_sha256`
+    /// when the stamp request carries cell specs.
+    pub source_sha256: String,
+    /// Discovered class-A text candidates (document order). Author one spec
+    /// per candidate: unguarded candidates MUST be named or ignored.
     pub candidates: Vec<StampCandidate>,
+    /// Discovered class-B cell candidates (label-adjacent empty cells).
+    pub cells: Vec<CellStampCandidate>,
+    /// Tables excluded from cell detection (invalid grid) — explicit
+    /// incomplete-coverage diagnostics.
+    pub skipped_tables: Vec<SkippedTable>,
 }
 
 /// Output data from a successful stamp operation.
@@ -29,9 +39,12 @@ pub struct StampData {
     pub output_path: String,
     /// Path to the manifest JSON.
     pub manifest_path: String,
-    /// Fields created by this stamp (spec order).
+    /// Text fields created by this stamp (spec order).
     pub stamped: Vec<StampedField>,
-    /// Number of explicitly ignored candidates.
+    /// Cell fields created by this stamp (document order; empty for
+    /// text-only legacy requests).
+    pub stamped_cells: Vec<CellStampedField>,
+    /// Number of explicitly ignored candidates (both classes).
     pub ignored: usize,
     /// Guarded candidates skipped because no spec approved them.
     pub skipped_guarded: usize,
@@ -39,17 +52,28 @@ pub struct StampData {
     pub size_bytes: u64,
 }
 
-/// Discover class-A placeholder candidates.
+/// Discover both candidate classes (text markers + label-adjacent cells).
 pub fn run_stamp_plan(file_path: &str) -> Result<StampPlanData, ToolErrorInfo> {
     let bytes = read_file_bytes(file_path)?;
-    let candidates = HwpxStamper::plan_bytes(&bytes).map_err(map_stamper_error)?;
-    Ok(StampPlanData { candidates })
+    let plan = HwpxStamper::plan_bytes_v2(&bytes).map_err(map_stamper_error)?;
+    Ok(StampPlanData {
+        source_sha256: plan.source_sha256,
+        candidates: plan.text,
+        cells: plan.cells,
+        skipped_tables: plan.skipped_tables,
+    })
 }
 
 /// Apply the approved spec set behind the admission gate.
+///
+/// Text-only requests without `source_sha256` run the legacy v1 path;
+/// any cell spec (or an explicit `source_sha256`) selects the v2 path
+/// with source-hash pinning and post-encode delta verification.
 pub fn run_stamp(
     file_path: &str,
     specs: &[StampSpec],
+    cells: &[CellStampSpec],
+    source_sha256: Option<&str>,
     output_path: &str,
     manifest_path: Option<&str>,
 ) -> Result<StampData, ToolErrorInfo> {
@@ -62,7 +86,53 @@ pub fn run_stamp(
     }
 
     let bytes = read_file_bytes(file_path)?;
-    let result = HwpxStamper::stamp(&bytes, specs).map_err(map_stamper_error)?;
+    let serialize_err = |e: serde_json::Error| {
+        ToolErrorInfo::new(
+            "STAMP_MANIFEST_SERIALIZE",
+            format!("manifest serialization failed: {e}"),
+            "Report this as a bug.",
+        )
+    };
+    let (out_bytes, manifest_json, stamped, stamped_cells, ignored, skipped_guarded) =
+        if cells.is_empty() && source_sha256.is_none() {
+            let result = HwpxStamper::stamp(&bytes, specs).map_err(map_stamper_error)?;
+            let manifest_json =
+                serde_json::to_string_pretty(&result.manifest).map_err(serialize_err)?;
+            (
+                result.bytes,
+                manifest_json,
+                result.outcome.stamped,
+                Vec::new(),
+                result.outcome.ignored,
+                result.outcome.skipped_guarded.len(),
+            )
+        } else {
+            let Some(sha) = source_sha256 else {
+                return Err(ToolErrorInfo::new(
+                    "MISSING_SOURCE_SHA256",
+                    "cell specs require source_sha256 (drift pinning)",
+                    "hwpforge_stamp_plan 의 source_sha256 을 그대로 전달하세요.",
+                ));
+            };
+            let request = StampRequestV2 {
+                schema_version: STAMP_MAP_VERSION,
+                source_sha256: sha.to_string(),
+                text: specs.to_vec(),
+                cells: cells.to_vec(),
+            };
+            let result = HwpxStamper::stamp_v2(&bytes, &request).map_err(map_stamper_error)?;
+            let manifest_json =
+                serde_json::to_string_pretty(&result.manifest).map_err(serialize_err)?;
+            (
+                result.bytes,
+                manifest_json,
+                result.outcome.text.stamped,
+                result.outcome.cells.stamped,
+                result.outcome.text.ignored + result.outcome.cells.ignored,
+                result.outcome.text.skipped_guarded.len()
+                    + result.outcome.cells.skipped_guarded.len(),
+            )
+        };
 
     // Review L1: serialize the manifest BEFORE writing anything, and remove
     // the .hwpx if the manifest write fails — a failed call must leave no
@@ -70,13 +140,6 @@ pub fn run_stamp(
     let manifest_file = manifest_path
         .map(str::to_string)
         .unwrap_or_else(|| format!("{}.manifest.json", output_path.trim_end_matches(".hwpx")));
-    let manifest_json = serde_json::to_string_pretty(&result.manifest).map_err(|e| {
-        ToolErrorInfo::new(
-            "STAMP_MANIFEST_SERIALIZE",
-            format!("manifest serialization failed: {e}"),
-            "Report this as a bug.",
-        )
-    })?;
     // R2: identical paths would silently overwrite the stamped .hwpx with
     // the manifest JSON and still report success.
     if std::path::Path::new(output_path) == std::path::Path::new(&manifest_file) {
@@ -86,19 +149,20 @@ pub fn run_stamp(
             "manifest_path 는 output_path 와 달라야 합니다.",
         ));
     }
-    write_output_file(output_path, &result.bytes)?;
+    write_output_file(output_path, &out_bytes)?;
     if let Err(e) = write_output_file(&manifest_file, manifest_json.as_bytes()) {
         let _ = std::fs::remove_file(output_path);
         return Err(e);
     }
 
-    let size_bytes = result.bytes.len() as u64;
+    let size_bytes = out_bytes.len() as u64;
     Ok(StampData {
         output_path: output_path.to_string(),
         manifest_path: manifest_file,
-        stamped: result.outcome.stamped,
-        ignored: result.outcome.ignored,
-        skipped_guarded: result.outcome.skipped_guarded.len(),
+        stamped,
+        stamped_cells,
+        ignored,
+        skipped_guarded,
         size_bytes,
     })
 }
@@ -127,6 +191,94 @@ fn map_stamper_error(error: StamperError) -> ToolErrorInfo {
             "STAMP_CODEC_FAILED",
             msg,
             "Check that the file is valid HWPX.",
+        ),
+        StamperError::SourceHashMismatch { expected, actual } => ToolErrorInfo::new(
+            "STAMP_SOURCE_HASH_MISMATCH",
+            format!("request is pinned to {expected}, input is {actual}"),
+            "문서가 변경됐습니다 — hwpforge_stamp_plan 을 다시 실행해 source_sha256 을 갱신하세요.",
+        ),
+        StamperError::CellStamp(inner) => map_cell_stamp_error(inner),
+        StamperError::DeltaMismatch { stage, detail } => ToolErrorInfo::new(
+            "STAMP_DELTA_MISMATCH",
+            format!("post-encode verification failed at {stage}: {detail}"),
+            "산출물 검증 실패 — 코덱 버그 가능성이 있어 무출력으로 거부했습니다.",
+        ),
+        other => ToolErrorInfo::new("STAMP_FAILED", other.to_string(), "Unexpected failure."),
+    }
+}
+
+fn map_cell_stamp_error(error: CellStampError) -> ToolErrorInfo {
+    match error {
+        CellStampError::TableNotFound { table } => ToolErrorInfo::new(
+            "TABLE_NOT_FOUND",
+            format!("table ordinal {table} does not exist"),
+            "hwpforge_stamp_plan 의 cells[].table 서수를 사용하세요.",
+        ),
+        CellStampError::TableGridInvalid { table, detail } => ToolErrorInfo::new(
+            "TABLE_GRID_INVALID",
+            format!("table {table}: {detail}"),
+            "이 표는 논리 격자를 만들 수 없어 셀 스탬핑 대상이 아닙니다.",
+        ),
+        CellStampError::NotAnAnchor { table, requested, anchor } => ToolErrorInfo::new(
+            "STAMP_CELL_NOT_ANCHOR",
+            format!("table {table}: ({},{}) is not an anchor", requested.row, requested.col),
+            match anchor {
+                Some(a) => {
+                    format!("병합 피복 위치입니다 — anchor ({},{}) 를 지정하세요.", a.row, a.col)
+                }
+                None => "격자 범위 밖 좌표입니다.".to_string(),
+            },
+        ),
+        CellStampError::TargetNotStampable { table, at } => ToolErrorInfo::new(
+            "STAMP_CELL_NOT_EMPTY",
+            format!("table {table}: cell ({},{}) has authored content", at.row, at.col),
+            "클래스-B 대상은 whitespace-only 빈 셀이어야 합니다.",
+        ),
+        CellStampError::LabelDrift { table, at, claimed, found } => ToolErrorInfo::new(
+            "STAMP_LABEL_DRIFT",
+            format!(
+                "table {table} ({},{}): claimed label {claimed:?}, live {found:?}",
+                at.row, at.col
+            ),
+            "문서가 변경됐습니다 — hwpforge_stamp_plan 을 다시 실행하세요.",
+        ),
+        CellStampError::UnknownCandidate { table, at } => ToolErrorInfo::new(
+            "STAMP_CELL_NOT_CANDIDATE",
+            format!("table {table}: ({},{}) is not a live candidate", at.row, at.col),
+            "ignore 는 live 후보에만 가능합니다.",
+        ),
+        CellStampError::DuplicateTarget { table, at } => ToolErrorInfo::new(
+            "STAMP_CELL_TARGET_DUPLICATE",
+            format!("table {table}: cell ({},{}) targeted twice", at.row, at.col),
+            "같은 셀을 두 번 분류했습니다.",
+        ),
+        CellStampError::EmptyName => ToolErrorInfo::new(
+            "STAMP_NAME_EMPTY",
+            "field name must not be empty",
+            "빈 이름은 허용되지 않습니다.",
+        ),
+        CellStampError::BlankHint { name } => ToolErrorInfo::new(
+            "STAMP_HINT_BLANK",
+            format!("cell spec {name:?}: hint must not be blank"),
+            "빈 셀엔 마커가 없어 hint 가 필수입니다 — plan 의 suggested_hint 를 참고하세요.",
+        ),
+        CellStampError::DuplicateName { name } => ToolErrorInfo::new(
+            "STAMP_NAME_DUPLICATE",
+            format!("duplicate field name {name:?}"),
+            "필드 이름은 text+cells 전체에서 유일해야 합니다.",
+        ),
+        CellStampError::NameCollision { name } => ToolErrorInfo::new(
+            "STAMP_NAME_COLLISION",
+            format!("field name {name:?} already exists in the document"),
+            "기존 누름틀과 이름이 겹칩니다 — hwpforge_fields 로 확인하세요.",
+        ),
+        CellStampError::UncoveredCandidate { table, at } => ToolErrorInfo::new(
+            "STAMP_CANDIDATE_UNCOVERED",
+            format!(
+                "unguarded cell candidate at table {table} ({},{}) has no spec",
+                at.row, at.col
+            ),
+            "모든 무가드 셀 후보는 이름 또는 ignore 로 분류해야 합니다.",
         ),
         other => ToolErrorInfo::new("STAMP_FAILED", other.to_string(), "Unexpected failure."),
     }
@@ -208,6 +360,101 @@ mod tests {
         }
     }
 
+    /// 성명/주소 2×2 라벨 서식 (set_cell 테스트와 동일 형태).
+    fn label_form_hwpx(dir: &std::path::Path) -> String {
+        use hwpforge_core::page::PageSettings;
+        use hwpforge_core::run::Run;
+        use hwpforge_core::table::{Table, TableCell, TableRow};
+        use hwpforge_core::{Document, Paragraph, Section};
+        use hwpforge_foundation::{CharShapeIndex, HwpUnit, ParaShapeIndex};
+        use hwpforge_smithy_hwpx::style_store::{HwpxCharShape, HwpxParaShape, HwpxStyleStore};
+        use hwpforge_smithy_hwpx::HwpxEncoder;
+
+        let text_para = |t: &str| {
+            Paragraph::with_runs(vec![Run::text(t, CharShapeIndex::new(0))], ParaShapeIndex::new(0))
+        };
+        let cell = |t: &str| TableCell::new(vec![text_para(t)], HwpUnit::new(8000).unwrap());
+        let table = Table::new(vec![
+            TableRow::new(vec![cell("성명"), cell("")]),
+            TableRow::new(vec![cell("주소"), cell("")]),
+        ]);
+        let mut host = Paragraph::new(ParaShapeIndex::new(0));
+        host.add_run(Run::table(table, CharShapeIndex::new(0)));
+        let mut doc = Document::new();
+        doc.add_section(Section::with_paragraphs(vec![host], PageSettings::default()));
+
+        let mut styles = HwpxStyleStore::with_default_fonts("함초롬돋움");
+        styles.push_char_shape(HwpxCharShape::default());
+        styles.push_para_shape(HwpxParaShape::default());
+        let bytes = HwpxEncoder::encode(
+            &doc.validate().unwrap(),
+            &styles,
+            &hwpforge_core::image::ImageStore::new(),
+        )
+        .unwrap();
+        let path = dir.join("label-form.hwpx");
+        std::fs::write(&path, bytes).unwrap();
+        path.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn stamp_v2_cells_via_mcp_surface() {
+        use hwpforge_core::table::grid::GridCoord;
+        use hwpforge_smithy_hwpx::stamp::{CellLabelClaim, CellStampAction};
+
+        let dir = tempfile::tempdir().unwrap();
+        let src = label_form_hwpx(dir.path());
+        let plan = run_stamp_plan(&src).unwrap();
+        assert_eq!(plan.cells.len(), 2, "{:?}", plan.cells);
+        assert!(plan.skipped_tables.is_empty());
+
+        let cell_specs = vec![
+            CellStampSpec {
+                table: 0,
+                at: GridCoord::new(0, 1),
+                label: Some(CellLabelClaim { at: GridCoord::new(0, 0), text: "성명".into() }),
+                action: CellStampAction::Field {
+                    name: "성명".into(), hint: "성명 입력".into()
+                },
+            },
+            CellStampSpec {
+                table: 0,
+                at: GridCoord::new(1, 1),
+                label: None,
+                action: CellStampAction::Ignore,
+            },
+        ];
+
+        // cells 만 있고 source_sha256 이 없으면 거부 (드리프트 핀 필수).
+        let out = dir.path().join("cells.hwpx");
+        let err = run_stamp(&src, &[], &cell_specs, None, out.to_str().unwrap(), None).unwrap_err();
+        assert_eq!(err.code, "MISSING_SOURCE_SHA256");
+
+        let data = run_stamp(
+            &src,
+            &[],
+            &cell_specs,
+            Some(&plan.source_sha256),
+            out.to_str().unwrap(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(data.stamped_cells.len(), 1);
+        assert_eq!(data.stamped_cells[0].name, "성명");
+        assert_eq!(data.ignored, 1);
+
+        // 산출물은 즉시 fields 로 발견 가능.
+        let fields = crate::tools::fields::run_fields(out.to_str().unwrap()).unwrap();
+        assert_eq!(fields.fields.len(), 1);
+        assert_eq!(fields.fields[0].name.as_deref(), Some("성명"));
+
+        // 틀린 sha 는 STAMP_SOURCE_HASH_MISMATCH.
+        let err =
+            run_stamp(&src, &[], &cell_specs, Some(&"0".repeat(64)), out.to_str().unwrap(), None)
+                .unwrap_err();
+        assert_eq!(err.code, "STAMP_SOURCE_HASH_MISMATCH");
+    }
+
     #[test]
     fn stamp_plan_lists_candidates_with_guard() {
         let dir = tempfile::tempdir().unwrap();
@@ -225,7 +472,7 @@ mod tests {
         let unguarded: Vec<_> = plan.candidates.iter().filter(|c| c.guard.is_none()).collect();
         let specs = vec![named(unguarded[0], "성명"), named(unguarded[1], "소속")];
         let out = dir.path().join("stamped.hwpx");
-        let data = run_stamp(&src, &specs, out.to_str().unwrap(), None).unwrap();
+        let data = run_stamp(&src, &specs, &[], None, out.to_str().unwrap(), None).unwrap();
         assert_eq!(data.stamped.len(), 2);
         assert_eq!(data.skipped_guarded, 1);
         assert!(std::path::Path::new(&data.manifest_path).exists());
@@ -239,7 +486,7 @@ mod tests {
     fn stamp_rejects_non_hwpx_extension() {
         let dir = tempfile::tempdir().unwrap();
         let src = make_template(&dir);
-        let err = run_stamp(&src, &[], "out.zip", None).unwrap_err();
+        let err = run_stamp(&src, &[], &[], None, "out.zip", None).unwrap_err();
         assert_eq!(err.code, "INVALID_EXTENSION");
     }
 
@@ -254,34 +501,41 @@ mod tests {
         let out_s = out.to_str().unwrap();
 
         // 미커버 무가드 후보
-        let err = run_stamp(&src, &[], out_s, None).unwrap_err();
+        let err = run_stamp(&src, &[], &[], None, out_s, None).unwrap_err();
         assert_eq!(err.code, "STAMP_CANDIDATE_UNCOVERED");
 
         // stale spec (span 어긋남)
         let mut stale = named(c1, "성명");
         stale.span = 0..1;
-        let err = run_stamp(&src, &[stale, named(c2, "소속")], out_s, None).unwrap_err();
+        let err = run_stamp(&src, &[stale, named(c2, "소속")], &[], None, out_s, None).unwrap_err();
         assert_eq!(err.code, "STAMP_SPEC_STALE");
 
         // 마커 불일치
         let mut wrong = named(c1, "성명");
         wrong.marker = "(x)".to_string();
-        let err = run_stamp(&src, &[wrong, named(c2, "소속")], out_s, None).unwrap_err();
+        let err = run_stamp(&src, &[wrong, named(c2, "소속")], &[], None, out_s, None).unwrap_err();
         assert_eq!(err.code, "STAMP_MARKER_MISMATCH");
 
         // 같은 후보 이중 분류
-        let err =
-            run_stamp(&src, &[named(c1, "a"), named(c1, "b"), named(c2, "소속")], out_s, None)
-                .unwrap_err();
+        let err = run_stamp(
+            &src,
+            &[named(c1, "a"), named(c1, "b"), named(c2, "소속")],
+            &[],
+            None,
+            out_s,
+            None,
+        )
+        .unwrap_err();
         assert_eq!(err.code, "STAMP_SPEC_DUPLICATE");
 
         // 이름 중복
-        let err =
-            run_stamp(&src, &[named(c1, "같음"), named(c2, "같음")], out_s, None).unwrap_err();
+        let err = run_stamp(&src, &[named(c1, "같음"), named(c2, "같음")], &[], None, out_s, None)
+            .unwrap_err();
         assert_eq!(err.code, "STAMP_NAME_DUPLICATE");
 
         // 빈 이름
-        let err = run_stamp(&src, &[named(c1, ""), named(c2, "소속")], out_s, None).unwrap_err();
+        let err = run_stamp(&src, &[named(c1, ""), named(c2, "소속")], &[], None, out_s, None)
+            .unwrap_err();
         assert_eq!(err.code, "STAMP_NAME_EMPTY");
 
         assert!(!out.exists(), "fail-closed: 거부 시 산출물이 없어야 한다");
@@ -300,6 +554,8 @@ mod tests {
         let err = run_stamp(
             &src,
             &specs,
+            &[],
+            None,
             out.to_str().unwrap(),
             Some("/nonexistent-dir/never.manifest.json"),
         )

--- a/crates/hwpforge-smithy-hwpx/src/cell_edit.rs
+++ b/crates/hwpforge-smithy-hwpx/src/cell_edit.rs
@@ -392,7 +392,7 @@ pub fn apply_set_cells(
 }
 
 /// NFC + Unicode-whitespace trim/collapse.
-fn normalize_label(s: &str) -> String {
+pub(crate) fn normalize_label(s: &str) -> String {
     let nfc: String = s.nfc().collect();
     nfc.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/crates/hwpforge-smithy-hwpx/src/cell_edit.rs
+++ b/crates/hwpforge-smithy-hwpx/src/cell_edit.rs
@@ -526,6 +526,10 @@ impl HwpxCellEditor {
             document.validate().map_err(|e| CellEditError::Codec(format!("validate: {e}")))?;
         let bytes = HwpxEncoder::encode(&validated, &style_store, &image_store)
             .map_err(|e| CellEditError::Codec(e.to_string()))?;
+        // Untouched paragraphs keep Hancom's line-layout cache so the
+        // renderer does not reflow (and repaginate) the whole document.
+        let bytes = crate::layout_carry::carry_line_segs(base, &e0, &bytes)
+            .map_err(|e| CellEditError::Codec(e.to_string()))?;
         Ok(CellEditResult { bytes, outcome })
     }
 }

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -292,8 +292,16 @@ fn convert_paragraph(
 
     // Normalize empty paragraphs: HWPX files from 한글 can have empty paragraphs
     // (blank lines). Core's validate() requires at least 1 run per paragraph.
+    // The placeholder keeps the first authored run's charPrIDRef — visually
+    // empty paragraphs/cells still carry a real character style on the wire,
+    // and editing surfaces (cell stamping, set-cell) restore styled text from
+    // it. Index 0 is only for paragraphs with no <hp:run> at all.
     if runs.is_empty() {
-        runs.push(Run::text("", CharShapeIndex::new(0)));
+        let char_shape_id = hx
+            .runs
+            .first()
+            .map_or(CharShapeIndex::new(0), |r| CharShapeIndex::new(r.char_pr_id_ref as usize));
+        runs.push(Run::text("", char_shape_id));
     }
 
     // Best-effort heading level: always decodes as `Some(1)` when a titleMark
@@ -1612,6 +1620,75 @@ mod tests {
         // Empty paragraphs are normalized to contain a single empty text run
         assert_eq!(result.paragraphs[0].runs.len(), 1);
         assert_eq!(result.paragraphs[0].runs[0].content.as_text(), Some(""));
+    }
+
+    #[test]
+    fn empty_paragraph_placeholder_preserves_authored_char_shape() {
+        // Visually empty paragraphs still carry a real charPrIDRef on the
+        // wire; the normalization placeholder must keep it so that editing
+        // surfaces (cell stamping / set-cell) can restore styled text.
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="7"><t/></run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        assert_eq!(result.paragraphs[0].runs.len(), 1);
+        assert_eq!(result.paragraphs[0].runs[0].content.as_text(), Some(""));
+        assert_eq!(result.paragraphs[0].runs[0].char_shape_id.get(), 7);
+    }
+
+    #[test]
+    fn empty_paragraph_first_authored_char_shape_wins() {
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="3"><t/></run>
+                <run charPrIDRef="5"><t/></run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        assert_eq!(result.paragraphs[0].runs.len(), 1);
+        assert_eq!(result.paragraphs[0].runs[0].char_shape_id.get(), 3);
+    }
+
+    #[test]
+    fn paragraph_without_wire_runs_defaults_char_shape_zero() {
+        // No <run> at all on the wire — nothing authored, index 0 is honest.
+        let xml = r#"<sec>
+            <p paraPrIDRef="0"></p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        assert_eq!(result.paragraphs[0].runs.len(), 1);
+        assert_eq!(result.paragraphs[0].runs[0].content.as_text(), Some(""));
+        assert_eq!(result.paragraphs[0].runs[0].char_shape_id.get(), 0);
+    }
+
+    #[test]
+    fn empty_table_cell_preserves_authored_char_shape() {
+        // The class-B stamping target: a visually empty form cell whose wire
+        // run carries the form's character style.
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <tbl rowCnt="1" colCnt="1">
+                        <tr>
+                            <tc name="A1">
+                                <subList><p paraPrIDRef="0"><run charPrIDRef="9"><t/></run></p></subList>
+                            </tc>
+                        </tr>
+                    </tbl>
+                </run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        match &result.paragraphs[0].runs[0].content {
+            RunContent::Table(table) => {
+                let cell = &table.rows[0].cells[0];
+                assert_eq!(cell.paragraphs[0].runs[0].content.as_text(), Some(""));
+                assert_eq!(cell.paragraphs[0].runs[0].char_shape_id.get(), 9);
+            }
+            _ => panic!("expected Table"),
+        }
     }
 
     // ── Page settings ────────────────────────────────────────────

--- a/crates/hwpforge-smithy-hwpx/src/layout_carry.rs
+++ b/crates/hwpforge-smithy-hwpx/src/layout_carry.rs
@@ -1,0 +1,315 @@
+//! Selective `<hp:linesegarray>` carry — Hancom's per-paragraph line-layout
+//! cache survives re-encode for paragraphs an edit did not touch.
+//!
+//! Full re-encode surfaces (stamp, set-cell) drop `<hp:linesegarray>`
+//! because the decoder never carried it into Core (a layout CACHE has no
+//! place in the IR). Without the cache the renderer reflows every
+//! paragraph from scratch, and on real government forms the accumulated
+//! drift moves page breaks (blank-HPC: 9 → 8 pages in PDF export).
+//!
+//! The carry is a wire-order splice, not a Core change:
+//!
+//! 1. scan the ORIGINAL section XML: one slot per `<hp:p>` in open order,
+//!    each with its raw `<hp:linesegarray>…</hp:linesegarray>` slice;
+//! 2. scan the BASELINE (no-op re-encode of the pristine document, already
+//!    produced by the admission gate) and the OUTPUT the same way;
+//! 3. a paragraph whose OUTPUT slice is byte-identical to its BASELINE
+//!    slice was not touched by the edit → re-inject the original cache
+//!    before its `</hp:p>`. Anything else (edited paragraphs, paragraphs
+//!    containing edited nested paragraphs, id-shifted elements) stays
+//!    cache-less and the renderer reflows just those.
+//!
+//! Fail-open by design: any count mismatch or scan anomaly disables the
+//! carry for that section — the result is the current (reflowed) behavior,
+//! never a stale cache attached to changed content.
+
+use crate::error::HwpxResult;
+use crate::patch::RawPackage;
+
+/// One `<hp:p>` occurrence in a section XML, in open order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParaSlice {
+    /// Byte offset of `<hp:p`.
+    start: usize,
+    /// Byte offset of `</hp:p>` (insert point for the cache); equals `end`
+    /// for a self-closing paragraph.
+    content_end: usize,
+    /// Byte offset just past the paragraph's close.
+    end: usize,
+    /// Raw `<hp:linesegarray…>` range, when the paragraph carries one.
+    line_seg: Option<(usize, usize)>,
+}
+
+/// Finds the end of the tag starting at `start` (`<` position), honoring
+/// quoted attribute values. Returns `(after_gt, self_closing)`.
+fn tag_end(xml: &str, start: usize) -> Option<(usize, bool)> {
+    let bytes = xml.as_bytes();
+    let mut in_quote = false;
+    let mut i = start;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => in_quote = !in_quote,
+            b'>' if !in_quote => {
+                let self_closing = i > start && bytes[i - 1] == b'/';
+                return Some((i + 1, self_closing));
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Scans every `<hp:p>` of a section XML in open (document) order.
+///
+/// Returns `None` on any structural anomaly (unbalanced tags, truncated
+/// XML) — callers treat that as "no carry".
+fn scan_paragraphs(xml: &str) -> Option<Vec<ParaSlice>> {
+    let mut slices: Vec<ParaSlice> = Vec::new();
+    let mut stack: Vec<usize> = Vec::new();
+    let mut pos = 0usize;
+
+    while let Some(rel) = xml[pos..].find('<') {
+        let at = pos + rel;
+        let rest = &xml[at..];
+        if let Some(after) = rest.strip_prefix("<hp:p") {
+            // `<hp:p ...>` / `<hp:p>` / `<hp:p/>` only — not `<hp:pic` etc.
+            match after.as_bytes().first() {
+                Some(b' ') | Some(b'>') | Some(b'/') => {
+                    let (tag_after, self_closing) = tag_end(xml, at)?;
+                    if self_closing {
+                        slices.push(ParaSlice {
+                            start: at,
+                            content_end: tag_after,
+                            end: tag_after,
+                            line_seg: None,
+                        });
+                    } else {
+                        stack.push(slices.len());
+                        slices.push(ParaSlice {
+                            start: at,
+                            content_end: 0,
+                            end: 0,
+                            line_seg: None,
+                        });
+                    }
+                    pos = tag_after;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        if rest.starts_with("</hp:p>") {
+            let idx = stack.pop()?;
+            slices[idx].content_end = at;
+            slices[idx].end = at + "</hp:p>".len();
+            pos = at + "</hp:p>".len();
+            continue;
+        }
+        if rest.starts_with("<hp:linesegarray") {
+            let owner = *stack.last()?;
+            let (tag_after, self_closing) = tag_end(xml, at)?;
+            let seg_end = if self_closing {
+                tag_after
+            } else {
+                const CLOSE: &str = "</hp:linesegarray>";
+                let rel = xml[tag_after..].find(CLOSE)?;
+                tag_after + rel + CLOSE.len()
+            };
+            slices[owner].line_seg = Some((at, seg_end));
+            pos = seg_end;
+            continue;
+        }
+        // Any other tag: skip it wholesale (quote-aware) so a '>' inside an
+        // attribute value cannot desync the scan.
+        let (tag_after, _) = tag_end(xml, at)?;
+        pos = tag_after;
+    }
+
+    if stack.is_empty() && slices.iter().all(|s| s.end != 0) {
+        Some(slices)
+    } else {
+        None
+    }
+}
+
+/// Splices the original line-layout caches into `output` for paragraphs
+/// whose slice is byte-identical to the baseline's. Returns `None` when the
+/// carry cannot be aligned (paragraph count mismatch, scan anomaly).
+fn splice_section(original: &str, baseline: &str, output: &str) -> Option<String> {
+    let orig = scan_paragraphs(original)?;
+    let base = scan_paragraphs(baseline)?;
+    let out = scan_paragraphs(output)?;
+    if orig.len() != base.len() || base.len() != out.len() {
+        return None;
+    }
+
+    let mut inserts: Vec<(usize, &str)> = Vec::new();
+    for i in 0..orig.len() {
+        let Some((seg_start, seg_end)) = orig[i].line_seg else {
+            continue;
+        };
+        let unchanged = baseline[base[i].start..base[i].end] == output[out[i].start..out[i].end];
+        let has_close = out[i].content_end < out[i].end;
+        let already = output[out[i].start..out[i].end].contains("<hp:linesegarray");
+        if unchanged && has_close && !already {
+            inserts.push((out[i].content_end, &original[seg_start..seg_end]));
+        }
+    }
+    if inserts.is_empty() {
+        return Some(output.to_string());
+    }
+
+    inserts.sort_by_key(|(pos, _)| *pos);
+    let mut result =
+        String::with_capacity(output.len() + inserts.iter().map(|(_, s)| s.len()).sum::<usize>());
+    let mut cursor = 0usize;
+    for (pos, seg) in inserts {
+        result.push_str(&output[cursor..pos]);
+        result.push_str(seg);
+        cursor = pos;
+    }
+    result.push_str(&output[cursor..]);
+    Some(result)
+}
+
+/// Carries `<hp:linesegarray>` caches from `original` into `output` for
+/// every section entry, comparing against `baseline` (the pristine no-op
+/// re-encode) to decide which paragraphs an edit left untouched.
+///
+/// Fail-open: sections that cannot be aligned are left as-is; the function
+/// only errors on package-level I/O problems.
+pub(crate) fn carry_line_segs(
+    original: &[u8],
+    baseline: &[u8],
+    output: &[u8],
+) -> HwpxResult<Vec<u8>> {
+    let orig_pkg = RawPackage::read(original)?;
+    let base_pkg = RawPackage::read(baseline)?;
+    let mut out_pkg = RawPackage::read(output)?;
+
+    let section_paths: Vec<String> = out_pkg
+        .entry_paths()
+        .filter(|p| p.starts_with("Contents/section") && p.ends_with(".xml"))
+        .map(str::to_string)
+        .collect();
+
+    let mut changed = false;
+    for path in section_paths {
+        let (Ok(orig_xml), Ok(base_xml), Ok(out_xml)) = (
+            orig_pkg.read_text_entry(&path),
+            base_pkg.read_text_entry(&path),
+            out_pkg.read_text_entry(&path),
+        ) else {
+            continue;
+        };
+        if !orig_xml.contains("<hp:linesegarray") {
+            continue;
+        }
+        if let Some(spliced) = splice_section(&orig_xml, &base_xml, &out_xml) {
+            if spliced != out_xml {
+                out_pkg.replace_text_entry(&path, spliced);
+                changed = true;
+            }
+        }
+    }
+
+    if changed {
+        out_pkg.write()
+    } else {
+        Ok(output.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LSA: &str = r#"<hp:linesegarray><hp:lineseg textpos="0" vertpos="0"/></hp:linesegarray>"#;
+
+    fn p(body: &str, with_lsa: bool) -> String {
+        let lsa = if with_lsa { LSA } else { "" };
+        format!(r#"<hp:p id="0"><hp:run charPrIDRef="0"><hp:t>{body}</hp:t></hp:run>{lsa}</hp:p>"#)
+    }
+
+    #[test]
+    fn scan_counts_paragraphs_and_assigns_line_segs() {
+        let xml = format!("<hs:sec>{}{}</hs:sec>", p("하나", true), p("둘", false));
+        let slices = scan_paragraphs(&xml).unwrap();
+        assert_eq!(slices.len(), 2);
+        assert!(slices[0].line_seg.is_some());
+        assert!(slices[1].line_seg.is_none());
+    }
+
+    #[test]
+    fn scan_assigns_nested_paragraph_cache_to_inner() {
+        // 표 셀 내부의 중첩 문단 — lsa 는 innermost 문단 소유.
+        let inner = p("셀", true);
+        let xml = format!(
+            r#"<hs:sec><hp:p id="1"><hp:run><hp:tbl><hp:tr><hp:tc><hp:subList>{inner}</hp:subList></hp:tc></hp:tr></hp:tbl></hp:run>{LSA}</hp:p></hs:sec>"#
+        );
+        let slices = scan_paragraphs(&xml).unwrap();
+        assert_eq!(slices.len(), 2);
+        // open 순서: 바깥 문단 먼저, 안쪽 문단 다음 — 둘 다 자기 lsa 를 가짐.
+        assert!(slices[0].line_seg.is_some());
+        assert!(slices[1].line_seg.is_some());
+        let (s, e) = slices[1].line_seg.unwrap();
+        assert!(slices[0].line_seg.unwrap().0 > e || slices[0].line_seg.unwrap().1 < s);
+    }
+
+    #[test]
+    fn scan_survives_gt_inside_attribute_values() {
+        let xml = format!(
+            r#"<hs:sec><hp:p id="0" note="a>b"><hp:run><hp:t>x</hp:t></hp:run></hp:p>{}</hs:sec>"#,
+            p("y", false)
+        );
+        assert_eq!(scan_paragraphs(&xml).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn scan_rejects_unbalanced_paragraphs() {
+        assert!(scan_paragraphs("<hs:sec><hp:p id=\"0\"><hp:run/></hs:sec>").is_none());
+    }
+
+    #[test]
+    fn splice_restores_cache_for_unchanged_paragraphs_only() {
+        // original = 캐시 있는 2문단, baseline = 캐시 없는 동일 문서(no-op
+        // 재인코드), output = 둘째 문단만 편집된 재인코드.
+        let original = format!("<hs:sec>{}{}</hs:sec>", p("하나", true), p("둘", true));
+        let baseline = format!("<hs:sec>{}{}</hs:sec>", p("하나", false), p("둘", false));
+        let output = format!("<hs:sec>{}{}</hs:sec>", p("하나", false), p("수정됨", false));
+
+        let spliced = splice_section(&original, &baseline, &output).unwrap();
+        // 첫 문단: 캐시 복원. 둘째 문단: 편집됨 → 캐시 없음.
+        let first = spliced.find(LSA).unwrap();
+        assert!(
+            spliced[first..].find(LSA).map(|r| r == 0).unwrap_or(false)
+                || spliced.matches(LSA).count() == 1
+        );
+        assert!(spliced.contains("수정됨"));
+        assert!(spliced.find("하나").unwrap() < first);
+    }
+
+    #[test]
+    fn splice_noop_roundtrip_restores_everything() {
+        let original = format!("<hs:sec>{}{}</hs:sec>", p("하나", true), p("둘", true));
+        let baseline = format!("<hs:sec>{}{}</hs:sec>", p("하나", false), p("둘", false));
+        let spliced = splice_section(&original, &baseline, &baseline).unwrap();
+        assert_eq!(spliced, original, "무편집 왕복은 원본 wire 로 완전 복원");
+    }
+
+    #[test]
+    fn splice_bails_on_paragraph_count_mismatch() {
+        let original = format!("<hs:sec>{}</hs:sec>", p("하나", true));
+        let two = format!("<hs:sec>{}{}</hs:sec>", p("하나", false), p("둘", false));
+        assert!(splice_section(&original, &two, &two).is_none());
+    }
+
+    #[test]
+    fn splice_skips_paragraph_that_already_has_cache() {
+        let original = format!("<hs:sec>{}</hs:sec>", p("하나", true));
+        let with_cache = original.clone();
+        let spliced = splice_section(&original, &with_cache, &with_cache).unwrap();
+        assert_eq!(spliced.matches("<hp:linesegarray").count(), 1);
+    }
+}

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -59,6 +59,7 @@ pub mod exchange;
 mod fill;
 pub mod grid_addr;
 mod inline_text;
+mod layout_carry;
 mod list_bridge;
 mod patch;
 pub mod presets;

--- a/crates/hwpforge-smithy-hwpx/src/patch.rs
+++ b/crates/hwpforge-smithy-hwpx/src/patch.rs
@@ -263,7 +263,7 @@ struct TextElementSpan {
 }
 
 #[derive(Debug, Clone)]
-struct RawPackage {
+pub(crate) struct RawPackage {
     entries: Vec<RawPackageEntry>,
     index_by_path: BTreeMap<String, usize>,
 }
@@ -276,7 +276,7 @@ struct RawPackageEntry {
 }
 
 impl RawPackage {
-    fn read(bytes: &[u8]) -> HwpxResult<Self> {
+    pub(crate) fn read(bytes: &[u8]) -> HwpxResult<Self> {
         let _ = PackageReader::new(bytes)?;
 
         let cursor = Cursor::new(bytes);
@@ -297,7 +297,11 @@ impl RawPackage {
         Ok(Self { entries, index_by_path })
     }
 
-    fn read_text_entry(&self, path: &str) -> HwpxResult<String> {
+    pub(crate) fn entry_paths(&self) -> impl Iterator<Item = &str> {
+        self.entries.iter().map(|e| e.path.as_str())
+    }
+
+    pub(crate) fn read_text_entry(&self, path: &str) -> HwpxResult<String> {
         let index = self
             .index_by_path
             .get(path)
@@ -307,13 +311,13 @@ impl RawPackage {
             .map_err(|e| HwpxError::Zip(format!("entry '{path}' is not valid UTF-8: {e}")))
     }
 
-    fn replace_text_entry(&mut self, path: &str, content: String) {
+    pub(crate) fn replace_text_entry(&mut self, path: &str, content: String) {
         if let Some(index) = self.index_by_path.get(path).copied() {
             self.entries[index].bytes = content.into_bytes();
         }
     }
 
-    fn write(&self) -> HwpxResult<Vec<u8>> {
+    pub(crate) fn write(&self) -> HwpxResult<Vec<u8>> {
         let cursor = Cursor::new(Vec::<u8>::new());
         let mut zip = ZipWriter::new(cursor);
 

--- a/crates/hwpforge-smithy-hwpx/src/stamp/apply_cells.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/apply_cells.rs
@@ -1,0 +1,774 @@
+//! Class-B apply — Wave 2B: preflight + all-or-nothing cell promotion.
+//!
+//! The engine is split into [`preflight_cells`] and [`commit_cells`] so a
+//! combined text+cell stamp can preflight EVERYTHING against the pristine
+//! document before any mutation (a second preflight failing after a first
+//! mutation would leave a half-stamped document). The commit phase is
+//! mechanical: every coordinate was resolved and every invariant checked
+//! against the same document snapshot, and class-A text mutation cannot
+//! invalidate a cell target (markers require non-whitespace text, stampable
+//! targets are whitespace-only, and run splits never move tables).
+//!
+//! Contract (design §7.3, Codex-settled):
+//! - spec `at` must be the canonical anchor — covered coordinates are
+//!   rejected, never silently resolved (unlike set-cell's read surface).
+//! - a spec with a label claim approves a DETECTED candidate: the claim is
+//!   re-verified against the live plan (target still stampable, label cell
+//!   still normalize-matches). A spec without a claim is an EXPLICIT orphan
+//!   authoring — new capability, still fully preflighted.
+//! - every unguarded candidate must be covered by a spec (field or ignore);
+//!   guarded candidates without a spec are skipped and reported.
+//! - promoted display = hint (caller-required); char shape comes from the
+//!   target cell's own first run (authored value preserved since the
+//!   empty-run charPrIDRef decoder fix), para shape untouched.
+//! - only the FIRST paragraph's run is replaced; trailing empty padding
+//!   paragraphs are preserved so table geometry cannot move. The replaced
+//!   run's text is recorded verbatim for the reverse-delta gate.
+
+use std::collections::{HashMap, HashSet};
+
+use hwpforge_core::document::{Document, Draft};
+use hwpforge_core::run::Run;
+use hwpforge_core::table::grid::{GridCoord, TableGrid};
+use hwpforge_core::Control;
+use hwpforge_foundation::FieldType;
+
+use super::cells::{is_stampable_empty, plan_cells, CellStampCandidate};
+use super::request::{CellLabelClaim, CellStampAction, CellStampSpec};
+use crate::cell_edit::normalize_label;
+use crate::fill::visit_section_fields;
+use crate::table_inventory::{for_each_table_mut, tables_in_document};
+
+/// One field created by [`commit_cells`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct CellStampedField {
+    /// The field name (unique in the output document).
+    pub name: String,
+    /// Table ordinal (shared inventory DFS pre-order).
+    pub table: usize,
+    /// Anchor coordinate of the stamped cell.
+    pub at: GridCoord,
+    /// The label claim the spec carried (`None` = explicit orphan).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<CellLabelClaim>,
+    /// The unfilled body/hint the field was created with.
+    pub hint: String,
+    /// Original first-paragraph run text (whitespace padding), recorded
+    /// verbatim for the reverse-delta gate.
+    pub original_text: String,
+}
+
+/// Result of a successful cell apply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CellStampOutcome {
+    /// Fields created, in spec order.
+    pub stamped: Vec<CellStampedField>,
+    /// Number of explicitly ignored candidates.
+    pub ignored: usize,
+    /// Guarded candidates left untouched because no spec approved them.
+    pub skipped_guarded: Vec<CellStampCandidate>,
+}
+
+/// Cell-apply preflight failure — nothing was modified.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CellStampError {
+    /// Spec table ordinal does not exist.
+    TableNotFound {
+        /// The requested ordinal.
+        table: usize,
+    },
+    /// The table's logical grid cannot be built.
+    TableGridInvalid {
+        /// Table ordinal.
+        table: usize,
+        /// First grid violation (human-readable).
+        detail: String,
+    },
+    /// Spec `at` is not a canonical anchor (out of bounds or covered).
+    NotAnAnchor {
+        /// Table ordinal.
+        table: usize,
+        /// The requested coordinate.
+        requested: GridCoord,
+        /// The anchor covering it, when the coordinate is merely covered.
+        anchor: Option<GridCoord>,
+    },
+    /// The target cell is not stampable empty (authored content).
+    TargetNotStampable {
+        /// Table ordinal.
+        table: usize,
+        /// Target anchor.
+        at: GridCoord,
+    },
+    /// The label claim no longer matches the live document/plan.
+    LabelDrift {
+        /// Table ordinal.
+        table: usize,
+        /// Target anchor.
+        at: GridCoord,
+        /// Label text the spec claimed.
+        claimed: String,
+        /// Normalized label actually adjacent at the claimed coordinate.
+        found: Option<String>,
+    },
+    /// An `ignore` spec names a coordinate with no live candidate.
+    UnknownCandidate {
+        /// Table ordinal.
+        table: usize,
+        /// Target anchor.
+        at: GridCoord,
+    },
+    /// Two specs target the same cell.
+    DuplicateTarget {
+        /// Table ordinal.
+        table: usize,
+        /// Duplicated anchor.
+        at: GridCoord,
+    },
+    /// A field spec has an empty name.
+    EmptyName,
+    /// A field spec has a blank hint.
+    BlankHint {
+        /// The offending field name.
+        name: String,
+    },
+    /// Two specs (cell or text) claim the same field name.
+    DuplicateName {
+        /// The duplicated name.
+        name: String,
+    },
+    /// A spec's name collides with an existing field in the document.
+    NameCollision {
+        /// The colliding name.
+        name: String,
+    },
+    /// An unguarded candidate has no spec — every candidate must be named
+    /// or explicitly ignored.
+    UncoveredCandidate {
+        /// Table ordinal.
+        table: usize,
+        /// Candidate anchor.
+        at: GridCoord,
+    },
+}
+
+impl std::fmt::Display for CellStampError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TableNotFound { table } => write!(f, "table ordinal {table} does not exist"),
+            Self::TableGridInvalid { table, detail } => {
+                write!(f, "table {table}: grid invalid: {detail}")
+            }
+            Self::NotAnAnchor { table, requested, anchor: Some(anchor) } => write!(
+                f,
+                "table {table}: ({},{}) is covered by the merge anchored at ({},{}) — specs must \
+                 target the anchor",
+                requested.row, requested.col, anchor.row, anchor.col
+            ),
+            Self::NotAnAnchor { table, requested, anchor: None } => write!(
+                f,
+                "table {table}: ({},{}) is outside the logical grid",
+                requested.row, requested.col
+            ),
+            Self::TargetNotStampable { table, at } => write!(
+                f,
+                "table {table}: cell ({},{}) is not a stampable empty cell",
+                at.row, at.col
+            ),
+            Self::LabelDrift { table, at, claimed, found } => write!(
+                f,
+                "table {table}: label claim {claimed:?} for ({},{}) no longer matches (found \
+                 {found:?})",
+                at.row, at.col
+            ),
+            Self::UnknownCandidate { table, at } => {
+                write!(f, "table {table}: ({},{}) is not a live candidate", at.row, at.col)
+            }
+            Self::DuplicateTarget { table, at } => {
+                write!(f, "table {table}: cell ({},{}) targeted twice", at.row, at.col)
+            }
+            Self::EmptyName => write!(f, "field name must not be empty"),
+            Self::BlankHint { name } => write!(f, "cell spec {name:?}: hint must not be blank"),
+            Self::DuplicateName { name } => write!(f, "duplicate field name {name:?}"),
+            Self::NameCollision { name } => {
+                write!(f, "field name {name:?} already exists in the document")
+            }
+            Self::UncoveredCandidate { table, at } => write!(
+                f,
+                "unguarded candidate at table {table} ({},{}) has no spec — name it or ignore it",
+                at.row, at.col
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CellStampError {}
+
+/// One fully-resolved pending edit (internal to preflight→commit).
+#[derive(Debug)]
+struct PlannedCellEdit {
+    table: usize,
+    row_idx: usize,
+    cell_idx: usize,
+    at: GridCoord,
+    name: String,
+    hint: String,
+    label: Option<CellLabelClaim>,
+}
+
+/// Everything [`commit_cells`] needs, produced against a pristine document.
+#[derive(Debug)]
+pub(crate) struct CellApplyPlan {
+    edits: Vec<PlannedCellEdit>,
+    ignored: usize,
+    skipped_guarded: Vec<CellStampCandidate>,
+}
+
+/// Preflights every cell spec against the CURRENT document state.
+///
+/// `reserved_names` carries field names claimed by class-A text specs in
+/// the same combined request so cross-class collisions fail here, before
+/// either class mutates.
+pub(crate) fn preflight_cells(
+    document: &mut Document<Draft>,
+    specs: &[CellStampSpec],
+    reserved_names: &HashSet<String>,
+) -> Result<CellApplyPlan, CellStampError> {
+    let plan = plan_cells(document);
+    let mut candidates: HashMap<(usize, GridCoord), &CellStampCandidate> = HashMap::new();
+    for candidate in &plan.candidates {
+        candidates.insert((candidate.table, candidate.at), candidate);
+    }
+    let skipped_grid: HashMap<usize, &str> =
+        plan.skipped_tables.iter().map(|s| (s.table, s.error.as_str())).collect();
+
+    // Existing field names (fill's visitor — the single definition of
+    // field-visit coverage).
+    let mut existing: HashSet<String> = HashSet::new();
+    for (idx, section) in document.sections_mut().iter_mut().enumerate() {
+        visit_section_fields(section, idx, &mut |slot| {
+            if let Control::Field { name: Some(name), .. } = &*slot.control {
+                existing.insert(name.clone());
+            }
+        });
+    }
+
+    let entries = tables_in_document(document);
+    let mut grids: HashMap<usize, TableGrid> = HashMap::new();
+
+    let mut edits = Vec::new();
+    let mut ignored = 0usize;
+    let mut covered: HashSet<(usize, GridCoord)> = HashSet::new();
+    let mut names: HashSet<String> = HashSet::new();
+
+    for spec in specs {
+        let Some(entry) = entries.get(spec.table) else {
+            return Err(CellStampError::TableNotFound { table: spec.table });
+        };
+        if let Some(detail) = skipped_grid.get(&spec.table) {
+            return Err(CellStampError::TableGridInvalid {
+                table: spec.table,
+                detail: (*detail).to_string(),
+            });
+        }
+        if let std::collections::hash_map::Entry::Vacant(slot) = grids.entry(spec.table) {
+            let grid = TableGrid::from_table(entry.table).map_err(|e| {
+                CellStampError::TableGridInvalid { table: spec.table, detail: e.to_string() }
+            })?;
+            slot.insert(grid);
+        }
+        let grid = &grids[&spec.table];
+
+        let Some(anchor) = grid.resolve(spec.at) else {
+            return Err(CellStampError::NotAnAnchor {
+                table: spec.table,
+                requested: spec.at,
+                anchor: None,
+            });
+        };
+        if anchor.anchor != spec.at {
+            return Err(CellStampError::NotAnAnchor {
+                table: spec.table,
+                requested: spec.at,
+                anchor: Some(anchor.anchor),
+            });
+        }
+        if !covered.insert((spec.table, spec.at)) {
+            return Err(CellStampError::DuplicateTarget { table: spec.table, at: spec.at });
+        }
+
+        let candidate = candidates.get(&(spec.table, spec.at));
+
+        // Label claim: must match a live candidate's label reference.
+        if let Some(claim) = &spec.label {
+            let claimed_norm = normalize_label(&claim.text);
+            let matched = candidate.is_some_and(|c| {
+                c.labels.iter().any(|l| l.at == claim.at && l.normalized == claimed_norm)
+            });
+            if !matched {
+                let found = candidate.map(|c| {
+                    c.labels.iter().map(|l| l.normalized.clone()).collect::<Vec<_>>().join(" | ")
+                });
+                return Err(CellStampError::LabelDrift {
+                    table: spec.table,
+                    at: spec.at,
+                    claimed: claim.text.clone(),
+                    found,
+                });
+            }
+        }
+
+        match &spec.action {
+            CellStampAction::Ignore => {
+                if candidate.is_none() {
+                    return Err(CellStampError::UnknownCandidate {
+                        table: spec.table,
+                        at: spec.at,
+                    });
+                }
+                ignored += 1;
+            }
+            CellStampAction::Field { name, hint } => {
+                // Explicit orphan targets are allowed without a candidate,
+                // but the cell itself must still be stampable.
+                let cell = &entry.table.rows[anchor.row_idx].cells[anchor.cell_idx];
+                if !is_stampable_empty(cell) {
+                    return Err(CellStampError::TargetNotStampable {
+                        table: spec.table,
+                        at: spec.at,
+                    });
+                }
+                if name.trim().is_empty() {
+                    return Err(CellStampError::EmptyName);
+                }
+                if hint.trim().is_empty() {
+                    return Err(CellStampError::BlankHint { name: name.clone() });
+                }
+                if !names.insert(name.clone()) || reserved_names.contains(name) {
+                    return Err(CellStampError::DuplicateName { name: name.clone() });
+                }
+                if existing.contains(name) {
+                    return Err(CellStampError::NameCollision { name: name.clone() });
+                }
+                edits.push(PlannedCellEdit {
+                    table: spec.table,
+                    row_idx: anchor.row_idx,
+                    cell_idx: anchor.cell_idx,
+                    at: spec.at,
+                    name: name.clone(),
+                    hint: hint.clone(),
+                    label: spec.label.clone(),
+                });
+            }
+        }
+    }
+
+    // Every unguarded candidate must be covered; uncovered guarded ones are
+    // skipped and reported.
+    let mut skipped_guarded = Vec::new();
+    for candidate in &plan.candidates {
+        if covered.contains(&(candidate.table, candidate.at)) {
+            continue;
+        }
+        if candidate.guarded {
+            skipped_guarded.push(candidate.clone());
+        } else {
+            return Err(CellStampError::UncoveredCandidate {
+                table: candidate.table,
+                at: candidate.at,
+            });
+        }
+    }
+
+    Ok(CellApplyPlan { edits, ignored, skipped_guarded })
+}
+
+/// Applies a preflighted [`CellApplyPlan`]. Mechanical: every invariant was
+/// checked by [`preflight_cells`] against the same document snapshot.
+pub(crate) fn commit_cells(
+    document: &mut Document<Draft>,
+    plan: CellApplyPlan,
+) -> CellStampOutcome {
+    let mut by_table: HashMap<usize, Vec<PlannedCellEdit>> = HashMap::new();
+    for edit in plan.edits {
+        by_table.entry(edit.table).or_default().push(edit);
+    }
+
+    let mut stamped = Vec::new();
+    for_each_table_mut(document, &mut |ordinal, table| {
+        let Some(edits) = by_table.remove(&ordinal) else {
+            return;
+        };
+        for edit in edits {
+            let paragraph = &mut table.rows[edit.row_idx].cells[edit.cell_idx].paragraphs[0];
+            let run = &mut paragraph.runs[0];
+            let original_text = run.content.as_text().unwrap_or_default().to_string();
+            let char_shape_id = run.char_shape_id;
+            *run = Run::control(
+                Control::Field {
+                    field_type: FieldType::ClickHere,
+                    hint_text: Some(edit.hint.clone()),
+                    help_text: None,
+                    name: Some(edit.name.clone()),
+                    display_text: edit.hint.clone(),
+                },
+                char_shape_id,
+            );
+            stamped.push(CellStampedField {
+                name: edit.name,
+                table: edit.table,
+                at: edit.at,
+                label: edit.label,
+                hint: edit.hint,
+                original_text,
+            });
+        }
+    });
+    // Spec order, not walk order: mirror class-A outcome semantics.
+    stamped.sort_by_key(|s| (s.table, s.at.row, s.at.col));
+
+    CellStampOutcome { stamped, ignored: plan.ignored, skipped_guarded: plan.skipped_guarded }
+}
+
+/// Standalone cell apply: preflight + commit, all-or-nothing.
+///
+/// # Errors
+///
+/// Any [`CellStampError`] leaves the document untouched.
+pub fn apply_cells(
+    document: &mut Document<Draft>,
+    specs: &[CellStampSpec],
+) -> Result<CellStampOutcome, CellStampError> {
+    let plan = preflight_cells(document, specs, &HashSet::new())?;
+    Ok(commit_cells(document, plan))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hwpforge_core::page::PageSettings;
+    use hwpforge_core::paragraph::Paragraph;
+    use hwpforge_core::run::RunContent;
+    use hwpforge_core::table::{Table, TableCell, TableRow};
+    use hwpforge_core::Section;
+    use hwpforge_foundation::{CharShapeIndex, HwpUnit, ParaShapeIndex};
+
+    fn text_cell_shaped(text: &str, shape: usize) -> TableCell {
+        TableCell::new(
+            vec![Paragraph::with_runs(
+                vec![Run::text(text, CharShapeIndex::new(shape))],
+                ParaShapeIndex::new(0),
+            )],
+            HwpUnit::ZERO,
+        )
+    }
+
+    fn text_cell(text: &str) -> TableCell {
+        text_cell_shaped(text, 0)
+    }
+
+    fn table(rows: Vec<Vec<TableCell>>) -> Table {
+        Table::new(rows.into_iter().map(TableRow::new).collect())
+    }
+
+    fn doc_with_tables(tables: Vec<Table>) -> Document {
+        let paras = tables
+            .into_iter()
+            .map(|t| {
+                Paragraph::with_runs(
+                    vec![Run {
+                        content: RunContent::Table(Box::new(t)),
+                        char_shape_id: CharShapeIndex::new(0),
+                    }],
+                    ParaShapeIndex::new(0),
+                )
+            })
+            .collect();
+        let mut doc = Document::new();
+        doc.add_section(Section::with_paragraphs(paras, PageSettings::default()));
+        doc
+    }
+
+    fn field_spec(table: usize, row: u32, col: u32, name: &str, hint: &str) -> CellStampSpec {
+        CellStampSpec {
+            table,
+            at: GridCoord::new(row, col),
+            label: None,
+            action: CellStampAction::Field { name: name.into(), hint: hint.into() },
+        }
+    }
+
+    fn labeled_spec(
+        table: usize,
+        row: u32,
+        col: u32,
+        label_at: (u32, u32),
+        label: &str,
+        name: &str,
+    ) -> CellStampSpec {
+        CellStampSpec {
+            table,
+            at: GridCoord::new(row, col),
+            label: Some(CellLabelClaim {
+                at: GridCoord::new(label_at.0, label_at.1),
+                text: label.into(),
+            }),
+            action: CellStampAction::Field { name: name.into(), hint: format!("{label} 입력") },
+        }
+    }
+
+    fn cell_text_at(doc: &Document<Draft>, row: usize, col: usize) -> String {
+        let section = &doc.sections()[0];
+        let RunContent::Table(t) = &section.paragraphs[0].runs[0].content else {
+            panic!("expected table");
+        };
+        t.rows[row].cells[col].paragraphs[0].text_content()
+    }
+
+    // ── happy paths ─────────────────────────────────────────────
+
+    #[test]
+    fn stamps_detected_candidate_and_preserves_char_shape() {
+        let t = table(vec![vec![text_cell("성명"), text_cell_shaped("", 7)]]);
+        let mut doc = doc_with_tables(vec![t]);
+        let outcome =
+            apply_cells(&mut doc, &[labeled_spec(0, 0, 1, (0, 0), "성명", "이름")]).unwrap();
+        assert_eq!(outcome.stamped.len(), 1);
+        let stamped = &outcome.stamped[0];
+        assert_eq!(stamped.name, "이름");
+        assert_eq!(stamped.original_text, "");
+
+        let section = &doc.sections()[0];
+        let RunContent::Table(t) = &section.paragraphs[0].runs[0].content else {
+            panic!("expected table");
+        };
+        let run = &t.rows[0].cells[1].paragraphs[0].runs[0];
+        assert_eq!(run.char_shape_id.get(), 7, "char shape must come from the target run");
+        let RunContent::Control(control) = &run.content else { panic!("expected field run") };
+        let Control::Field { name, display_text, hint_text, .. } = control.as_ref() else {
+            panic!("expected Field");
+        };
+        assert_eq!(name.as_deref(), Some("이름"));
+        assert_eq!(display_text, "성명 입력");
+        assert_eq!(hint_text.as_deref(), Some("성명 입력"));
+    }
+
+    #[test]
+    fn multi_paragraph_padding_keeps_paragraph_count_and_records_original() {
+        let padded = TableCell::new(
+            vec![
+                Paragraph::with_runs(
+                    vec![Run::text("\u{3000}", CharShapeIndex::new(3))],
+                    ParaShapeIndex::new(0),
+                ),
+                Paragraph::with_runs(
+                    vec![Run::text("", CharShapeIndex::new(3))],
+                    ParaShapeIndex::new(0),
+                ),
+            ],
+            HwpUnit::ZERO,
+        );
+        let t = table(vec![vec![text_cell("주소"), padded]]);
+        let mut doc = doc_with_tables(vec![t]);
+        let outcome = apply_cells(&mut doc, &[field_spec(0, 0, 1, "주소필드", "주소")]).unwrap();
+        assert_eq!(outcome.stamped[0].original_text, "\u{3000}");
+
+        let section = &doc.sections()[0];
+        let RunContent::Table(t) = &section.paragraphs[0].runs[0].content else {
+            panic!("expected table");
+        };
+        let cell = &t.rows[0].cells[1];
+        assert_eq!(cell.paragraphs.len(), 2, "padding paragraph must survive");
+        assert!(matches!(&cell.paragraphs[1].runs[0].content, RunContent::Text(t) if t.is_empty()));
+    }
+
+    #[test]
+    fn ignore_covers_candidate_and_guarded_skips_without_spec() {
+        let t = table(vec![
+            vec![text_cell("성명"), text_cell("")],
+            vec![text_cell("※ 기재 금지"), text_cell("")],
+        ]);
+        let mut doc = doc_with_tables(vec![t]);
+        let spec = CellStampSpec {
+            table: 0,
+            at: GridCoord::new(0, 1),
+            label: None,
+            action: CellStampAction::Ignore,
+        };
+        let outcome = apply_cells(&mut doc, &[spec]).unwrap();
+        assert_eq!(outcome.ignored, 1);
+        assert_eq!(outcome.skipped_guarded.len(), 1);
+        assert_eq!(outcome.skipped_guarded[0].at, GridCoord::new(1, 1));
+        assert_eq!(cell_text_at(&doc, 0, 1), "", "ignored cell untouched");
+    }
+
+    // ── preflight rejections (document untouched) ───────────────
+
+    fn assert_untouched(doc: &Document<Draft>, reference: &Document<Draft>) {
+        assert_eq!(doc, reference, "failed preflight must leave the document untouched");
+    }
+
+    #[test]
+    fn rejects_unknown_table_and_out_of_grid() {
+        let mut doc = doc_with_tables(vec![table(vec![vec![text_cell("성명"), text_cell("")]])]);
+        let reference = doc.clone();
+        let err = apply_cells(&mut doc, &[field_spec(9, 0, 1, "x", "h")]).unwrap_err();
+        assert!(matches!(err, CellStampError::TableNotFound { table: 9 }));
+        let err = apply_cells(&mut doc, &[field_spec(0, 5, 5, "x", "h")]).unwrap_err();
+        assert!(matches!(err, CellStampError::NotAnAnchor { anchor: None, .. }));
+        assert_untouched(&doc, &reference);
+    }
+
+    #[test]
+    fn rejects_covered_coordinate_with_anchor_pointer() {
+        // 병합 target: (0,1) rowspan 2 → (1,1) 은 covered.
+        let t = table(vec![
+            vec![
+                text_cell("비고"),
+                TableCell::with_span(
+                    vec![Paragraph::with_runs(
+                        vec![Run::text("", CharShapeIndex::new(0))],
+                        ParaShapeIndex::new(0),
+                    )],
+                    HwpUnit::ZERO,
+                    1,
+                    2,
+                ),
+            ],
+            vec![text_cell("이월")],
+        ]);
+        let mut doc = doc_with_tables(vec![t]);
+        let err = apply_cells(&mut doc, &[field_spec(0, 1, 1, "x", "h")]).unwrap_err();
+        match err {
+            CellStampError::NotAnAnchor { requested, anchor: Some(anchor), .. } => {
+                assert_eq!(requested, GridCoord::new(1, 1));
+                assert_eq!(anchor, GridCoord::new(0, 1));
+            }
+            other => panic!("expected covered rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_authored_target_and_label_drift() {
+        let t = table(vec![vec![text_cell("성명"), text_cell("홍길동")]]);
+        let mut doc = doc_with_tables(vec![table(vec![vec![text_cell("성명"), text_cell("")]])]);
+        // authored target
+        let mut doc2 = doc_with_tables(vec![t]);
+        let err = apply_cells(&mut doc2, &[field_spec(0, 0, 1, "x", "h")]).unwrap_err();
+        assert!(matches!(err, CellStampError::TargetNotStampable { .. }));
+
+        // label drift: claim says "전화번호" but the live label is "성명"
+        let err =
+            apply_cells(&mut doc, &[labeled_spec(0, 0, 1, (0, 0), "전화번호", "x")]).unwrap_err();
+        match err {
+            CellStampError::LabelDrift { claimed, found, .. } => {
+                assert_eq!(claimed, "전화번호");
+                assert_eq!(found.as_deref(), Some("성명"));
+            }
+            other => panic!("expected label drift, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn label_claim_matches_normalized_text() {
+        // 스펙이 raw "성 명"(공백 포함)을 claim 해도 normalize 매치로 통과.
+        let mut doc = doc_with_tables(vec![table(vec![vec![text_cell(" 성 명 "), text_cell("")]])]);
+        let outcome =
+            apply_cells(&mut doc, &[labeled_spec(0, 0, 1, (0, 0), "성 명", "성명필드")]).unwrap();
+        assert_eq!(outcome.stamped.len(), 1);
+    }
+
+    #[test]
+    fn rejects_duplicate_target_duplicate_name_and_existing_collision() {
+        let two =
+            table(vec![vec![text_cell("성명"), text_cell(""), text_cell("주소"), text_cell("")]]);
+        let mut doc = doc_with_tables(vec![two]);
+        let err =
+            apply_cells(&mut doc, &[field_spec(0, 0, 1, "a", "h"), field_spec(0, 0, 1, "b", "h")])
+                .unwrap_err();
+        assert!(matches!(err, CellStampError::DuplicateTarget { .. }));
+
+        let err = apply_cells(
+            &mut doc,
+            &[field_spec(0, 0, 1, "같음", "h"), field_spec(0, 0, 3, "같음", "h")],
+        )
+        .unwrap_err();
+        assert!(matches!(err, CellStampError::DuplicateName { .. }));
+
+        // existing ClickHere named "기존" in a body paragraph
+        let mut para = Paragraph::new(ParaShapeIndex::new(0));
+        para.add_run(Run::control(
+            Control::Field {
+                field_type: FieldType::ClickHere,
+                hint_text: Some("h".into()),
+                help_text: None,
+                name: Some("기존".into()),
+                display_text: "h".into(),
+            },
+            CharShapeIndex::new(0),
+        ));
+        doc.sections_mut()[0].paragraphs.push(para);
+        let err = apply_cells(
+            &mut doc,
+            &[field_spec(0, 0, 1, "기존", "h"), field_spec(0, 0, 3, "b", "h")],
+        )
+        .unwrap_err();
+        assert!(matches!(err, CellStampError::NameCollision { .. }));
+    }
+
+    #[test]
+    fn rejects_uncovered_unguarded_candidate() {
+        let two =
+            table(vec![vec![text_cell("성명"), text_cell(""), text_cell("주소"), text_cell("")]]);
+        let mut doc = doc_with_tables(vec![two]);
+        let reference = doc.clone();
+        let err = apply_cells(&mut doc, &[field_spec(0, 0, 1, "성명만", "h")]).unwrap_err();
+        match err {
+            CellStampError::UncoveredCandidate { table: 0, at } => {
+                assert_eq!(at, GridCoord::new(0, 3));
+            }
+            other => panic!("expected uncovered candidate, got {other:?}"),
+        }
+        assert_untouched(&doc, &reference);
+    }
+
+    #[test]
+    fn ignore_on_non_candidate_is_rejected() {
+        // orphan 빈 셀(라벨 없음)은 후보가 아니므로 ignore 할 것도 없다.
+        let t = table(vec![vec![text_cell(""), text_cell("성명"), text_cell("")]]);
+        // (0,0): 라벨이 오른쪽뿐 → orphan. (0,2): left 라벨 후보.
+        let mut doc = doc_with_tables(vec![t]);
+        let orphan_ignore = CellStampSpec {
+            table: 0,
+            at: GridCoord::new(0, 0),
+            label: None,
+            action: CellStampAction::Ignore,
+        };
+        let cover = field_spec(0, 0, 2, "성명값", "h");
+        let err = apply_cells(&mut doc, &[orphan_ignore, cover]).unwrap_err();
+        assert!(matches!(err, CellStampError::UnknownCandidate { .. }));
+    }
+
+    #[test]
+    fn explicit_orphan_field_spec_is_allowed() {
+        let t = table(vec![vec![text_cell(""), text_cell("성명"), text_cell("")]]);
+        let mut doc = doc_with_tables(vec![t]);
+        let orphan = field_spec(0, 0, 0, "머리빈칸", "값 입력");
+        let cover = field_spec(0, 0, 2, "성명값", "성명");
+        let outcome = apply_cells(&mut doc, &[orphan, cover]).unwrap();
+        assert_eq!(outcome.stamped.len(), 2);
+        assert_eq!(outcome.stamped[0].name, "머리빈칸");
+        assert!(outcome.stamped[0].label.is_none());
+    }
+
+    #[test]
+    fn reserved_names_from_text_specs_collide() {
+        let mut doc = doc_with_tables(vec![table(vec![vec![text_cell("성명"), text_cell("")]])]);
+        let reserved = HashSet::from(["겹침".to_string()]);
+        let err =
+            preflight_cells(&mut doc, &[field_spec(0, 0, 1, "겹침", "h")], &reserved).unwrap_err();
+        assert!(matches!(err, CellStampError::DuplicateName { .. }));
+    }
+}

--- a/crates/hwpforge-smithy-hwpx/src/stamp/cells.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/cells.rs
@@ -2,12 +2,14 @@
 //!
 //! Two definitions everything downstream (detect/plan/apply) builds on:
 //!
-//! - **Canonical empty**: a cell is a class-B target only when it is exactly
-//!   one paragraph holding exactly one empty `Text` run — the shape the HWPX
-//!   decoder produces for visually empty form cells (99.6% of empty cells in
-//!   the government-form corpus). Whitespace-only or multi-run cells are NOT
-//!   canonical; they carry authored content the delta gate cannot restore
-//!   losslessly.
+//! - **Stampable empty**: a cell is a class-B target only when every one of
+//!   its paragraphs is exactly one whitespace-only `Text` run — the shapes
+//!   native Hancom forms use for unfilled value cells (single empty run,
+//!   multi-empty-paragraph row-height padding, `U+3000` full-width-space
+//!   padding; blank-HPC exhibits all three across its 63 label→empty
+//!   pairs). Any authored text, extra run, or non-text content disqualifies
+//!   the cell — the delta gate must be able to restore the original
+//!   losslessly, and apply only ever replaces the first paragraph's run.
 //! - **Shared-boundary adjacency**: a label annotates a target when their
 //!   merged regions share a full grid edge, not when a single probed
 //!   coordinate matches — 44.8% of corpus label→empty pairs involve merged
@@ -20,12 +22,14 @@
 
 use std::collections::HashMap;
 
+use hwpforge_core::document::{Document, Draft};
 use hwpforge_core::run::RunContent;
 use hwpforge_core::table::grid::{GridCell, GridCoord, TableGrid};
 use hwpforge_core::table::{Table, TableCell};
 
 use super::detect::{paragraph_guard, GuardReason};
 use crate::cell_edit::normalize_label;
+use crate::table_inventory::{render_path, tables_in_document, TableEntry};
 
 /// Direction from a label cell to the class-B target it annotates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -57,17 +61,24 @@ pub struct LabelRef {
     pub duplicate_count: usize,
 }
 
-/// Returns `true` iff `cell` is a canonical empty class-B target: exactly one
-/// paragraph holding exactly one empty [`RunContent::Text`] run.
-#[allow(dead_code)] // consumed by the Wave 2A plan slice
-pub(crate) fn is_canonical_empty(cell: &TableCell) -> bool {
-    let [paragraph] = cell.paragraphs.as_slice() else {
-        return false;
-    };
-    let [run] = paragraph.runs.as_slice() else {
-        return false;
-    };
-    matches!(&run.content, RunContent::Text(text) if text.is_empty())
+/// Returns `true` iff `cell` is a stampable empty class-B target: at least
+/// one paragraph, and EVERY paragraph holds exactly one
+/// [`RunContent::Text`] run whose text is empty or Unicode whitespace.
+///
+/// Native Hancom forms pad value cells with multiple empty paragraphs (row
+/// height) and full-width spaces (`U+3000`) — blank-HPC has 17 multi-empty-
+/// paragraph and 3 `U+3000` value cells among its 63 label→empty pairs, so
+/// the stricter "exactly one `Text(\"\")` run" predicate covers only 70% of
+/// the acceptance fixture. Whitespace padding is not authored content: the
+/// apply phase replaces only the FIRST paragraph's run (geometry preserved)
+/// and the delta records the original run text verbatim, so reversal stays
+/// exact. Multi-run paragraphs and non-text content remain excluded.
+pub(crate) fn is_stampable_empty(cell: &TableCell) -> bool {
+    !cell.paragraphs.is_empty()
+        && cell.paragraphs.iter().all(|paragraph| {
+            matches!(paragraph.runs.as_slice(),
+                [run] if matches!(&run.content, RunContent::Text(text) if text.trim().is_empty()))
+        })
 }
 
 /// Raw cell text: all paragraph text joined with `\n` (no normalization).
@@ -90,7 +101,6 @@ fn raw_cell_text(table: &Table, cell: &GridCell) -> String {
 ///
 /// `duplicates` is the document-wide normalized-label tally (see
 /// [`tally_normalized_labels`]); unknown labels get `duplicate_count = 1`.
-#[allow(dead_code)] // consumed by the Wave 2A plan slice
 pub(crate) fn adjacent_labels(
     table: &Table,
     grid: &TableGrid,
@@ -137,7 +147,6 @@ pub(crate) fn adjacent_labels(
 
 /// Adds every non-empty normalized label text of `table` into `tally`
 /// (document-wide aggregation happens across tables at plan time).
-#[allow(dead_code)] // consumed by the Wave 2A plan slice
 pub(crate) fn tally_normalized_labels(
     table: &Table,
     grid: &TableGrid,
@@ -149,6 +158,131 @@ pub(crate) fn tally_normalized_labels(
             *tally.entry(normalized).or_insert(0) += 1;
         }
     }
+}
+
+/// One detected class-B candidate: a stampable empty cell with at least one
+/// adjacent label.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct CellStampCandidate {
+    /// Table ordinal (shared inventory DFS pre-order, across sections).
+    pub table: usize,
+    /// Section index the table lives in.
+    pub section: usize,
+    /// Canonical anchor coordinate of the empty target cell.
+    pub at: GridCoord,
+    /// Every adjacent label reference (`Left` before `Above`).
+    pub labels: Vec<LabelRef>,
+    /// True when every adjacent label is guarded: the candidate is never
+    /// auto-required in preflight and needs an explicit spec to be stamped
+    /// (mirrors class-A guarded semantics).
+    pub guarded: bool,
+    /// Normalized text of the preferred clean label (first `Left`, else
+    /// first `Above`), present only when unique in the document — a
+    /// grounded name suggestion, never applied automatically.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_name: Option<String>,
+    /// Raw text of the preferred clean label — a grounded hint suggestion,
+    /// never applied automatically.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_hint: Option<String>,
+}
+
+/// A table whose logical grid could not be built during [`plan_cells`] —
+/// reported as an explicit incomplete-coverage diagnostic, never silently
+/// skipped.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct SkippedTable {
+    /// Table ordinal (shared inventory DFS pre-order).
+    pub table: usize,
+    /// Serde-shaped path of the table (from the document root).
+    pub path: String,
+    /// Why the grid failed (first violation, human-readable).
+    pub error: String,
+}
+
+/// Result of class-B detection over a whole document.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct CellPlan {
+    /// Detected candidates in document order (table ordinal, then row-major
+    /// anchor order).
+    pub candidates: Vec<CellStampCandidate>,
+    /// Tables excluded from detection because their grid is invalid.
+    pub skipped_tables: Vec<SkippedTable>,
+}
+
+/// Enumerates class-B cell candidates across all tables of the document.
+///
+/// Read-only. A candidate is a [stampable empty](is_stampable_empty) anchor
+/// cell with at least one [adjacent label](adjacent_labels); orphan empty
+/// cells (53% in the government-form corpus — matrix interiors and spacers)
+/// are NOT candidates and can only be targeted by explicit specs. Tables
+/// whose grid cannot be built are reported in
+/// [`skipped_tables`](CellPlan::skipped_tables).
+pub fn plan_cells(document: &Document<Draft>) -> CellPlan {
+    let entries = tables_in_document(document);
+
+    // Pass 1: per-table grids + the document-wide normalized-label tally.
+    let mut grids: Vec<Option<TableGrid>> = Vec::with_capacity(entries.len());
+    let mut skipped_tables = Vec::new();
+    let mut tally = HashMap::new();
+    for entry in &entries {
+        match TableGrid::from_table(entry.table) {
+            Ok(grid) => {
+                tally_normalized_labels(entry.table, &grid, &mut tally);
+                grids.push(Some(grid));
+            }
+            Err(error) => {
+                skipped_tables.push(SkippedTable {
+                    table: entry.ordinal,
+                    path: table_path(entry),
+                    error: error.to_string(),
+                });
+                grids.push(None);
+            }
+        }
+    }
+
+    // Pass 2: canonical empty anchors with adjacent labels become candidates.
+    let mut candidates = Vec::new();
+    for (entry, grid) in entries.iter().zip(&grids) {
+        let Some(grid) = grid else {
+            continue;
+        };
+        for anchor in grid.iter_anchors() {
+            let cell = &entry.table.rows[anchor.row_idx].cells[anchor.cell_idx];
+            if !is_stampable_empty(cell) {
+                continue;
+            }
+            let labels = adjacent_labels(entry.table, grid, anchor, &tally);
+            if labels.is_empty() {
+                continue;
+            }
+            let guarded = labels.iter().all(|label| label.guard.is_some());
+            let preferred = labels.iter().find(|label| label.guard.is_none());
+            let suggested_name = preferred
+                .filter(|label| label.duplicate_count == 1)
+                .map(|label| label.normalized.clone());
+            let suggested_hint = preferred.map(|label| label.raw.clone());
+            candidates.push(CellStampCandidate {
+                table: entry.ordinal,
+                section: entry.section,
+                at: anchor.anchor,
+                labels,
+                guarded,
+                suggested_name,
+                suggested_hint,
+            });
+        }
+    }
+
+    CellPlan { candidates, skipped_tables }
+}
+
+fn table_path(entry: &TableEntry<'_>) -> String {
+    format!("sections[{}].{}", entry.section, render_path("", &entry.path))
 }
 
 #[cfg(test)]
@@ -189,21 +323,48 @@ mod tests {
         *grid.resolve(GridCoord::new(row, col)).expect("anchor")
     }
 
-    // ── canonical empty ─────────────────────────────────────────
+    // ── stampable empty ─────────────────────────────────────────
 
     #[test]
-    fn canonical_empty_accepts_single_empty_text_run() {
-        assert!(is_canonical_empty(&text_cell("")));
+    fn stampable_empty_accepts_single_empty_text_run() {
+        assert!(is_stampable_empty(&text_cell("")));
     }
 
     #[test]
-    fn canonical_empty_rejects_whitespace_text() {
-        assert!(!is_canonical_empty(&text_cell("  ")));
-        assert!(!is_canonical_empty(&text_cell("성명")));
+    fn stampable_empty_accepts_whitespace_padding_but_not_text() {
+        // 네이티브 한컴 양식은 값 칸을 전각 공백(U+3000)으로 패딩한다.
+        assert!(is_stampable_empty(&text_cell("  ")));
+        assert!(is_stampable_empty(&text_cell("\u{3000}")));
+        assert!(!is_stampable_empty(&text_cell("성명")));
     }
 
     #[test]
-    fn canonical_empty_rejects_multiple_runs() {
+    fn stampable_empty_accepts_multi_empty_paragraph_cell() {
+        // blank-HPC 쌍 63개 중 17개가 이 모양 (빈 문단 여러 개 = 행 높이).
+        let paragraph = |text: &str| {
+            Paragraph::with_runs(
+                vec![Run::text(text, CharShapeIndex::new(0))],
+                ParaShapeIndex::new(0),
+            )
+        };
+        let cell = TableCell::new(
+            vec![paragraph(""), paragraph("\u{3000}"), paragraph("")],
+            HwpUnit::ZERO,
+        );
+        assert!(is_stampable_empty(&cell));
+
+        let with_text = TableCell::new(vec![paragraph(""), paragraph("메모")], HwpUnit::ZERO);
+        assert!(!is_stampable_empty(&with_text));
+    }
+
+    #[test]
+    fn stampable_empty_rejects_zero_paragraphs() {
+        let cell = TableCell::new(vec![], HwpUnit::ZERO);
+        assert!(!is_stampable_empty(&cell));
+    }
+
+    #[test]
+    fn stampable_empty_rejects_multiple_runs() {
         let cell = TableCell::new(
             vec![Paragraph::with_runs(
                 vec![Run::text("", CharShapeIndex::new(0)), Run::text("", CharShapeIndex::new(1))],
@@ -211,23 +372,11 @@ mod tests {
             )],
             HwpUnit::ZERO,
         );
-        assert!(!is_canonical_empty(&cell));
+        assert!(!is_stampable_empty(&cell));
     }
 
     #[test]
-    fn canonical_empty_rejects_multiple_paragraphs() {
-        let paragraph = || {
-            Paragraph::with_runs(
-                vec![Run::text("", CharShapeIndex::new(0))],
-                ParaShapeIndex::new(0),
-            )
-        };
-        let cell = TableCell::new(vec![paragraph(), paragraph()], HwpUnit::ZERO);
-        assert!(!is_canonical_empty(&cell));
-    }
-
-    #[test]
-    fn canonical_empty_rejects_non_text_content() {
+    fn stampable_empty_rejects_non_text_content() {
         let nested = Run {
             content: RunContent::Table(Box::new(table(vec![vec![text_cell("")]]))),
             char_shape_id: CharShapeIndex::new(0),
@@ -236,7 +385,7 @@ mod tests {
             vec![Paragraph::with_runs(vec![nested], ParaShapeIndex::new(0))],
             HwpUnit::ZERO,
         );
-        assert!(!is_canonical_empty(&cell));
+        assert!(!is_stampable_empty(&cell));
     }
 
     // ── shared-boundary adjacency ───────────────────────────────
@@ -339,6 +488,161 @@ mod tests {
 
         let refs = adjacent_labels(&t, &grid, &target, &HashMap::new());
         assert_eq!(refs[0].duplicate_count, 1);
+    }
+
+    // ── plan_cells ──────────────────────────────────────────────
+
+    use hwpforge_core::page::PageSettings;
+    use hwpforge_core::{Control, Section};
+    use hwpforge_foundation::FieldType;
+
+    fn table_run(t: Table) -> Run {
+        Run { content: RunContent::Table(Box::new(t)), char_shape_id: CharShapeIndex::new(0) }
+    }
+
+    fn doc_with_tables(tables: Vec<Table>) -> hwpforge_core::Document {
+        let paras = tables
+            .into_iter()
+            .map(|t| Paragraph::with_runs(vec![table_run(t)], ParaShapeIndex::new(0)))
+            .collect();
+        let mut doc = hwpforge_core::Document::new();
+        doc.add_section(Section::with_paragraphs(paras, PageSettings::default()));
+        doc
+    }
+
+    #[test]
+    fn plan_cells_empty_document_is_empty() {
+        let plan = plan_cells(&hwpforge_core::Document::new());
+        assert!(plan.candidates.is_empty());
+        assert!(plan.skipped_tables.is_empty());
+    }
+
+    #[test]
+    fn plan_cells_detects_left_labeled_empty_cell() {
+        let doc = doc_with_tables(vec![table(vec![vec![text_cell("성명"), text_cell("")]])]);
+        let plan = plan_cells(&doc);
+        assert!(plan.skipped_tables.is_empty());
+        assert_eq!(plan.candidates.len(), 1);
+        let c = &plan.candidates[0];
+        assert_eq!((c.table, c.section), (0, 0));
+        assert_eq!(c.at, GridCoord::new(0, 1));
+        assert_eq!(c.labels.len(), 1);
+        assert!(!c.guarded);
+        assert_eq!(c.suggested_name.as_deref(), Some("성명"));
+        assert_eq!(c.suggested_hint.as_deref(), Some("성명"));
+    }
+
+    #[test]
+    fn plan_cells_duplicate_label_suppresses_suggested_name_only() {
+        let make = || table(vec![vec![text_cell("성명"), text_cell("")]]);
+        let doc = doc_with_tables(vec![make(), make()]);
+        let plan = plan_cells(&doc);
+        assert_eq!(plan.candidates.len(), 2);
+        for c in &plan.candidates {
+            assert_eq!(c.labels[0].duplicate_count, 2);
+            assert_eq!(c.suggested_name, None);
+            assert_eq!(c.suggested_hint.as_deref(), Some("성명"));
+        }
+    }
+
+    #[test]
+    fn plan_cells_fully_guarded_candidate_has_no_suggestions() {
+        let doc = doc_with_tables(vec![table(vec![vec![
+            text_cell("※ 이 난은 기재하지 마십시오"),
+            text_cell(""),
+        ]])]);
+        let plan = plan_cells(&doc);
+        assert_eq!(plan.candidates.len(), 1);
+        let c = &plan.candidates[0];
+        assert!(c.guarded);
+        assert_eq!(c.suggested_name, None);
+        assert_eq!(c.suggested_hint, None);
+    }
+
+    #[test]
+    fn plan_cells_mixed_guard_prefers_clean_label() {
+        // left = guarded 안내문, above = clean 라벨 → guarded=false 이고
+        // 제안은 clean 라벨에서 나온다.
+        let doc = doc_with_tables(vec![table(vec![
+            vec![text_cell("제목"), text_cell("성명")],
+            vec![text_cell("※ 안내"), text_cell("")],
+        ])]);
+        let plan = plan_cells(&doc);
+        assert_eq!(plan.candidates.len(), 1);
+        let c = &plan.candidates[0];
+        assert!(!c.guarded);
+        assert_eq!(c.labels.len(), 2);
+        assert_eq!(c.suggested_name.as_deref(), Some("성명"));
+        assert_eq!(c.suggested_hint.as_deref(), Some("성명"));
+    }
+
+    #[test]
+    fn plan_cells_invalid_grid_is_reported_not_silently_skipped() {
+        // 표 A = ragged (2행이 1셀뿐, hole → NotTiled), 표 B = 정상.
+        let ragged = table(vec![vec![text_cell("성명"), text_cell("")], vec![text_cell("주소")]]);
+        let ok = table(vec![vec![text_cell("기관명"), text_cell("")]]);
+        let doc = doc_with_tables(vec![ragged, ok]);
+        let plan = plan_cells(&doc);
+        assert_eq!(plan.skipped_tables.len(), 1);
+        assert_eq!(plan.skipped_tables[0].table, 0);
+        assert!(plan.skipped_tables[0].path.contains("sections[0]"));
+        assert!(!plan.skipped_tables[0].error.is_empty());
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].table, 1);
+    }
+
+    #[test]
+    fn plan_cells_orphan_and_authored_cells_are_not_candidates() {
+        // (0,0) 빈 셀은 라벨이 오른쪽에만 있음(orphan) · (1,1) 은 authored 텍스트.
+        let doc = doc_with_tables(vec![table(vec![
+            vec![text_cell(""), text_cell("성명")],
+            vec![text_cell("주소"), text_cell("기입됨")],
+        ])]);
+        assert!(plan_cells(&doc).candidates.is_empty());
+    }
+
+    #[test]
+    fn plan_cells_whitespace_padded_cell_is_a_candidate() {
+        // 전각 공백 패딩 칸(blank-HPC t3 실물 패턴)도 자동 후보다.
+        let doc =
+            doc_with_tables(vec![table(vec![vec![text_cell("성명"), text_cell("\u{3000}")]])]);
+        let plan = plan_cells(&doc);
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].at, GridCoord::new(0, 1));
+    }
+
+    #[test]
+    fn plan_cells_nested_table_gets_its_own_ordinal() {
+        let inner = table(vec![vec![text_cell("항목"), text_cell("")]]);
+        let outer_cell = TableCell::new(
+            vec![Paragraph::with_runs(vec![table_run(inner)], ParaShapeIndex::new(0))],
+            HwpUnit::ZERO,
+        );
+        let outer = Table::new(vec![TableRow::new(vec![outer_cell])]);
+        let doc = doc_with_tables(vec![outer]);
+        let plan = plan_cells(&doc);
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].table, 1); // DFS pre-order: outer=0, inner=1
+        assert_eq!(plan.candidates[0].at, GridCoord::new(0, 1));
+    }
+
+    #[test]
+    fn plan_cells_existing_clickhere_cell_is_not_a_candidate() {
+        let mut para = Paragraph::new(ParaShapeIndex::new(0));
+        para.add_run(Run::control(
+            Control::Field {
+                field_type: FieldType::ClickHere,
+                hint_text: Some("힌트".to_string()),
+                help_text: None,
+                name: Some("이미승격".to_string()),
+                display_text: "힌트".to_string(),
+            },
+            CharShapeIndex::new(0),
+        ));
+        let field_cell = TableCell::new(vec![para], HwpUnit::ZERO);
+        let t = Table::new(vec![TableRow::new(vec![text_cell("성명"), field_cell])]);
+        let doc = doc_with_tables(vec![t]);
+        assert!(plan_cells(&doc).candidates.is_empty());
     }
 
     #[test]

--- a/crates/hwpforge-smithy-hwpx/src/stamp/cells.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/cells.rs
@@ -1,0 +1,357 @@
+//! Class-B (cell-position) stamping primitives — Wave 2, P0-ⓒ.
+//!
+//! Two definitions everything downstream (detect/plan/apply) builds on:
+//!
+//! - **Canonical empty**: a cell is a class-B target only when it is exactly
+//!   one paragraph holding exactly one empty `Text` run — the shape the HWPX
+//!   decoder produces for visually empty form cells (99.6% of empty cells in
+//!   the government-form corpus). Whitespace-only or multi-run cells are NOT
+//!   canonical; they carry authored content the delta gate cannot restore
+//!   losslessly.
+//! - **Shared-boundary adjacency**: a label annotates a target when their
+//!   merged regions share a full grid edge, not when a single probed
+//!   coordinate matches — 44.8% of corpus label→empty pairs involve merged
+//!   cells, and a merged target can touch several labels along one edge.
+//!
+//! Guards are evaluated **per label reference** (a guarded left label must
+//! not demote a clean above label), and `duplicate_count` carries the
+//! document-wide normalized-label tally so callers can see when a suggested
+//! name is ambiguous (94% of corpus documents repeat at least one label).
+
+use std::collections::HashMap;
+
+use hwpforge_core::run::RunContent;
+use hwpforge_core::table::grid::{GridCell, GridCoord, TableGrid};
+use hwpforge_core::table::{Table, TableCell};
+
+use super::detect::{paragraph_guard, GuardReason};
+use crate::cell_edit::normalize_label;
+
+/// Direction from a label cell to the class-B target it annotates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum LabelDirection {
+    /// The label's region ends exactly at the target's left edge.
+    Left,
+    /// The label's region ends exactly at the target's top edge.
+    Above,
+}
+
+/// One label cell adjacent to a class-B target along a shared grid boundary.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct LabelRef {
+    /// Which edge of the target this label touches.
+    pub direction: LabelDirection,
+    /// Anchor coordinate of the label cell.
+    pub at: GridCoord,
+    /// Raw label text (paragraphs joined with `\n`, un-normalized).
+    pub raw: String,
+    /// Normalized label text (NFC + whitespace collapse) — the identity used
+    /// for duplicate counting and drift re-verification.
+    pub normalized: String,
+    /// Instruction-context guard for THIS label reference only.
+    pub guard: Option<GuardReason>,
+    /// Document-wide occurrence count of `normalized` among label cells.
+    pub duplicate_count: usize,
+}
+
+/// Returns `true` iff `cell` is a canonical empty class-B target: exactly one
+/// paragraph holding exactly one empty [`RunContent::Text`] run.
+#[allow(dead_code)] // consumed by the Wave 2A plan slice
+pub(crate) fn is_canonical_empty(cell: &TableCell) -> bool {
+    let [paragraph] = cell.paragraphs.as_slice() else {
+        return false;
+    };
+    let [run] = paragraph.runs.as_slice() else {
+        return false;
+    };
+    matches!(&run.content, RunContent::Text(text) if text.is_empty())
+}
+
+/// Raw cell text: all paragraph text joined with `\n` (no normalization).
+fn raw_cell_text(table: &Table, cell: &GridCell) -> String {
+    table.rows[cell.row_idx].cells[cell.cell_idx]
+        .paragraphs
+        .iter()
+        .map(|p| p.text_content())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Collects every label cell adjacent to `target` along a shared grid edge.
+///
+/// A neighbor qualifies as a label when its normalized text is non-empty.
+/// `Left` labels are regions whose column range ends exactly at the target's
+/// left edge with overlapping row ranges; `Above` labels end exactly at the
+/// target's top edge with overlapping column ranges. Results are ordered
+/// `Left` before `Above`, each group by ascending `(row, col)`.
+///
+/// `duplicates` is the document-wide normalized-label tally (see
+/// [`tally_normalized_labels`]); unknown labels get `duplicate_count = 1`.
+#[allow(dead_code)] // consumed by the Wave 2A plan slice
+pub(crate) fn adjacent_labels(
+    table: &Table,
+    grid: &TableGrid,
+    target: &GridCell,
+    duplicates: &HashMap<String, usize>,
+) -> Vec<LabelRef> {
+    let t_row = target.anchor.row;
+    let t_col = target.anchor.col;
+    let t_row_end = t_row + u32::from(target.row_span);
+    let t_col_end = t_col + u32::from(target.col_span);
+
+    let mut refs = Vec::new();
+    for label in grid.iter_anchors() {
+        let l_row_end = label.anchor.row + u32::from(label.row_span);
+        let l_col_end = label.anchor.col + u32::from(label.col_span);
+
+        let direction = if l_col_end == t_col && label.anchor.row < t_row_end && t_row < l_row_end {
+            LabelDirection::Left
+        } else if l_row_end == t_row && label.anchor.col < t_col_end && t_col < l_col_end {
+            LabelDirection::Above
+        } else {
+            continue;
+        };
+
+        let raw = raw_cell_text(table, label);
+        let normalized = normalize_label(&raw);
+        if normalized.is_empty() {
+            continue;
+        }
+        let duplicate_count = duplicates.get(&normalized).copied().unwrap_or(1);
+        let guard = paragraph_guard(&raw);
+        refs.push(LabelRef {
+            direction,
+            at: label.anchor,
+            raw,
+            normalized,
+            guard,
+            duplicate_count,
+        });
+    }
+    refs.sort_by_key(|r| (r.direction == LabelDirection::Above, r.at.row, r.at.col));
+    refs
+}
+
+/// Adds every non-empty normalized label text of `table` into `tally`
+/// (document-wide aggregation happens across tables at plan time).
+#[allow(dead_code)] // consumed by the Wave 2A plan slice
+pub(crate) fn tally_normalized_labels(
+    table: &Table,
+    grid: &TableGrid,
+    tally: &mut HashMap<String, usize>,
+) {
+    for anchor in grid.iter_anchors() {
+        let normalized = normalize_label(&raw_cell_text(table, anchor));
+        if !normalized.is_empty() {
+            *tally.entry(normalized).or_insert(0) += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hwpforge_core::paragraph::Paragraph;
+    use hwpforge_core::run::Run;
+    use hwpforge_core::table::TableRow;
+    use hwpforge_foundation::{CharShapeIndex, HwpUnit, ParaShapeIndex};
+
+    fn text_cell(text: &str) -> TableCell {
+        TableCell::new(
+            vec![Paragraph::with_runs(
+                vec![Run::text(text, CharShapeIndex::new(0))],
+                ParaShapeIndex::new(0),
+            )],
+            HwpUnit::ZERO,
+        )
+    }
+
+    fn spanned_cell(text: &str, col_span: u16, row_span: u16) -> TableCell {
+        TableCell::with_span(
+            vec![Paragraph::with_runs(
+                vec![Run::text(text, CharShapeIndex::new(0))],
+                ParaShapeIndex::new(0),
+            )],
+            HwpUnit::ZERO,
+            col_span,
+            row_span,
+        )
+    }
+
+    fn table(rows: Vec<Vec<TableCell>>) -> Table {
+        Table::new(rows.into_iter().map(TableRow::new).collect())
+    }
+
+    fn anchor_at(grid: &TableGrid, row: u32, col: u32) -> GridCell {
+        *grid.resolve(GridCoord::new(row, col)).expect("anchor")
+    }
+
+    // ── canonical empty ─────────────────────────────────────────
+
+    #[test]
+    fn canonical_empty_accepts_single_empty_text_run() {
+        assert!(is_canonical_empty(&text_cell("")));
+    }
+
+    #[test]
+    fn canonical_empty_rejects_whitespace_text() {
+        assert!(!is_canonical_empty(&text_cell("  ")));
+        assert!(!is_canonical_empty(&text_cell("성명")));
+    }
+
+    #[test]
+    fn canonical_empty_rejects_multiple_runs() {
+        let cell = TableCell::new(
+            vec![Paragraph::with_runs(
+                vec![Run::text("", CharShapeIndex::new(0)), Run::text("", CharShapeIndex::new(1))],
+                ParaShapeIndex::new(0),
+            )],
+            HwpUnit::ZERO,
+        );
+        assert!(!is_canonical_empty(&cell));
+    }
+
+    #[test]
+    fn canonical_empty_rejects_multiple_paragraphs() {
+        let paragraph = || {
+            Paragraph::with_runs(
+                vec![Run::text("", CharShapeIndex::new(0))],
+                ParaShapeIndex::new(0),
+            )
+        };
+        let cell = TableCell::new(vec![paragraph(), paragraph()], HwpUnit::ZERO);
+        assert!(!is_canonical_empty(&cell));
+    }
+
+    #[test]
+    fn canonical_empty_rejects_non_text_content() {
+        let nested = Run {
+            content: RunContent::Table(Box::new(table(vec![vec![text_cell("")]]))),
+            char_shape_id: CharShapeIndex::new(0),
+        };
+        let cell = TableCell::new(
+            vec![Paragraph::with_runs(vec![nested], ParaShapeIndex::new(0))],
+            HwpUnit::ZERO,
+        );
+        assert!(!is_canonical_empty(&cell));
+    }
+
+    // ── shared-boundary adjacency ───────────────────────────────
+
+    #[test]
+    fn left_and_above_labels_found() {
+        // ┌────────┬────────┐
+        // │ 제목    │ 성명    │
+        // ├────────┼────────┤
+        // │ 주소    │ (빈칸)  │
+        // └────────┴────────┘
+        let t = table(vec![
+            vec![text_cell("제목"), text_cell("성명")],
+            vec![text_cell("주소"), text_cell("")],
+        ]);
+        let grid = TableGrid::from_table(&t).unwrap();
+        let target = anchor_at(&grid, 1, 1);
+        let refs = adjacent_labels(&t, &grid, &target, &HashMap::new());
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].direction, LabelDirection::Left);
+        assert_eq!(refs[0].normalized, "주소");
+        assert_eq!(refs[0].at, GridCoord::new(1, 0));
+        assert_eq!(refs[1].direction, LabelDirection::Above);
+        assert_eq!(refs[1].normalized, "성명");
+        assert_eq!(refs[1].at, GridCoord::new(0, 1));
+    }
+
+    #[test]
+    fn merged_label_reaches_every_row_it_borders() {
+        // ┌────────┬────────┐
+        // │ 비고    │ (빈칸A) │
+        // │ (r2)   ├────────┤
+        // │        │ (빈칸B) │
+        // └────────┴────────┘
+        let t = table(vec![vec![spanned_cell("비고", 1, 2), text_cell("")], vec![text_cell("")]]);
+        let grid = TableGrid::from_table(&t).unwrap();
+        for row in 0..2 {
+            let target = anchor_at(&grid, row, 1);
+            let refs = adjacent_labels(&t, &grid, &target, &HashMap::new());
+            assert_eq!(refs.len(), 1, "row {row}");
+            assert_eq!(refs[0].direction, LabelDirection::Left);
+            assert_eq!(refs[0].normalized, "비고");
+        }
+    }
+
+    #[test]
+    fn merged_target_collects_multiple_left_labels() {
+        // ┌────────┬────────┐
+        // │ 성명    │ (빈칸   │
+        // ├────────┤  r2)   │
+        // │ 주소    │        │
+        // └────────┴────────┘
+        let t =
+            table(vec![vec![text_cell("성명"), spanned_cell("", 1, 2)], vec![text_cell("주소")]]);
+        let grid = TableGrid::from_table(&t).unwrap();
+        let target = anchor_at(&grid, 0, 1);
+        let refs = adjacent_labels(&t, &grid, &target, &HashMap::new());
+        assert_eq!(refs.len(), 2);
+        assert_eq!(
+            refs.iter().map(|r| r.normalized.as_str()).collect::<Vec<_>>(),
+            vec!["성명", "주소"],
+        );
+        assert!(refs.iter().all(|r| r.direction == LabelDirection::Left));
+    }
+
+    #[test]
+    fn non_touching_and_empty_neighbors_are_not_labels() {
+        // 라벨과 target 사이에 빈 셀이 끼면 인접이 아니다.
+        let t = table(vec![vec![text_cell("성명"), text_cell(""), text_cell("")]]);
+        let grid = TableGrid::from_table(&t).unwrap();
+        let target = anchor_at(&grid, 0, 2);
+        assert!(adjacent_labels(&t, &grid, &target, &HashMap::new()).is_empty());
+    }
+
+    #[test]
+    fn guard_is_evaluated_per_label_reference() {
+        // left = 안내문 라벨(guarded), above = 정상 라벨(clean).
+        let t = table(vec![
+            vec![text_cell("제목"), text_cell("성명")],
+            vec![text_cell("※ 아래 빈칸은 기재하지 마십시오"), text_cell("")],
+        ]);
+        let grid = TableGrid::from_table(&t).unwrap();
+        let target = anchor_at(&grid, 1, 1);
+        let refs = adjacent_labels(&t, &grid, &target, &HashMap::new());
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].direction, LabelDirection::Left);
+        assert_eq!(refs[0].guard, Some(GuardReason::InstructionContext));
+        assert_eq!(refs[1].direction, LabelDirection::Above);
+        assert_eq!(refs[1].guard, None);
+    }
+
+    #[test]
+    fn duplicate_count_comes_from_document_tally() {
+        let t = table(vec![vec![text_cell("과제명"), text_cell("")]]);
+        let grid = TableGrid::from_table(&t).unwrap();
+        let target = anchor_at(&grid, 0, 1);
+        let tally = HashMap::from([("과제명".to_string(), 3)]);
+        let refs = adjacent_labels(&t, &grid, &target, &tally);
+        assert_eq!(refs[0].duplicate_count, 3);
+
+        let refs = adjacent_labels(&t, &grid, &target, &HashMap::new());
+        assert_eq!(refs[0].duplicate_count, 1);
+    }
+
+    #[test]
+    fn tally_counts_normalized_labels_per_table() {
+        let t = table(vec![
+            vec![text_cell(" 성명 "), text_cell("성명")],
+            vec![text_cell("주소"), text_cell("")],
+        ]);
+        let grid = TableGrid::from_table(&t).unwrap();
+        let mut tally = HashMap::new();
+        tally_normalized_labels(&t, &grid, &mut tally);
+        assert_eq!(tally.get("성명"), Some(&2));
+        assert_eq!(tally.get("주소"), Some(&1));
+        assert_eq!(tally.len(), 2);
+    }
+}

--- a/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
@@ -23,7 +23,7 @@ mod request;
 mod stamper;
 
 pub use apply::{apply, StampAction, StampError, StampOutcome, StampSpec, StampedField};
-pub use cells::{LabelDirection, LabelRef};
+pub use cells::{plan_cells, CellPlan, CellStampCandidate, LabelDirection, LabelRef, SkippedTable};
 pub use detect::{detect_markers, paragraph_guard, BuiltinPattern, GuardReason, MarkerHit};
 pub use plan::{plan, StampCandidate};
 pub use request::{

--- a/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
@@ -16,6 +16,7 @@
 //!   plan preflights, then applies atomically
 
 mod apply;
+mod apply_cells;
 mod cells;
 mod detect;
 mod plan;
@@ -23,6 +24,7 @@ mod request;
 mod stamper;
 
 pub use apply::{apply, StampAction, StampError, StampOutcome, StampSpec, StampedField};
+pub use apply_cells::{apply_cells, CellStampError, CellStampOutcome, CellStampedField};
 pub use cells::{plan_cells, CellPlan, CellStampCandidate, LabelDirection, LabelRef, SkippedTable};
 pub use detect::{detect_markers, paragraph_guard, BuiltinPattern, GuardReason, MarkerHit};
 pub use plan::{plan, StampCandidate};
@@ -35,6 +37,7 @@ pub use request::{
 // fail-closed contract.
 pub(crate) use stamper::{admission_compare, check_zip_carry, encode_hwpx};
 pub use stamper::{
-    HwpxStamper, ManifestField, StampManifest, StampMeta, StampResult, StamperError,
-    STAMP_MANIFEST_VERSION,
+    HwpxStamper, ManifestField, ManifestFieldV2, StampManifest, StampManifestV2, StampMeta,
+    StampOriginV2, StampOutcomeV2, StampResult, StampResultV2, StamperError,
+    STAMP_MANIFEST_V2_VERSION, STAMP_MANIFEST_VERSION,
 };

--- a/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
@@ -19,12 +19,17 @@ mod apply;
 mod cells;
 mod detect;
 mod plan;
+mod request;
 mod stamper;
 
 pub use apply::{apply, StampAction, StampError, StampOutcome, StampSpec, StampedField};
 pub use cells::{LabelDirection, LabelRef};
 pub use detect::{detect_markers, paragraph_guard, BuiltinPattern, GuardReason, MarkerHit};
 pub use plan::{plan, StampCandidate};
+pub use request::{
+    parse_stamp_map, CellLabelClaim, CellStampAction, CellStampSpec, StampMap, StampMapError,
+    StampRequestV2, STAMP_MAP_VERSION,
+};
 // E3 cell editing reuses the stamp admission gate (decode→encode→decode
 // no-op equality + ZIP closed-world) so both mutation facades share one
 // fail-closed contract.

--- a/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
@@ -38,6 +38,6 @@ pub use request::{
 pub(crate) use stamper::{admission_compare, check_zip_carry, encode_hwpx};
 pub use stamper::{
     HwpxStamper, ManifestField, ManifestFieldV2, StampManifest, StampManifestV2, StampMeta,
-    StampOriginV2, StampOutcomeV2, StampResult, StampResultV2, StamperError,
+    StampOriginV2, StampOutcomeV2, StampPlanV2, StampResult, StampResultV2, StamperError,
     STAMP_MANIFEST_V2_VERSION, STAMP_MANIFEST_VERSION,
 };

--- a/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/mod.rs
@@ -16,11 +16,13 @@
 //!   plan preflights, then applies atomically
 
 mod apply;
+mod cells;
 mod detect;
 mod plan;
 mod stamper;
 
 pub use apply::{apply, StampAction, StampError, StampOutcome, StampSpec, StampedField};
+pub use cells::{LabelDirection, LabelRef};
 pub use detect::{detect_markers, paragraph_guard, BuiltinPattern, GuardReason, MarkerHit};
 pub use plan::{plan, StampCandidate};
 // E3 cell editing reuses the stamp admission gate (decode→encode→decode

--- a/crates/hwpforge-smithy-hwpx/src/stamp/request.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/request.rs
@@ -1,0 +1,372 @@
+//! Stamp map v2 envelope — Wave 2, P0-ⓑ.
+//!
+//! The caller-approval map grows a versioned object form carrying class-B
+//! cell specs next to the legacy class-A text specs:
+//!
+//! ```json
+//! {
+//!   "schema_version": 2,
+//!   "source_sha256": "…64 hex…",
+//!   "text":  [ { "section": 0, "path": "…", "span": {"start": 0, "end": 3},
+//!                "marker": "□", "action": {"field": {"name": "동의"}} } ],
+//!   "cells": [ { "table": 3, "at": {"row": 5, "col": 3},
+//!                "label": {"at": {"row": 5, "col": 2}, "text": "성 명"},
+//!                "action": {"field": {"name": "성명", "hint": "지원자 성명"}} } ]
+//! }
+//! ```
+//!
+//! Contract (design §7.3-5, Codex-settled):
+//!
+//! - The legacy flat `[StampSpec…]` array keeps parsing unchanged; the two
+//!   shapes are sniffed by the top-level JSON token, never guessed.
+//! - The object form is **versioned and closed**: `schema_version` must be
+//!   `2`, unknown fields are rejected (a typo must fail, not be silently
+//!   swallowed), and `source_sha256` is mandatory so a map can never be
+//!   replayed against a drifted document.
+//! - Class-B `field` actions REQUIRE a non-blank `hint` — an empty cell has
+//!   no marker to seed the unfilled ClickHere display, and the engine never
+//!   invents one (labels only ever appear as plan-side suggestions).
+
+use hwpforge_core::table::grid::GridCoord;
+
+use super::apply::StampSpec;
+
+/// The stamp map schema version this build accepts in the object form.
+pub const STAMP_MAP_VERSION: u32 = 2;
+
+/// Caller decision for one class-B cell target.
+///
+/// Unlike class-A [`StampAction`](super::StampAction), the `hint` is
+/// **required**: a canonical
+/// empty cell carries no marker text, so the unfilled field body must come
+/// from the caller (see module docs).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum CellStampAction {
+    /// Promote the cell content to a named ClickHere field.
+    Field {
+        /// Unique field name (unique across text+cell specs AND existing
+        /// fields).
+        name: String,
+        /// Unfilled field body and hint (must not be blank).
+        hint: String,
+    },
+    /// Explicitly leave this candidate unstamped.
+    Ignore,
+}
+
+/// Drift re-verification claim for a detected candidate's label.
+///
+/// Present on specs approving a detected candidate: preflight re-checks
+/// that the label cell at `at` still normalize-matches `text`. Absent for
+/// explicit (caller-authored) orphan targets.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct CellLabelClaim {
+    /// Anchor coordinate of the label cell.
+    pub at: GridCoord,
+    /// Label text as reported by plan (compared normalized).
+    pub text: String,
+}
+
+/// One approved class-B target: identity + drift claim + action.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct CellStampSpec {
+    /// Table ordinal in shared inventory (DFS pre-order) document order.
+    pub table: usize,
+    /// Canonical anchor coordinate of the target cell (covered coordinates
+    /// are rejected at preflight, never silently resolved).
+    pub at: GridCoord,
+    /// Label drift claim; `None` marks an explicit orphan target.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<CellLabelClaim>,
+    /// What to do with this target.
+    pub action: CellStampAction,
+}
+
+/// Versioned stamp map (object form).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct StampRequestV2 {
+    /// Must equal [`STAMP_MAP_VERSION`].
+    pub schema_version: u32,
+    /// SHA-256 (64 hex chars) of the exact input bytes the plan ran on.
+    pub source_sha256: String,
+    /// Class-A text specs (same shape as the legacy array).
+    #[serde(default)]
+    pub text: Vec<StampSpec>,
+    /// Class-B cell specs.
+    #[serde(default)]
+    pub cells: Vec<CellStampSpec>,
+}
+
+/// A parsed stamp map: either the legacy flat array or the v2 envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StampMap {
+    /// Legacy `[StampSpec…]` array — class-A only, no source-hash pinning.
+    Legacy(Vec<StampSpec>),
+    /// Versioned v2 envelope.
+    V2(StampRequestV2),
+}
+
+/// Stamp map parse/validation failure.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum StampMapError {
+    /// JSON syntax or shape error (including unknown fields).
+    Parse(String),
+    /// The top-level JSON value is neither an array nor an object.
+    UnsupportedShape,
+    /// `schema_version` is not [`STAMP_MAP_VERSION`].
+    UnsupportedVersion(u32),
+    /// `source_sha256` is not a 64-char hex SHA-256.
+    InvalidSourceHash(String),
+    /// A cell `field` action has a blank hint.
+    BlankHint {
+        /// The offending field name.
+        name: String,
+    },
+}
+
+impl std::fmt::Display for StampMapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(detail) => write!(f, "stamp map parse error: {detail}"),
+            Self::UnsupportedShape => {
+                write!(f, "stamp map must be a spec array (legacy) or a versioned object (v2)")
+            }
+            Self::UnsupportedVersion(v) => {
+                write!(f, "unsupported stamp map schema_version {v} (expected {STAMP_MAP_VERSION})")
+            }
+            Self::InvalidSourceHash(got) => {
+                write!(f, "source_sha256 must be 64 hex chars, got {got:?}")
+            }
+            Self::BlankHint { name } => {
+                write!(f, "cell spec {name:?}: hint must not be blank (empty cells have no marker to fall back on)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StampMapError {}
+
+/// Parses a stamp map in either shape and validates the v2 contract.
+///
+/// The shape is decided by the top-level JSON token: an array parses as the
+/// legacy `Vec<StampSpec>` (unchanged semantics), an object as
+/// [`StampRequestV2`] with unknown fields rejected, `schema_version`
+/// pinned, `source_sha256` well-formed, and every cell `field` hint
+/// non-blank. Anything else is [`StampMapError::UnsupportedShape`].
+pub fn parse_stamp_map(json: &str) -> Result<StampMap, StampMapError> {
+    let value: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| StampMapError::Parse(e.to_string()))?;
+    match value {
+        serde_json::Value::Array(_) => {
+            let specs: Vec<StampSpec> =
+                serde_json::from_value(value).map_err(|e| StampMapError::Parse(e.to_string()))?;
+            Ok(StampMap::Legacy(specs))
+        }
+        serde_json::Value::Object(_) => {
+            let request: StampRequestV2 =
+                serde_json::from_value(value).map_err(|e| StampMapError::Parse(e.to_string()))?;
+            validate_request(&request)?;
+            Ok(StampMap::V2(request))
+        }
+        _ => Err(StampMapError::UnsupportedShape),
+    }
+}
+
+fn validate_request(request: &StampRequestV2) -> Result<(), StampMapError> {
+    if request.schema_version != STAMP_MAP_VERSION {
+        return Err(StampMapError::UnsupportedVersion(request.schema_version));
+    }
+    let sha = &request.source_sha256;
+    if sha.len() != 64 || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(StampMapError::InvalidSourceHash(sha.clone()));
+    }
+    for spec in &request.cells {
+        if let CellStampAction::Field { name, hint } = &spec.action {
+            if hint.trim().is_empty() {
+                return Err(StampMapError::BlankHint { name: name.clone() });
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stamp::StampAction;
+
+    const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn v2_json(body: &str) -> String {
+        format!(r#"{{"schema_version":2,"source_sha256":"{SHA}",{body}}}"#)
+    }
+
+    #[test]
+    fn legacy_flat_array_parses_unchanged() {
+        let json = r#"[{"section":0,"path":"paragraphs[0].runs[0].text",
+            "span":{"start":0,"end":3},"marker":"□","action":"ignore"}]"#;
+        match parse_stamp_map(json).unwrap() {
+            StampMap::Legacy(specs) => {
+                assert_eq!(specs.len(), 1);
+                assert_eq!(specs[0].marker, "□");
+                assert_eq!(specs[0].action, StampAction::Ignore);
+            }
+            other => panic!("expected legacy map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn v2_object_parses_with_text_and_cells() {
+        let json = v2_json(
+            r#""text":[{"section":0,"path":"p","span":{"start":0,"end":1},
+                "marker":"□","action":{"field":{"name":"동의","hint":null}}}],
+              "cells":[{"table":3,"at":{"row":5,"col":3},
+                "label":{"at":{"row":5,"col":2},"text":"성 명"},
+                "action":{"field":{"name":"성명","hint":"지원자 성명"}}}]"#,
+        );
+        match parse_stamp_map(&json).unwrap() {
+            StampMap::V2(req) => {
+                assert_eq!(req.schema_version, 2);
+                assert_eq!(req.source_sha256, SHA);
+                assert_eq!(req.text.len(), 1);
+                assert_eq!(req.cells.len(), 1);
+                let cell = &req.cells[0];
+                assert_eq!(cell.table, 3);
+                assert_eq!(cell.at, GridCoord::new(5, 3));
+                assert_eq!(cell.label.as_ref().unwrap().text, "성 명");
+                assert_eq!(
+                    cell.action,
+                    CellStampAction::Field {
+                        name: "성명".into(), hint: "지원자 성명".into()
+                    },
+                );
+            }
+            other => panic!("expected v2 map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn v2_defaults_empty_spec_lists() {
+        let json = v2_json(r#""cells":[]"#);
+        match parse_stamp_map(&json).unwrap() {
+            StampMap::V2(req) => {
+                assert!(req.text.is_empty());
+                assert!(req.cells.is_empty());
+            }
+            other => panic!("expected v2 map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn v2_unknown_top_level_field_rejected() {
+        let json = v2_json(r#""cell":[]"#); // typo of "cells"
+        let err = parse_stamp_map(&json).unwrap_err();
+        assert!(matches!(err, StampMapError::Parse(ref d) if d.contains("cell")), "{err}");
+    }
+
+    #[test]
+    fn v2_unknown_cell_spec_field_rejected() {
+        let json = v2_json(
+            r#""cells":[{"table":0,"at":{"row":0,"col":1},"labe":null,"action":"ignore"}]"#,
+        );
+        assert!(matches!(parse_stamp_map(&json).unwrap_err(), StampMapError::Parse(_)));
+    }
+
+    #[test]
+    fn v2_wrong_schema_version_rejected() {
+        for version in [1, 3] {
+            let json =
+                format!(r#"{{"schema_version":{version},"source_sha256":"{SHA}","cells":[]}}"#);
+            assert!(matches!(
+                parse_stamp_map(&json).unwrap_err(),
+                StampMapError::UnsupportedVersion(v) if v == version,
+            ));
+        }
+    }
+
+    #[test]
+    fn v2_malformed_source_hash_rejected() {
+        for sha in ["", "abc", &format!("{}g", &SHA[..63])] {
+            let json = format!(r#"{{"schema_version":2,"source_sha256":"{sha}","cells":[]}}"#);
+            assert!(matches!(
+                parse_stamp_map(&json).unwrap_err(),
+                StampMapError::InvalidSourceHash(_),
+            ));
+        }
+    }
+
+    #[test]
+    fn v2_blank_cell_hint_rejected() {
+        for hint in ["", "   "] {
+            let json = v2_json(&format!(
+                r#""cells":[{{"table":0,"at":{{"row":0,"col":1}},
+                    "action":{{"field":{{"name":"성명","hint":"{hint}"}}}}}}]"#,
+            ));
+            assert!(matches!(
+                parse_stamp_map(&json).unwrap_err(),
+                StampMapError::BlankHint { ref name } if name == "성명",
+            ));
+        }
+    }
+
+    #[test]
+    fn v2_ignore_action_needs_no_hint() {
+        let json = v2_json(r#""cells":[{"table":0,"at":{"row":0,"col":1},"action":"ignore"}]"#);
+        match parse_stamp_map(&json).unwrap() {
+            StampMap::V2(req) => {
+                assert_eq!(req.cells[0].action, CellStampAction::Ignore);
+                assert!(req.cells[0].label.is_none());
+            }
+            other => panic!("expected v2 map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_array_non_object_rejected() {
+        assert!(matches!(parse_stamp_map("42").unwrap_err(), StampMapError::UnsupportedShape));
+        assert!(matches!(parse_stamp_map("\"x\"").unwrap_err(), StampMapError::UnsupportedShape));
+    }
+
+    #[test]
+    fn cell_spec_serialization_shape_is_locked() {
+        // Golden shape — the CLI/MCP JSON contract for one cell spec.
+        let spec = CellStampSpec {
+            table: 3,
+            at: GridCoord::new(5, 3),
+            label: Some(CellLabelClaim { at: GridCoord::new(5, 2), text: "성 명".into() }),
+            action: CellStampAction::Field {
+                name: "성명".into(), hint: "지원자 성명".into()
+            },
+        };
+        let expected = serde_json::json!({
+            "table": 3,
+            "at": {"row": 5, "col": 3},
+            "label": {"at": {"row": 5, "col": 2}, "text": "성 명"},
+            "action": {"field": {"name": "성명", "hint": "지원자 성명"}},
+        });
+        assert_eq!(serde_json::to_value(&spec).unwrap(), expected);
+
+        // Explicit orphan spec omits `label` entirely.
+        let orphan = CellStampSpec {
+            table: 0,
+            at: GridCoord::new(2, 2),
+            label: None,
+            action: CellStampAction::Ignore,
+        };
+        let expected = serde_json::json!({
+            "table": 0,
+            "at": {"row": 2, "col": 2},
+            "action": "ignore",
+        });
+        assert_eq!(serde_json::to_value(&orphan).unwrap(), expected);
+    }
+}

--- a/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
@@ -7,19 +7,30 @@
 //! every input ZIP entry. Anything else is rejected with no output; file
 //! names and provenance are never used as a safety proxy.
 
+use std::collections::HashSet;
 use std::io::Cursor;
 
 use serde::Serialize;
 
-use super::apply::{apply, StampError, StampOutcome, StampSpec};
+use hwpforge_core::run::{Run, RunContent};
+use hwpforge_core::table::grid::GridCoord;
+use hwpforge_core::Control;
+
+use super::apply::{apply, StampAction, StampError, StampOutcome, StampSpec};
+use super::apply_cells::{commit_cells, preflight_cells, CellStampError, CellStampOutcome};
 use super::plan::{plan, StampCandidate};
+use super::request::{CellLabelClaim, StampRequestV2};
 use crate::decoder::{HwpxDecoder, HwpxDocument};
 use crate::encoder::HwpxEncoder;
 use crate::fill::{FieldInfo, HwpxFiller};
 use crate::patch::sha256_hex;
+use crate::table_inventory::for_each_table_mut;
 
 /// Manifest schema version (bump on breaking manifest shape changes).
 pub const STAMP_MANIFEST_VERSION: u32 = 1;
+
+/// v2 manifest schema version (text+cell origins, tagged `stamp` enum).
+pub const STAMP_MANIFEST_V2_VERSION: u32 = 2;
 
 /// Byte-level stamping entry point.
 ///
@@ -110,6 +121,26 @@ pub enum StamperError {
         /// Human-readable description.
         detail: String,
     },
+    /// The v2 map's `source_sha256` does not match the input bytes — the
+    /// map was authored against a different (drifted) document.
+    SourceHashMismatch {
+        /// Hash the map claimed.
+        expected: String,
+        /// Hash of the actual input.
+        actual: String,
+    },
+    /// Cell-apply preflight rejection.
+    CellStamp(CellStampError),
+    /// Post-encode verification failure: the re-decoded output does not
+    /// reduce back to the pre-stamp document (reverse delta), or is not an
+    /// encode/decode fixed point.
+    DeltaMismatch {
+        /// Which verification stage failed (`reverse_delta` / `fixed_point`
+        /// / `stamped_cell`).
+        stage: String,
+        /// First differing component or a description of the failure.
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for StamperError {
@@ -130,6 +161,15 @@ impl std::fmt::Display for StamperError {
             ),
             Self::Stamp(e) => write!(f, "stamp preflight: {e}"),
             Self::ManifestInvariant { detail } => write!(f, "manifest invariant: {detail}"),
+            Self::SourceHashMismatch { expected, actual } => write!(
+                f,
+                "source_sha256 mismatch: map was authored for {expected}, input is {actual} — \
+                 re-run plan on the current document"
+            ),
+            Self::CellStamp(e) => write!(f, "cell stamp preflight: {e}"),
+            Self::DeltaMismatch { stage, detail } => {
+                write!(f, "post-encode verification failed at {stage}: {detail}")
+            }
         }
     }
 }
@@ -139,6 +179,12 @@ impl std::error::Error for StamperError {}
 impl From<StampError> for StamperError {
     fn from(e: StampError) -> Self {
         Self::Stamp(e)
+    }
+}
+
+impl From<CellStampError> for StamperError {
+    fn from(e: CellStampError) -> Self {
+        Self::CellStamp(e)
     }
 }
 
@@ -188,6 +234,250 @@ impl HwpxStamper {
         let manifest = build_manifest(base, &bytes, &fields, &outcome)?;
         Ok(StampResult { bytes, manifest, outcome })
     }
+
+    /// Stamps a v2 request (class-A text + class-B cells), all-or-nothing.
+    ///
+    /// Pipeline: source-hash pinning → admission gate → unified preflight
+    /// (cell preflight against the pristine document, cross-class name
+    /// reservation) → text apply → cell commit → encode → re-decode →
+    /// post-encode verification (per-cell expected field, reverse cell
+    /// delta against a text-only reference round-trip, output fixed point)
+    /// → v2 manifest. Fail-closed: no bytes on any error.
+    ///
+    /// # Errors
+    ///
+    /// See [`StamperError`] — notably [`StamperError::SourceHashMismatch`],
+    /// [`StamperError::CellStamp`], and [`StamperError::DeltaMismatch`].
+    pub fn stamp_v2(base: &[u8], request: &StampRequestV2) -> Result<StampResultV2, StamperError> {
+        // ── source-hash pinning (drift rejection) ───────────────────
+        let actual = sha256_hex(base);
+        if !actual.eq_ignore_ascii_case(&request.source_sha256) {
+            return Err(StamperError::SourceHashMismatch {
+                expected: request.source_sha256.clone(),
+                actual,
+            });
+        }
+
+        // ── admission gate (identical to v1) ────────────────────────
+        let d0 = HwpxDecoder::decode(base).map_err(|e| StamperError::Codec(e.to_string()))?;
+        let e0 = encode_hwpx(&d0)?;
+        let d1 = HwpxDecoder::decode(&e0).map_err(|e| StamperError::Codec(e.to_string()))?;
+        admission_compare(&d0, &d1)?;
+        check_zip_carry(base, &e0)?;
+
+        // ── unified preflight, then mutate ──────────────────────────
+        let HwpxDocument { mut document, style_store, image_store } = d0;
+        let reserved: HashSet<String> = request
+            .text
+            .iter()
+            .filter_map(|s| match &s.action {
+                StampAction::Field { name, .. } => Some(name.clone()),
+                StampAction::Ignore => None,
+            })
+            .collect();
+        // Cell preflight runs against the pristine document; text apply is
+        // internally atomic; cell commit is mechanical — so a failure at
+        // any point leaves no partially-stamped output (combined
+        // atomicity).
+        let cell_plan = preflight_cells(&mut document, &request.cells, &reserved)?;
+        let text_outcome = apply(&mut document, &request.text)?;
+        // Text-only reference for the reverse-delta gate (before cells).
+        let text_only = HwpxDocument {
+            document: document.clone(),
+            style_store: style_store.clone(),
+            image_store: image_store.clone(),
+        };
+        let cell_outcome = commit_cells(&mut document, cell_plan);
+
+        let validated =
+            document.validate().map_err(|e| StamperError::Codec(format!("validate: {e}")))?;
+        let bytes = HwpxEncoder::encode(&validated, &style_store, &image_store)
+            .map_err(|e| StamperError::Codec(e.to_string()))?;
+
+        // ── post-encode verification on the re-decoded OUTPUT ───────
+        let d2 = HwpxDecoder::decode(&bytes)
+            .map_err(|e| StamperError::Codec(format!("output decode: {e}")))?;
+        verify_and_reverse_cells(&d2, &text_only, &cell_outcome)?;
+        let e2 = encode_hwpx(&d2)?;
+        let d3 = HwpxDecoder::decode(&e2)
+            .map_err(|e| StamperError::Codec(format!("fixed-point decode: {e}")))?;
+        admission_compare(&d2, &d3).map_err(|e| StamperError::DeltaMismatch {
+            stage: "fixed_point".to_string(),
+            detail: e.to_string(),
+        })?;
+
+        // ── v2 manifest from the OUTPUT ─────────────────────────────
+        let fields = HwpxFiller::list_fields(&bytes)
+            .map_err(|e| StamperError::Codec(format!("output list_fields: {e}")))?;
+        let manifest = build_manifest_v2(base, &bytes, &fields, &text_outcome, &cell_outcome)?;
+        Ok(StampResultV2 {
+            bytes,
+            manifest,
+            outcome: StampOutcomeV2 { text: text_outcome, cells: cell_outcome },
+        })
+    }
+}
+
+/// Verifies each stamped cell in the re-decoded output and reverses the
+/// cell delta, comparing against the text-only reference round-trip.
+///
+/// Both sides of the comparison have been through exactly one
+/// encode→decode, so codec normalization cancels and any residual
+/// difference is a real stamping defect.
+fn verify_and_reverse_cells(
+    d2: &HwpxDocument,
+    text_only: &HwpxDocument,
+    cells: &CellStampOutcome,
+) -> Result<(), StamperError> {
+    let mut reverted = d2.document.clone();
+    let mut pending: std::collections::HashMap<usize, Vec<&super::apply_cells::CellStampedField>> =
+        std::collections::HashMap::new();
+    for stamped in &cells.stamped {
+        pending.entry(stamped.table).or_default().push(stamped);
+    }
+    let mut failure: Option<StamperError> = None;
+    for_each_table_mut(&mut reverted, &mut |ordinal, table| {
+        let Some(edits) = pending.remove(&ordinal) else {
+            return;
+        };
+        if failure.is_some() {
+            return;
+        }
+        let Ok(grid) = hwpforge_core::table::grid::TableGrid::from_table(table) else {
+            failure = Some(StamperError::DeltaMismatch {
+                stage: "stamped_cell".to_string(),
+                detail: format!("table {ordinal}: output grid invalid"),
+            });
+            return;
+        };
+        for stamped in edits {
+            let Some(anchor) = grid.resolve(stamped.at).copied() else {
+                failure = Some(stamped_cell_failure(stamped, "cell missing from output grid"));
+                return;
+            };
+            let cell = &mut table.rows[anchor.row_idx].cells[anchor.cell_idx];
+            let Some(run) = cell.paragraphs.first_mut().and_then(|p| p.runs.first_mut()) else {
+                failure = Some(stamped_cell_failure(stamped, "cell has no runs in output"));
+                return;
+            };
+            let is_expected = matches!(
+                &run.content,
+                RunContent::Control(control) if matches!(
+                    control.as_ref(),
+                    Control::Field { name: Some(name), .. } if *name == stamped.name
+                )
+            );
+            if !is_expected {
+                failure = Some(stamped_cell_failure(stamped, "expected named ClickHere not found"));
+                return;
+            }
+            *run = Run::text(&stamped.original_text, run.char_shape_id);
+        }
+    });
+    if let Some(err) = failure {
+        return Err(err);
+    }
+
+    let reverted = HwpxDocument {
+        document: reverted,
+        style_store: d2.style_store.clone(),
+        image_store: d2.image_store.clone(),
+    };
+    // Reference: the text-only document after ONE encode→decode round trip.
+    let reference_bytes = encode_hwpx(text_only)?;
+    let reference = HwpxDecoder::decode(&reference_bytes)
+        .map_err(|e| StamperError::Codec(format!("reference decode: {e}")))?;
+    admission_compare(&reverted, &reference).map_err(|e| StamperError::DeltaMismatch {
+        stage: "reverse_delta".to_string(),
+        detail: e.to_string(),
+    })
+}
+
+fn stamped_cell_failure(
+    stamped: &super::apply_cells::CellStampedField,
+    detail: &str,
+) -> StamperError {
+    StamperError::DeltaMismatch {
+        stage: "stamped_cell".to_string(),
+        detail: format!(
+            "table {} ({},{}) field {:?}: {detail}",
+            stamped.table, stamped.at.row, stamped.at.col, stamped.name
+        ),
+    }
+}
+
+/// Result of a successful [`HwpxStamper::stamp_v2`].
+#[derive(Debug)]
+pub struct StampResultV2 {
+    /// The stamped `.hwpx` bytes.
+    pub bytes: Vec<u8>,
+    /// The v2 manifest describing every field in the output.
+    pub manifest: StampManifestV2,
+    /// Apply-phase outcomes for both classes.
+    pub outcome: StampOutcomeV2,
+}
+
+/// Combined apply outcome of a v2 stamp.
+#[derive(Debug)]
+pub struct StampOutcomeV2 {
+    /// Class-A text outcome.
+    pub text: StampOutcome,
+    /// Class-B cell outcome.
+    pub cells: CellStampOutcome,
+}
+
+/// Machine-readable v2 inventory of the stamped output.
+///
+/// Same invariant as v1: `fields[*]` (minus `stamp`) is the re-decoded
+/// OUTPUT's `list_fields` result verbatim.
+#[derive(Debug, Clone, Serialize)]
+pub struct StampManifestV2 {
+    /// Manifest schema version ([`STAMP_MANIFEST_V2_VERSION`]).
+    pub schema_version: u32,
+    /// SHA-256 (hex) of the input bytes.
+    pub source_sha256: String,
+    /// SHA-256 (hex) of the output bytes.
+    pub output_sha256: String,
+    /// Every ClickHere field in the output document, in document order.
+    pub fields: Vec<ManifestFieldV2>,
+}
+
+/// One field in the v2 output inventory.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManifestFieldV2 {
+    /// The field as `list_fields` reports it.
+    #[serde(flatten)]
+    pub field: FieldInfo,
+    /// Stamping provenance — present only for fields this stamp created.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stamp: Option<StampOriginV2>,
+}
+
+/// Provenance of a v2-stamped field, tagged by origin class.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StampOriginV2 {
+    /// Class-A: promoted from an inline text marker.
+    Text {
+        /// Detector id (`builtin:checkbox`, …).
+        pattern: String,
+        /// Original marker text the field replaced.
+        marker: String,
+        /// Pre-stamp semantic path (addresses the ORIGINAL document).
+        source_location: String,
+        /// UTF-8 byte span of the marker within the original slot text.
+        span: (usize, usize),
+    },
+    /// Class-B: promoted from a stampable empty table cell.
+    Cell {
+        /// Table ordinal (shared inventory DFS pre-order).
+        table: usize,
+        /// Anchor coordinate of the stamped cell.
+        at: GridCoord,
+        /// The approved label claim (`None` = explicit orphan).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        label: Option<CellLabelClaim>,
+    },
 }
 
 pub(crate) fn encode_hwpx(doc: &HwpxDocument) -> Result<Vec<u8>, StamperError> {
@@ -336,6 +626,67 @@ fn build_manifest(
 
     Ok(StampManifest {
         schema_version: STAMP_MANIFEST_VERSION,
+        source_sha256: sha256_hex(base),
+        output_sha256: sha256_hex(output),
+        fields,
+    })
+}
+
+fn check_stamped_name(fields: &[FieldInfo], name: &str) -> Result<(), StamperError> {
+    let matches: Vec<&FieldInfo> =
+        fields.iter().filter(|f| f.name.as_deref() == Some(name)).collect();
+    match matches.as_slice() {
+        [one] if one.fillable => Ok(()),
+        [_] => Err(StamperError::ManifestInvariant {
+            detail: format!("stamped field {name:?} is not fillable"),
+        }),
+        [] => Err(StamperError::ManifestInvariant {
+            detail: format!("stamped field {name:?} missing from output"),
+        }),
+        _ => Err(StamperError::ManifestInvariant {
+            detail: format!("stamped field {name:?} appears more than once"),
+        }),
+    }
+}
+
+fn build_manifest_v2(
+    base: &[u8],
+    output: &[u8],
+    fields: &[FieldInfo],
+    text: &StampOutcome,
+    cells: &CellStampOutcome,
+) -> Result<StampManifestV2, StamperError> {
+    for stamped in &text.stamped {
+        check_stamped_name(fields, &stamped.name)?;
+    }
+    for stamped in &cells.stamped {
+        check_stamped_name(fields, &stamped.name)?;
+    }
+
+    let fields = fields
+        .iter()
+        .map(|f| ManifestFieldV2 {
+            field: f.clone(),
+            stamp: f.name.as_deref().and_then(|name| {
+                if let Some(s) = text.stamped.iter().find(|s| s.name == name) {
+                    return Some(StampOriginV2::Text {
+                        pattern: format!("builtin:{}", s.pattern.id()),
+                        marker: s.marker.clone(),
+                        source_location: s.path.clone(),
+                        span: (s.span.start, s.span.end),
+                    });
+                }
+                cells.stamped.iter().find(|s| s.name == name).map(|s| StampOriginV2::Cell {
+                    table: s.table,
+                    at: s.at,
+                    label: s.label.clone(),
+                })
+            }),
+        })
+        .collect();
+
+    Ok(StampManifestV2 {
+        schema_version: STAMP_MANIFEST_V2_VERSION,
         source_sha256: sha256_hex(base),
         output_sha256: sha256_hex(output),
         fields,

--- a/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
@@ -18,6 +18,7 @@ use hwpforge_core::Control;
 
 use super::apply::{apply, StampAction, StampError, StampOutcome, StampSpec};
 use super::apply_cells::{commit_cells, preflight_cells, CellStampError, CellStampOutcome};
+use super::cells::plan_cells;
 use super::plan::{plan, StampCandidate};
 use super::request::{CellLabelClaim, StampRequestV2};
 use crate::decoder::{HwpxDecoder, HwpxDocument};
@@ -200,6 +201,27 @@ impl HwpxStamper {
     pub fn plan_bytes(base: &[u8]) -> Result<Vec<StampCandidate>, StamperError> {
         let decoded = HwpxDecoder::decode(base).map_err(|e| StamperError::Codec(e.to_string()))?;
         Ok(plan(&decoded.document))
+    }
+
+    /// Decodes the input and enumerates BOTH candidate classes (v2 plan).
+    ///
+    /// Discovery only — no admission gate, no mutation. The returned
+    /// `source_sha256` must be copied verbatim into the v2 map so
+    /// [`HwpxStamper::stamp_v2`] can reject drifted inputs.
+    ///
+    /// # Errors
+    ///
+    /// [`StamperError::Codec`] when the input fails to decode.
+    pub fn plan_bytes_v2(base: &[u8]) -> Result<StampPlanV2, StamperError> {
+        let decoded = HwpxDecoder::decode(base).map_err(|e| StamperError::Codec(e.to_string()))?;
+        let cells = plan_cells(&decoded.document);
+        Ok(StampPlanV2 {
+            schema_version: super::request::STAMP_MAP_VERSION,
+            source_sha256: sha256_hex(base),
+            text: plan(&decoded.document),
+            cells: cells.candidates,
+            skipped_tables: cells.skipped_tables,
+        })
     }
 
     /// Stamps the input with the approved specs, all-or-nothing.
@@ -404,6 +426,24 @@ fn stamped_cell_failure(
             stamped.table, stamped.at.row, stamped.at.col, stamped.name
         ),
     }
+}
+
+/// Result of [`HwpxStamper::plan_bytes_v2`]: both candidate classes plus
+/// the source hash the approval map must pin.
+#[derive(Debug, Clone, Serialize)]
+pub struct StampPlanV2 {
+    /// The map schema version this plan feeds
+    /// ([`super::request::STAMP_MAP_VERSION`]).
+    pub schema_version: u32,
+    /// SHA-256 (hex) of the input bytes — copy into the v2 map verbatim.
+    pub source_sha256: String,
+    /// Class-A text candidates (same shape as [`HwpxStamper::plan_bytes`]).
+    pub text: Vec<StampCandidate>,
+    /// Class-B cell candidates.
+    pub cells: Vec<super::cells::CellStampCandidate>,
+    /// Tables excluded from cell detection (invalid grid) — explicit
+    /// incomplete-coverage diagnostics.
+    pub skipped_tables: Vec<super::cells::SkippedTable>,
 }
 
 /// Result of a successful [`HwpxStamper::stamp_v2`].

--- a/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
@@ -249,6 +249,10 @@ impl HwpxStamper {
             document.validate().map_err(|e| StamperError::Codec(format!("validate: {e}")))?;
         let bytes = HwpxEncoder::encode(&validated, &style_store, &image_store)
             .map_err(|e| StamperError::Codec(e.to_string()))?;
+        // Untouched paragraphs keep Hancom's line-layout cache (no full
+        // document reflow/repagination in the renderer).
+        let bytes = crate::layout_carry::carry_line_segs(base, &e0, &bytes)
+            .map_err(|e| StamperError::Codec(format!("layout carry: {e}")))?;
 
         // ── manifest from the OUTPUT (re-decode is the source of truth) ─
         let fields = HwpxFiller::list_fields(&bytes)
@@ -315,6 +319,10 @@ impl HwpxStamper {
             document.validate().map_err(|e| StamperError::Codec(format!("validate: {e}")))?;
         let bytes = HwpxEncoder::encode(&validated, &style_store, &image_store)
             .map_err(|e| StamperError::Codec(e.to_string()))?;
+        // Untouched paragraphs keep Hancom's line-layout cache (no full
+        // document reflow/repagination in the renderer).
+        let bytes = crate::layout_carry::carry_line_segs(base, &e0, &bytes)
+            .map_err(|e| StamperError::Codec(format!("layout carry: {e}")))?;
 
         // ── post-encode verification on the re-decoded OUTPUT ───────
         let d2 = HwpxDecoder::decode(&bytes)

--- a/crates/hwpforge-smithy-hwpx/tests/stamp_roundtrip.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/stamp_roundtrip.rs
@@ -290,3 +290,141 @@ fn stamper_error_display_names_the_rejection() {
         assert!(msg.contains(needle), "{msg:?} must contain {needle:?}");
     }
 }
+
+// ── Wave 2B: class-B cell stamping E2E ──────────────────────────────
+
+#[test]
+fn stamp_v2_cells_end_to_end() {
+    use hwpforge_core::table::grid::GridCoord;
+    use hwpforge_smithy_hwpx::stamp::{
+        plan_cells, CellLabelClaim, CellStampAction, CellStampSpec, StampOriginV2, StampRequestV2,
+        STAMP_MANIFEST_V2_VERSION,
+    };
+
+    // 양식 표: 성명|빈칸 · 주소|U+3000 패딩(2문단) + 본문 class-A 괄호빈칸.
+    let width = HwpUnit::new(8000).unwrap();
+    let padded = TableCell::new(vec![text_para("\u{3000}"), text_para("")], width);
+    let table = Table::new(vec![
+        TableRow::new(vec![
+            TableCell::new(vec![text_para("성명")], width),
+            TableCell::new(vec![text_para("")], width),
+        ]),
+        TableRow::new(vec![TableCell::new(vec![text_para("주소")], width), padded]),
+    ]);
+    let mut host = Paragraph::new(ParaShapeIndex::new(0));
+    host.add_run(Run::table(table, CharShapeIndex::new(0)));
+
+    let mut doc = Document::new();
+    doc.add_section(Section::with_paragraphs(
+        vec![text_para("연락처: (   )"), host],
+        PageSettings::default(),
+    ));
+
+    // 탐지 확인: class-B 후보 2 (성명·주소 좌라벨)
+    let cell_plan = plan_cells(&doc);
+    assert_eq!(cell_plan.candidates.len(), 2, "{cell_plan:?}");
+    assert!(cell_plan.skipped_tables.is_empty());
+    let text_candidates = plan(&doc);
+    assert_eq!(text_candidates.len(), 1);
+
+    let bytes = encode(doc);
+
+    // source-hash 핀: 오답 sha 는 거부되고, 에러가 실제 해시를 알려준다.
+    let bad = StampRequestV2 {
+        schema_version: 2,
+        source_sha256: "0".repeat(64),
+        text: vec![],
+        cells: vec![],
+    };
+    let sha = match HwpxStamper::stamp_v2(&bytes, &bad) {
+        Err(StamperError::SourceHashMismatch { actual, .. }) => actual,
+        other => panic!("expected SourceHashMismatch, got {other:?}"),
+    };
+
+    let c = &text_candidates[0];
+    let request = StampRequestV2 {
+        schema_version: 2,
+        source_sha256: sha,
+        text: vec![StampSpec {
+            section: c.section,
+            path: c.path.clone(),
+            span: c.span.clone(),
+            marker: c.marker.clone(),
+            action: StampAction::Field { name: "연락처".into(), hint: None },
+        }],
+        cells: vec![
+            CellStampSpec {
+                table: 0,
+                at: GridCoord::new(0, 1),
+                label: Some(CellLabelClaim { at: GridCoord::new(0, 0), text: "성명".into() }),
+                action: CellStampAction::Field {
+                    name: "성명".into(), hint: "성명 입력".into()
+                },
+            },
+            CellStampSpec {
+                table: 0,
+                at: GridCoord::new(1, 1),
+                label: None, // explicit coverage of the 주소 candidate
+                action: CellStampAction::Field {
+                    name: "주소".into(), hint: "주소 입력".into()
+                },
+            },
+        ],
+    };
+    let result = HwpxStamper::stamp_v2(&bytes, &request).expect("stamp_v2");
+
+    // outcome + delta records
+    assert_eq!(result.outcome.text.stamped.len(), 1);
+    assert_eq!(result.outcome.cells.stamped.len(), 2);
+    assert_eq!(result.outcome.cells.stamped[0].original_text, "");
+    assert_eq!(result.outcome.cells.stamped[1].original_text, "\u{3000}");
+
+    // v2 manifest: 태그드 origin
+    assert_eq!(result.manifest.schema_version, STAMP_MANIFEST_V2_VERSION);
+    let origins: Vec<(&str, bool)> = result
+        .manifest
+        .fields
+        .iter()
+        .map(|f| match &f.stamp {
+            Some(StampOriginV2::Text { .. }) => ("text", f.field.fillable),
+            Some(StampOriginV2::Cell { .. }) => ("cell", f.field.fillable),
+            None => ("none", f.field.fillable),
+        })
+        .collect();
+    assert_eq!(origins.iter().filter(|(o, _)| *o == "text").count(), 1);
+    assert_eq!(origins.iter().filter(|(o, _)| *o == "cell").count(), 2);
+    assert!(origins.iter().all(|(_, fillable)| *fillable));
+    let cell_origin = result
+        .manifest
+        .fields
+        .iter()
+        .find_map(|f| match &f.stamp {
+            Some(StampOriginV2::Cell { table, at, label: Some(claim) }) => {
+                Some((*table, *at, claim.text.clone()))
+            }
+            _ => None,
+        })
+        .expect("labeled cell origin");
+    assert_eq!(cell_origin, (0, GridCoord::new(0, 1), "성명".to_string()));
+
+    // 산출물은 배포된 fill 표면으로 즉시 소비 가능
+    let fields = HwpxFiller::list_fields(&result.bytes).expect("list_fields");
+    assert_eq!(fields.len(), 3);
+    let mut values = BTreeMap::new();
+    values.insert("성명".to_string(), "홍길동".to_string());
+    let filled = HwpxFiller::fill(&result.bytes, &values).expect("fill");
+    let refetched = HwpxFiller::list_fields(&filled.bytes).expect("re-list");
+    let name_field = refetched.iter().find(|f| f.name.as_deref() == Some("성명")).unwrap();
+    assert_eq!(name_field.current, "홍길동");
+
+    // 기하 보존: 패딩 문단이 살아있고 첫 문단만 field 로 교체됨
+    let d = HwpxDecoder::decode(&result.bytes).expect("decode output");
+    let out_plan = plan_cells(&d.document);
+    assert!(out_plan.candidates.is_empty(), "stamped cells must not re-plan");
+    let section = &d.document.sections()[0];
+    let hwpforge_core::run::RunContent::Table(t) = &section.paragraphs[1].runs[0].content else {
+        panic!("expected table");
+    };
+    let padded_cell = &t.rows[1].cells[1];
+    assert_eq!(padded_cell.paragraphs.len(), 2, "padding paragraph must survive");
+}


### PR DESCRIPTION
## 요약

E6 Wave 2 — **클래스-B 셀 스탬핑**: 라벨에 인접한 빈 표 셀을 이름 붙은 누름틀(ClickHere)로 승격한다. E3 격자 주소가 풀어준 잠금으로, 별지서식군의 지배적 placeholder 축(라벨 옆 빈 칸)이 `stamp-plan → stamp --map(v2) → fields/fill` 사슬에 들어온다.

설계·리서치·Codex 토론 정본 = `.docs/planning/2026-07-20-e6-template-stamping.md` §7 (쟁점 7개 전부 Codex 수정안 채택).

## 커밋 구성 (P0 → 2A → 2B → 2C)

| 커밋 | 내용 |
| --- | --- |
| `9d6dce5` | **P0-ⓐ (fix)** 디코더가 빈 문단 placeholder 에 authored `charPrIDRef` 보존 — 편집 표면이 빈 셀에 스타일 있는 텍스트를 복원하기 위한 선행 fidelity 수정 (blank-HPC 실측: char shape 전부 0 → authored 분포 복원) |
| `adcfbb7` | **P0-ⓒ** `stamp::cells` 기본 술어 — stampable-empty + shared-boundary 인접(병합 다중 라벨·per-reference guard·문서 전역 duplicate tally) |
| `7cb5fc7` | **P0-ⓑ** stamp map v2 versioned envelope — `{schema_version:2, source_sha256, text[], cells[]}`, unknown field 거부, 셀 hint 필수, legacy 배열 무모호 병행 |
| `c5580ed` | **2A** `plan_cells` 탐지 — 후보(라벨 배열·suggested_name/hint 제안·guarded)·invalid 격자 명시 진단. eligibility 실측 확장: 네이티브 한컴의 다문단 all-empty(17)·U+3000 패딩(3) 수용 |
| `41905d9` | **2B** `apply_cells` + `HwpxStamper::stamp_v2` — 통합 cross-class preflight(전량 검증 후 단일 mutation), source SHA 핀, **산출물 재decode 검증**(셀별 기대 필드 + 역치환 delta + encode/decode 고정점), manifest v2(태그드 origin `text|cell`) |
| `42b30b5` | **2C** CLI/MCP 배선 — `stamp-plan` v2 출력(source_sha256·cells·skipped_tables), `stamp --map` legacy/v2 판별, MCP `cells`+`source_sha256`, 에러 코드 8종 신설 |

## 불변식 (fail-closed)

- **이름/힌트 정본 = 호출자 map** — suggested_name/hint 는 제안일 뿐 자동 적용 없음. 셀 hint 필수(빈 셀엔 마커가 없어 엔진이 본문을 발명하지 않음).
- **source SHA-256 핀** — 드리프트된 문서에 맵 재사용 시 `STAMP_SOURCE_HASH_MISMATCH` 거부.
- **anchor 강제** — 피병합 좌표 스펙은 거부하고 anchor 를 안내 (`STAMP_CELL_NOT_ANCHOR`).
- **승격 = 첫 문단 run 교체만** — char shape 는 대상 run 의 authored 값, 패딩 문단 보존(행 높이/기하 불변), 원본 run 텍스트 verbatim 기록.
- **산출물 검증 후에만 출력** — 재decode 에서 역치환하면 원본과 정확히 일치해야 하고(양변 1회 왕복으로 코덱 정규화 상쇄), 산출물은 encode/decode 고정점이어야 함 (`STAMP_DELTA_MISMATCH`).
- 기존 public 타입(`StampSpec`/`StampMeta`/`StampOutcome`/v1 manifest)·CLI/MCP JSON 계약 **전부 불변** — 신규 타입/optional 필드만 추가 (비파괴 feat + fix).

## 실측 (blank-HPC 네이티브 acceptance)

- 셀 후보 **64** (라벨 인접 쌍 63 + 마커-셀 라벨 1 · guarded 0 · skipped 0) — corpus python 분석과 좌표 단위 검산 일치
- **64/64 전량 승격** (delta·고정점 게이트 무오류) → `fields` 64 전부 fillable → `fill` 왕복 성공
- corpus 68문서 기반 설계 수치: 라벨 인접이 탐지 필터(orphan 53% 제외) · 병합 관여 쌍 44.8%(shared-boundary 필수) · 라벨 중복 문서 94%(라벨 단독 이름 불가)

## 테스트

- 단위 게이트 신규 ~47개 (cells 23 · request 11 · apply_cells 12 + E2E 1) + CLI 통합 4 + MCP 1
- 워크스페이스 전체 **2,883 passed** · 커버리지 **90.06%** (`--fail-under-lines 90` 통과)

## 시각 게이트 1차 발견 → 수정 (`b37fd13`)

사용자 PDF 대조에서 **쪽수 9→8 밀림 + 선언문 줄바꿈 변화** 발견. wire diff로 근본 원인 확정 = `<hp:linesegarray>`(한컴 문단별 줄 조판 캐시) 전량 소실(475→0; 내용은 문단 475=475·fwSpace 43=43로 보존). admission은 Core 의미만 비교하므로 decode-side wire 캐시 소실은 검출 불가 — 알려진 한계의 첫 실물이며 **Wave 2 고유 회귀가 아니라 전 재인코드 표면 공통**.

수정 = `layout_carry` 모듈 (Core 무접촉): 원본을 문단 순서로 스캔 → e0(무편집 재인코드)와 산출물의 문단 XML 조각을 순번별 바이트 비교 → **동일 문단에만 원본 캐시 재주입**, 편집 문단은 자동 탈락(fail-open — 거짓 캐시 경로 없음, 한컴이 그 문단만 재조판). stamp v1/v2 + set-cell 3표면 배선. blank-HPC 실측 **399/475 보존** (탈락 76 = 스탬프 셀 문단 64 + 변경 표 호스트). 단위 게이트 8개.

## 시각 게이트 (사용자 확인 항목)

`examples/hwp5_review/_verify/stamped-cells-blank-hpc.hwpx` (+manifest) — ① 복구 경고 없음 ② 쪽수/행높이/표 기하 원본 동일 ③ 셀 64곳이 라벨 텍스트 hint 로 표시·클릭 시 누름틀 동작 ④ **한컴 저장 후** fields/fill 재검증(멀티-run 분해 위험 확인).

## 후속 (합의된 backlog)

클래스-A reverse-delta 의 v1 경로 확장 · convert `--stamp` 직행 · 48k-anchor 성능 게이트 · E6 잔여(R3/L4) · gso-group 디코더 갭
