### PR TITLE
docs: 정식 에픽 워크플로우 명문화(.claude/rules) + Current Status v0.11.6 정합

### DIFF
--- a/.claude/rules/epic-workflow.md
+++ b/.claude/rules/epic-workflow.md
@@ -1,0 +1,66 @@
+# 정식 에픽 워크플로우
+
+E3(표 격자 주소)·E4(문단 구조 편집)·E5(outline/read/diff)·E6(템플릿 스탬핑)으로 검증된 프로세스.
+새 에픽/슬라이스는 아래 게이트를 **순서대로** 통과한다. 단계별 상세 규칙이 CLAUDE.md 의 다른 절에
+있으면 그쪽이 canonical — 이 파일은 순서·게이트·금지사항만 정의한다.
+
+## 0. 사전 확인 (ground truth)
+
+- root `AGENTS.md` → `crates/AGENTS.md` → 대상 크레이트 로컬 `AGENTS.md` 순으로 읽는다.
+- 로드맵/브랜치 prose 를 믿지 말고 **코드·매니페스트·git** 에서 현재 상태를 확인한다.
+- workspace grep 으로 **이미 구현된 레이어**를 확인한다 (중복 구현 방지).
+- HWP5 가 새 semantic 을 드러내면 공유 모델(Core)이 carry 가능한지부터 확인한다 (shared-model first).
+- public API/semver 파괴 가능성이 보이면 **즉시 멈추고 사전 승인**을 받는다.
+
+## 1. 연구·설계 재검토 (`.docs/planning/`)
+
+- `.docs/planning/YYYY-MM-DD-<epic>.md` 에 설계를 작성한다 (내부 문서 — **git 커밋 금지**).
+- 설계 결정마다 **실측 근거**를 단다: 코퍼스 측정·네이티브 한컴 fixture 대조·바이트 검증.
+  가정으로 진행하지 않는다 (예: E4 거부 규칙은 정부서식 corpus 과잉거부 0.00% 실측으로 확정).
+- 네이티브 fixture 가 필요하면 **사용자에게 제작을 요청**한다 (한컴에서 만들어줄 수 있음).
+
+## 2. Codex 적대 리뷰 (설계 단계)
+
+- 설계안을 Codex 와 토론해 구멍을 찾는다 (`codex:codex-rescue`).
+- 반영/기각 결과를 계획 문서에 기록한다 (실측이 Codex 원안과 다르면 실측이 이긴다).
+
+## 3. 확정 계획 보고 → 사용자 승인 (필수 게이트)
+
+- **승인 전 구현 착수 금지.** 확정 계획(범위·웨이브 분해·수용 기준·semver 영향·리스크)을
+  보고하고 승인을 받는다.
+
+## 4. TDD 웨이브 구현
+
+- W1..Wn 웨이브 단위로 진행: edge-first TDD → atomic conventional commits (breaking 은 `type!:`).
+- 커밋/푸시·훅·nextest·clippy 함정은 CLAUDE.md **"Tooling Gotchas"** 절이 canonical
+  (commit/push 는 run_in_background + 파일 리다이렉트, 파이프 금지 등).
+- 구현 중 설계와 다른 실측이 나오면 그 자리에서 계획 문서에 수정 근거를 기록한다.
+
+## 5. 시각 게이트 (사용자 판정)
+
+- 실제 산출물을 `examples/hwp5_review/_verify/` 에 생성하고 `open <절대경로>` 로 제시한다.
+- 레이아웃에 닿는 편집(재인코드 경로 포함)은 **PDF 대조**(쪽수·줄바꿈)까지 한다 —
+  admission 은 Core 비교라 wire 캐시(linesegarray 등) 소실을 못 본다.
+- **사용자 판정 없이 통과 처리 금지.**
+
+## 6. 독립 리뷰 + 상환
+
+- 구현 컨텍스트와 **분리된 lane** 에서 코드리뷰를 받는다 (같은 컨텍스트 자기승인 금지).
+- Critical/High = 즉시 수정. Medium/Low = 상환하거나 **백로그로 명시 문서화** (무음 드롭 금지).
+
+## 7. CI → PR → merge queue
+
+- push 전 `make ci` (플래그 일치: `--all-targets`·`--all-features`·fmt `--all`).
+- coverage 게이트 ≥90% — **linux 가 macOS 보다 ~0.02–0.06% 낮게** 나오므로 마진을 확보한다.
+- PR 제목·본문은 **한글**. 머지는 GraphQL `enqueuePullRequest` 로만 (CLAUDE.md "Releasing" 절 canonical).
+
+## 8. 릴리스 (release-plz 소유)
+
+- Release PR 머지 후 release-plz·npm-publish workflow success + crates.io sparse index·
+  GitHub Release·npm 레지스트리 버전을 **실측 검증**한다 (추측 보고 금지).
+- 버전/태그/publish 수동 조작 금지 (CLAUDE.md "Releasing" 절 canonical).
+
+## 9. 기록
+
+- memory `MEMORY.md` 체크포인트 + CLAUDE.md **Current Status** 스냅샷 갱신 (릴리스 후 docs PR).
+- 에픽 상세 이력은 `.docs/planning/` 계획 문서에 남긴다 (CLAUDE.md 에 wave-by-wave 재축적 금지).

