### PR TITLE
refactor+test: E4 구조 편집 admission/self-verify DRY + 커버리지 마진

### DIFF
--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -3621,6 +3621,60 @@ fn structural_edit_batch_and_structural_rejections() {
 }
 
 #[test]
+fn structural_edit_write_failure_and_batch_json_shape() {
+    let f = fixture("plain_paragraphs.hwpx");
+    let tmp = test_tmp();
+
+    // Unwritable output path → FILE_WRITE_FAILED, exit code 2.
+    let bad = "/nonexistent-dir-e4/out.hwpx";
+    let (err, _, c) = run_json(&[
+        "insert-para",
+        f.to_str().unwrap(),
+        "--section",
+        "0",
+        "--anchor",
+        "1",
+        "--text",
+        "x",
+        "-o",
+        bad,
+    ]);
+    assert_eq!(c, 2);
+    assert_eq!(err["code"], "FILE_WRITE_FAILED");
+
+    let (err, _, c) = run_json(&[
+        "delete-para",
+        f.to_str().unwrap(),
+        "--section",
+        "0",
+        "--index",
+        "1",
+        "-o",
+        bad,
+    ]);
+    assert_eq!(c, 2);
+    assert_eq!(err["code"], "FILE_WRITE_FAILED");
+
+    // Batch delete success JSON carries the requested indices.
+    let out = tmp.join("o.hwpx");
+    let (v, _, c) = run_json(&[
+        "delete-para",
+        f.to_str().unwrap(),
+        "--section",
+        "0",
+        "--index",
+        "1",
+        "--index",
+        "3",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(c, 0);
+    assert_eq!(v["deleted"], 2);
+    assert_eq!(v["indices"], serde_json::json!([1, 3]));
+}
+
+#[test]
 fn fill_named_field_end_to_end() {
     let f = fixture("clickhere_named.hwpx");
     let tmp = test_tmp();

--- a/crates/hwpforge-bindings-mcp/src/tools/structural.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/structural.rs
@@ -204,6 +204,17 @@ mod tests {
     }
 
     #[test]
+    fn write_failure_is_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = base_doc(&dir);
+        let err =
+            run_insert_para(&base, 0, 1, false, "x", "/nonexistent-dir-e4/o.hwpx").unwrap_err();
+        assert_eq!(err.code, "FILE_WRITE_FAILED");
+        let err = run_delete_para(&base, 0, &[1], "/nonexistent-dir-e4/o.hwpx").unwrap_err();
+        assert_eq!(err.code, "FILE_WRITE_FAILED");
+    }
+
+    #[test]
     fn error_code_mapping_reference_and_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let out = dir.path().join("out.hwpx");

--- a/crates/hwpforge-smithy-hwpx/src/structural.rs
+++ b/crates/hwpforge-smithy-hwpx/src/structural.rs
@@ -235,6 +235,33 @@ fn map_admission(error: StamperError) -> StructuralEditError {
     }
 }
 
+/// Input admission gate shared by insert and delete: the base must round-trip
+/// (decode→encode→decode is a no-op) so a byte-splice edit can be verified.
+/// Returns the decoded base on success.
+fn admit(base: &[u8]) -> Result<HwpxDocument, StructuralEditError> {
+    let d0 = HwpxDecoder::decode(base).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
+    let e0 = encode_hwpx(&d0).map_err(map_admission)?;
+    let d1 = HwpxDecoder::decode(&e0).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
+    admission_compare(&d0, &d1).map_err(map_admission)?;
+    check_zip_carry(base, &e0).map_err(map_admission)?;
+    Ok(d0)
+}
+
+/// Reverse-delta self-verify shared by insert and delete: the re-decoded output
+/// must equal the declared delta (Core-structure equality), else the edit is
+/// refused with no bytes.
+fn self_verify(bytes: &[u8], expected: &HwpxDocument) -> Result<(), StructuralEditError> {
+    let d2 = HwpxDecoder::decode(bytes).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
+    admission_compare(&d2, expected).map_err(|e| match e {
+        StamperError::NotRoundTripSafe { component, diff_path } => {
+            StructuralEditError::DeltaMismatch {
+                detail: format!("{component} diverges at {diff_path}"),
+            }
+        }
+        other => StructuralEditError::DeltaMismatch { detail: other.to_string() },
+    })
+}
+
 /// Byte-splice structural editor (preserve-first, admission-gated).
 #[derive(Debug)]
 pub struct HwpxStructuralEditor;
@@ -261,13 +288,7 @@ impl HwpxStructuralEditor {
             return Ok(base.to_vec());
         }
         // ── input admission: base must round-trip so we can verify ──
-        let d0 =
-            HwpxDecoder::decode(base).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
-        let e0 = encode_hwpx(&d0).map_err(map_admission)?;
-        let d1 = HwpxDecoder::decode(&e0).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
-        admission_compare(&d0, &d1).map_err(map_admission)?;
-        check_zip_carry(base, &e0).map_err(map_admission)?;
-
+        let d0 = admit(base)?;
         let sections = d0.document.sections();
 
         // ── preflight: ranges, duplicates, rejection rules ──
@@ -376,21 +397,12 @@ impl HwpxStructuralEditor {
         let bytes = package.write().map_err(|e| StructuralEditError::Codec(e.to_string()))?;
 
         // ── reverse-delta self-verify: output ≡ declared delta ──
-        let d2 =
-            HwpxDecoder::decode(&bytes).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
         let expected_doc = HwpxDocument {
             document: expected,
             style_store: d0.style_store.clone(),
             image_store: d0.image_store.clone(),
         };
-        admission_compare(&d2, &expected_doc).map_err(|e| match e {
-            StamperError::NotRoundTripSafe { component, diff_path } => {
-                StructuralEditError::DeltaMismatch {
-                    detail: format!("{component} diverges at {diff_path}"),
-                }
-            }
-            other => StructuralEditError::DeltaMismatch { detail: other.to_string() },
-        })?;
+        self_verify(&bytes, &expected_doc)?;
 
         Ok(bytes)
     }
@@ -417,12 +429,7 @@ impl HwpxStructuralEditor {
         }
 
         // ── input admission ──
-        let d0 =
-            HwpxDecoder::decode(base).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
-        let e0 = encode_hwpx(&d0).map_err(map_admission)?;
-        let d1 = HwpxDecoder::decode(&e0).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
-        admission_compare(&d0, &d1).map_err(map_admission)?;
-        check_zip_carry(base, &e0).map_err(map_admission)?;
+        let d0 = admit(base)?;
 
         let anchor = insertion.anchor;
         let sections = d0.document.sections();
@@ -533,21 +540,12 @@ impl HwpxStructuralEditor {
         let bytes = package.write().map_err(|e| StructuralEditError::Codec(e.to_string()))?;
 
         // ── reverse-delta self-verify ──
-        let d2 =
-            HwpxDecoder::decode(&bytes).map_err(|e| StructuralEditError::Codec(e.to_string()))?;
         let expected_doc = HwpxDocument {
             document: expected,
             style_store: d0.style_store.clone(),
             image_store: d0.image_store.clone(),
         };
-        admission_compare(&d2, &expected_doc).map_err(|e| match e {
-            StamperError::NotRoundTripSafe { component, diff_path } => {
-                StructuralEditError::DeltaMismatch {
-                    detail: format!("{component} diverges at {diff_path}"),
-                }
-            }
-            other => StructuralEditError::DeltaMismatch { detail: other.to_string() },
-        })?;
+        self_verify(&bytes, &expected_doc)?;
 
         Ok(bytes)
     }
@@ -1151,6 +1149,20 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn insert_refuses_non_round_trip_safe_input() {
+        // The insert admission path (mirrors delete) must also reject a
+        // Hancom-authored input that does not round-trip.
+        let base = fixture("plain_inserted.hwpx");
+        assert!(matches!(
+            HwpxStructuralEditor::insert_paragraph(
+                &base,
+                &insertion(0, 1, InsertPosition::After, "x")
+            ),
+            Err(StructuralEditError::NotRoundTripSafe { .. })
+        ));
+    }
+
     fn paragraph_ids(bytes: &[u8]) -> Vec<u32> {
         let pkg = RawPackage::read(bytes).unwrap();
         let xml = pkg.read_text_entry("Contents/section0.xml").unwrap();
@@ -1256,6 +1268,49 @@ mod tests {
         );
         let out = strip_line_segs_from(xml, 5).unwrap();
         assert_eq!(out, xml, "no paragraph at or past the index → unchanged");
+    }
+
+    #[test]
+    fn self_verify_flags_a_declared_delta_mismatch() {
+        // Safety-net coverage: feed self_verify an "expected" document that
+        // does not match the bytes → the reverse-delta guard must fire.
+        let base = fixture("plain_paragraphs.hwpx");
+        let decoded = HwpxDecoder::decode(&base).unwrap();
+        // Valid bytes decode to 4 paragraphs; claim a 3-paragraph expected.
+        let mut wrong = decoded.document.clone();
+        wrong.sections_mut()[0].paragraphs.pop();
+        let expected = HwpxDocument {
+            document: wrong,
+            style_store: decoded.style_store.clone(),
+            image_store: decoded.image_store.clone(),
+        };
+        assert!(matches!(
+            self_verify(&base, &expected),
+            Err(StructuralEditError::DeltaMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn self_verify_passes_for_matching_expected() {
+        let base = fixture("plain_paragraphs.hwpx");
+        let decoded = HwpxDecoder::decode(&base).unwrap();
+        let expected = HwpxDocument {
+            document: decoded.document.clone(),
+            style_store: decoded.style_store.clone(),
+            image_store: decoded.image_store.clone(),
+        };
+        assert!(self_verify(&base, &expected).is_ok());
+    }
+
+    #[test]
+    fn admit_accepts_round_trip_safe_and_rejects_others() {
+        let base = fixture("plain_paragraphs.hwpx");
+        assert!(admit(&base).is_ok());
+        assert!(matches!(admit(b"not a zip"), Err(StructuralEditError::Codec(_))));
+        assert!(matches!(
+            admit(&fixture("plain_inserted.hwpx")),
+            Err(StructuralEditError::NotRoundTripSafe { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
E4(#112) 머지 후 워크스페이스 커버리지가 90% 문턱 바로 위에 걸려 Release PR(#113)의 Coverage 게이트가 linux 에서 미세하게 실패. E4 구조 편집기의 방어 코드(도달 불가한 안전망: SpanCountMismatch 등)가 커버리지를 눌러서.

이 PR:
- **DRY 리팩터**: delete/insert 에 중복됐던 입력 admission 게이트와 reverse-delta self-verify 를 공유 헬퍼(admit/self_verify)로 추출 — 코드 정리 + 중복 미커버 라인 제거.
- **안전망 fault-injection 테스트**: self_verify 델타 불일치·admit round-trip 거부 등 이전 도달 불가 방어 경로를 직접 커버(안전망 자체의 테스트).
- CLI/MCP FILE_WRITE_FAILED·batch json·insert admission 표면 테스트 보강.

결과: smithy structural.rs 라인 커버 92.36→94.79%, 워크스페이스 90.06%. 안전 코드는 커버리지 위해 제거하지 않음(원칙).