--- a/.gitignore
+++ b/.gitignore
@@ -480,6 +480,8 @@ $RECYCLE.BIN/
 .claude/*
 # Share skills (agentskills.io standard — project-level AI instructions)
 !.claude/skills/
+# Share rules (auto-loaded project process rules — e.g. epic workflow)
+!.claude/rules/
 
 # npm package bin/ directories (override global [Bb]in rule)
 !npm/packages/*/bin/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document formats, designed with LLM-first principles. The goal is to enable AI agents (like Claude Code) to generate Korean government proposal documents using natural language + Markdown + YAML style templates.
 
-**Current Status** (snapshot — 2026-07-13):
+**Current Status** (snapshot — 2026-07-25):
 
 - HWPX codec: read/write shipped · Markdown bridge: read/write shipped
 - HWP5 → HWPX converter path: active, style/layout fidelity line in progress
@@ -17,7 +17,7 @@ HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document 
 - Phase 12 HWP5→HWPX carry series (GSO shapes/equation/memo/dutmal/compose/indexmark/click-here·auto fields/cross-ref instId/document metadata/outline 1–10) `main` 머지 완료.
 - **E6 IR 와이어-누출 상환 완료** (`0.9.0`): Summery rename(A) · BookmarkName collapse(B) · raw wire 필드 제거(C) · `inst_id`/`SystemId`→공유 `ObjectId`(M2). **H1(display_text)=Won't-do** (ADR-009 §CLOSURE, memory `e6-wire-leak-status-h1-wontdo.md`).
 - **0.10.0 릴리스** (2026-07-02): colLine(다단 구분선) HWPX+HWP5 carry(breaking) + rmcp 2.0 보안(GHSA-89vp-x53w-74fx)·quick-xml 0.41 + 문서 정합.
-- **AI 편집 Wave 1** (2026-07-12~13): 누름틀(ClickHere) 채우기 — PR #97, **`0.11.0` 릴리스 완료** (crates.io+npm, `feat!:` `Field::display_text` 의미 변경) + `fill` 델타 API·`fields` 발견 표면 — PR #99, **`0.11.1` 릴리스 완료** (2026-07-13, Release PR #100). 설계/로드맵 = `.docs/planning/2026-07-10-agent-editing-architecture.md` (남은 조각: E3 표 격자 주소 · E6 스탬핑).
+- **AI 편집(에이전트 편집) 전 에픽 배포 완료** (2026-07-12~24, `0.11.0`→`0.11.6`): E1 누름틀 채우기(`0.11.0`, `feat!:` `display_text` 의미 변경) · E2 `fill` 델타 API·`fields`(`0.11.1`) · E6 템플릿 스탬핑 W1(`0.11.2`) · E3 표 격자 주소+`set-cell`(`0.11.3`) · E6 W2 클래스-B 셀 스탬핑+`layout_carry` linesegarray 보존(`0.11.4`) · E5 outline/read/diff 읽기 3표면(`0.11.5`) · E4 문단 구조 편집 `insert-para`/`delete-para`(`0.11.6`, preserve-first 바이트 스플라이스 + reverse-delta self-verify). 설계/로드맵 = `.docs/planning/2026-07-10-agent-editing-architecture.md` (남은 후속: E4b 표 행 편집 · `<hp:t>` 줄 경계 분할 보존 등 backlog).
 
 > **이 섹션은 짧은 상태 스냅샷으로만 유지한다 (wave-by-wave 이력을 여기 다시 쌓지 말 것).**
 > Wave별 상세 이력 + breaking change: **`CHANGELOG.md`** (canonical) 와 memory `MEMORY.md` / `phase11_wave_history.md`.
@@ -34,7 +34,7 @@ HwpForge is a Rust library for programmatic control of Korean HWP/HWPX document 
 
 **Workspace Facts** (code-grounded — 카운트는 drift하니 인용 전 확인):
 
-- Cargo packages `11` · crates.io published `0.11.1` (E2 fill 델타 API, 2026-07-13) · MSRV `1.88` · Dev toolchain Rust `1.93`
+- Cargo packages `11` · crates.io published `0.11.6` (E4 문단 구조 편집, 2026-07-24) · MSRV `1.88` · Dev toolchain Rust `1.93`
 - `crates/` 추적 src 파일 ~`177` · nextest ~`2,688` passed + `2` skipped · `examples/` 산출물 `68`+ (미추적 `examples/hwp5_review/` 리뷰 영역 별도 — gitignore 아님) · GitHub workflows `5`
 
 ---
@@ -359,26 +359,10 @@ Local planning and research workspace. It may be git-excluded in this repository
 
 ## Working on a New Slice
 
-### Before Starting
+> **정식 에픽 워크플로우 = `.claude/rules/epic-workflow.md`** (자동 로드 — E3~E6·E4 로 검증된 프로세스, 그쪽이 canonical).
+> 요약: 사전 확인(ground truth) → 연구·설계(`.docs/planning/`, 실측 근거) → Codex 적대 리뷰 → **확정 계획 보고·사용자 승인** → TDD 웨이브 → 시각 게이트(사용자 판정·PDF 대조) → 독립 리뷰 상환 → CI·merge queue → release-plz 릴리스 실측 검증 → 기록.
 
-1. Read root `AGENTS.md`.
-2. Read `crates/AGENTS.md` and the target crate's local `AGENTS.md` if present.
-3. Check code, manifests, and entrypoints before trusting roadmap prose.
-4. If HWP5 reveals a new semantic, confirm the shared model can carry it before wiring format-specific code.
-5. If the change may break public API or semver, stop and get approval first.
-
-### During Implementation
-
-1. **TDD**: Edge cases first
-2. **Atomic commits**: One logical change per commit
-3. **Documentation**: 100% rustdoc (enforced by `#![deny(missing_docs)]`)
-4. **Zero warnings**: `cargo clippy -- -D warnings`
-
-### After Implementation
-
-1. Run `make ci-fast` (or stricter checks if the slice warrants it)
-2. Re-check public API / semver impact before release-facing actions
-3. Update local research or Serena memory only if it materially changes the working model
+구현 중 상시 규칙: **TDD edge-first** · **atomic conventional commits** · **100% rustdoc** (`#![deny(missing_docs)]`) · **zero clippy warnings**.
 
 ---
 


### PR DESCRIPTION
## 요약

E3(표 격자 주소)·E4(문단 구조 편집)·E5(outline/read/diff)·E6(템플릿 스탬핑)으로 검증된 에픽 프로세스를 **정식 워크플로우로 명문화**하고, CLAUDE.md 상태 스냅샷을 v0.11.6 정합으로 갱신한다.

## 변경 내용

### 1. `.claude/rules/epic-workflow.md` 신설 (자동 로드 규칙)

Claude Code 공식 `.claude/rules/` 메커니즘(세션 시작 시 자동 로드)으로 10단계 게이트를 정의:

0. 사전 확인 (ground truth — AGENTS.md·코드·매니페스트, workspace grep)
1. 연구·설계 재검토 (`.docs/planning/`, **설계 결정마다 실측 근거**)
2. Codex 적대 리뷰
3. **확정 계획 보고 → 사용자 승인** (승인 전 구현 착수 금지)
4. TDD 웨이브 구현 (edge-first, atomic conventional commits)
5. 시각 게이트 (사용자 판정·PDF 대조 — admission 은 wire 캐시 소실을 못 봄)
6. 독립 리뷰 + 상환 (분리 lane, Critical/High 즉시 수정)
7. CI → PR → merge queue (coverage linux 마진 주의)
8. 릴리스 (release-plz 소유, 레지스트리 실측 검증)
9. 기록 (memory 체크포인트 + 스냅샷 갱신)

상세 규칙이 CLAUDE.md 다른 절(Tooling Gotchas·Releasing)에 있으면 그쪽이 canonical — 이 파일은 순서·게이트만 정의 (중복 서술 방지).

### 2. `.gitignore` — `!.claude/rules/` 예외 추가

`.claude/*` 무시 아래 skills 와 동일 패턴으로 rules 를 팀 공유 대상으로 승격.

### 3. CLAUDE.md

- `Working on a New Slice` 절을 rules 포인터 + 상시 규칙 요약으로 축소
- Current Status 스냅샷 0.11.1(2026-07-13) → **0.11.6(2026-07-25)** 정합: AI 편집 전 에픽(E1~E6·E4) 배포 완료, 남은 후속 = E4b 표 행 편집·`<hp:t>` 줄 경계 분할 보존 backlog

## 검증

- dprint fmt 통과 (CJK 마크다운)
- pre-commit/pre-push 훅 전부 통과 (docs-only — clippy skip)
- `git status` 로 `.claude/rules/` 추적 전환 확인 (`??` 표시 = 예외 작동)
- 릴리스 비트리거 (`docs:` — release-plz 규칙상 feat/fix 계열만 트리거)