### PR TITLE
feat: E3·E4 소소 후속 묶음 — span-폭주 가드·배치 삽입·IndexMark 경고

### DIFF
--- a/.claude/skills/hwpforge/SKILL.md
+++ b/.claude/skills/hwpforge/SKILL.md
@@ -59,8 +59,10 @@ What does the user want?
 │   │
 │   ├─ ADD or REMOVE a top-level paragraph (structural edit, byte-preserving)
 │   │     → outline/read to find the index → insert-para / delete-para [E4]
-│   │       insert-para --section N --anchor I [--before] --text "…"  (shape inherited)
+│   │       insert-para --section N --anchor I [--before] --text "…"  (shape inherited;
+│   │         --text 반복 = 연속 블록 batch 삽입)
 │   │       delete-para --section N --index I [--index J …]           (batch)
+│   │         IndexMark 든 문단 삭제 시 warnings 로 색인 소멸 advisory (거부 아님)
 │   │       fail-closed: refuses deleting a paragraph with a reference
 │   │       (bookmark/cross-ref/footnote), a hard page/column break, or the
 │   │       section's first paragraph (secPr). Only round-trip-safe inputs.
@@ -146,8 +148,10 @@ hwpforge stamp template.hwpx --map specs.json -o form.hwpx   # + form.manifest.j
 # Structural paragraph editing (E4) — insert/delete top-level paragraphs, byte-preserving.
 hwpforge insert-para doc.hwpx --section 0 --anchor 3 --text "추가 문단" -o out.hwpx
 hwpforge insert-para doc.hwpx --section 0 --anchor 3 --before --text "앞에 추가" -o out.hwpx
+hwpforge insert-para doc.hwpx --section 0 --anchor 3 --text "하나" --text "둘" -o out.hwpx  # 연속 블록 batch
 hwpforge delete-para doc.hwpx --section 0 --index 5 -o out.hwpx           # batch: --index 5 --index 7
-#   새 문단은 앵커의 문단/글자 모양을 상속(스타일 발명 없음); --text 는 한 줄 평문
+#   새 문단은 앵커의 문단/글자 모양을 상속(스타일 발명 없음, batch 는 균일 상속); --text 는 한 줄 평문
+#   delete 는 IndexMark 문단에 warnings advisory 를 내보냄 (JSON: warnings 배열, 텍스트: stderr)
 #   fail-closed 거부: 참조(책갈피/상호참조/각주) 든 문단 삭제·hard page/column break·
 #   섹션 첫 문단(secPr)·섹션을 비우는 삭제. round-trip-safe 입력만. 표 행 편집은 미지원.
 #   반드시 `diff base out` 로 의도한 델타만 났는지 검증

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ bacon test    # Auto-run tests
 - 용량 큰 이미지 임베드 fixture(~MB)는 리뷰 산출물 영역 `examples/hwp5_review/`(미추적 — `git add -A` 주의. **디렉터리 통째 gitignore 금지**: tracked 리뷰 샘플 39개가 있어 cargo/release-plz 가 "committed and in .gitignore" 로 실패, PR #92)에만 두고, 회귀 방지는 **단위 테스트로 잠금**(수 MB fixture를 커밋하지 말 것).
 - **pre-commit `cargo fmt` 훅**: 스테이지된 Rust(특히 테스트의 다줄 배열/`assert!`)를 재포맷하며 커밋을 **거부**함 → `cargo fmt` 수동 실행 → 재-`git add` → 재커밋 (dprint 표와 동일 패턴).
 - **pre-commit/pre-push 훅이 workspace clippy(+`make ci`)를 돌림** → 다파일 커밋·push는 **2분+**, cold/contended 빌드 땐 **20분+** 까지 감. 항상 `run_in_background`로 commit/push 후 폴링.
+- **docs-only 커밋/push 는 빠름**: pre-commit clippy·fmt 는 staged 에 Rust 파일이 있을 때만 실행(`no files to check` skip) — "훅 2분+" 은 Rust 변경 시에만 해당 (백그라운드 실행 원칙은 동일).
 - **`git push` 를 파이프에 연결 금지**(`| tail` 등) — pre-push 훅의 대량 테스트 출력이 `BlockingIOError [Errno 35]` 로 push 자체를 죽임. run_in_background(파일 리다이렉트)로 실행하고, 성공 판정은 `git ls-remote --heads origin <branch> | grep -q .` 로.
 - pre-push `cargo deny` 가 RustSec advisory DB fetch 네트워크 오류로 간헐 실패 → 재시도로 해결.
 - **전체 `cargo nextest run --workspace`는 cold 빌드 시 15분+** (foreground 한계 초과) → 변경 영향 크레이트만 `-p <crate>`로 돌리고 byte-중립 게이트만 골라 검증. **테스트 실행 중 소스 편집 금지**(rebuild 유발로 더 느려짐).
@@ -382,6 +383,7 @@ Local planning and research workspace. It may be git-excluded in this repository
 - **inter-crate 의존성은 `version = "0"` 유지 — 정확 핀으로 "고치지" 말 것.** 통합버전(`version.workspace = true`) 워크스페이스에서 release-plz 는 커밋 없는 베이스 crate 를 못 올려, 정확 핀이면 breaking bump 시 `failed to select a version` 으로 Release PR 생성이 죽음 (PR #94 로 해결; `version_group`·`release_always` 는 무효 — 로컬 전수검증, memory `release-plz-unified-version-workspace.md`).
 - **release-plz 디버깅은 로컬 프리빌트로 재현** (CI 머지 사이클로 추측 금지): `gh release download release-plz-v0.3.159 --repo release-plz/release-plz` + 깨끗한 clone 에서 `release-plz update`. `{{ release_link }}` 는 로컬 렌더 실패 → 임시 제거 후 실험 (cargo install 은 rustc 1.94 요구로 로컬 1.93 에서 실패).
 - **publish 검증**: crates.io API(`crates.io/api`) 는 샌드박스에서 막힐 수 있음 → sparse index `index.crates.io/hw/pf/<crate>`(`dangerouslyDisableSandbox`)로 published 버전 확인.
+- **릴리스 완주 판정**: GitHub Release 는 release-plz 실행 **도중** 먼저 게시되고 그 이벤트가 npm-publish 를 트리거 → release-plz·npm-publish **둘 다 success** + npm 레지스트리(`npm view @hwpforge/mcp version`)·sparse index 실측까지 확인해야 완료 (Release 게시만 보고 완료 오판 금지).
 
 ---
 

--- a/crates/hwpforge-bindings-cli/src/analysis/deep_counts/table_properties.rs
+++ b/crates/hwpforge-bindings-cli/src/analysis/deep_counts/table_properties.rs
@@ -73,6 +73,9 @@ pub(crate) struct DeepTablePropertiesSummary {
     pub repeat_header_tables: usize,
     pub header_rows: usize,
     pub nonzero_cell_spacing_tables: usize,
+    /// Tables whose covered span area exceeded the placement cap, so the
+    /// grid-aware cell-address scan was skipped (positional fallback used).
+    pub cell_addr_scan_skipped_tables: usize,
     pub table_border_fill_ids: BTreeSet<u32>,
     pub cell_border_fill_ids: BTreeSet<u32>,
     pub cell_heights_hwp: BTreeSet<i32>,
@@ -109,7 +112,16 @@ impl DeepTablePropertiesSummary {
             row_max_cell_heights_hwp,
         );
 
-        let cell_addrs = compute_table_cell_addresses(table);
+        let cell_addrs = match compute_table_cell_addresses(table) {
+            Some(addrs) => addrs,
+            None => {
+                // Covered-area cap tripped: degrade to positional column
+                // addresses instead of feeding the placement scan, and
+                // surface the skip through the notes channel.
+                self.cell_addr_scan_skipped_tables += 1;
+                positional_cell_addresses(table)
+            }
+        };
         for (row_idx, row) in table.rows.iter().enumerate() {
             for (cell_idx, cell) in row.cells.iter().enumerate() {
                 self.observe_table_cell(
@@ -359,6 +371,12 @@ pub(crate) fn append_table_property_notes(
     if summary.nonzero_cell_spacing_tables > 0 {
         notes.push(format!("table-nonzero-cell-spacing: {}", summary.nonzero_cell_spacing_tables));
     }
+    if summary.cell_addr_scan_skipped_tables > 0 {
+        notes.push(format!(
+            "table-cell-addr-scan-skipped: {}",
+            summary.cell_addr_scan_skipped_tables
+        ));
+    }
     if !summary.table_border_fill_ids.is_empty() {
         let ids =
             summary.table_border_fill_ids.iter().map(u32::to_string).collect::<Vec<_>>().join(",");
@@ -492,7 +510,15 @@ fn deep_table_vertical_align_from_core(value: TableVerticalAlign) -> DeepTableVe
     }
 }
 
-fn compute_table_cell_addresses(table: &Table) -> Vec<Vec<u16>> {
+fn compute_table_cell_addresses(table: &Table) -> Option<Vec<Vec<u16>>> {
+    // Guard the lenient placement scan before it allocates per-position
+    // state — this surface reads untrusted files, so pathological spans
+    // (e.g. 65535×65535) must not exhaust memory. `None` = caller degrades.
+    if hwpforge_core::table::grid::covered_area(table)
+        > hwpforge_core::table::grid::MAX_GRID_POSITIONS
+    {
+        return None;
+    }
     // Shared lenient placement (same scan the HWPX encoder uses); this
     // analysis surface reports u16 like the wire, clamping pathological
     // widths instead of wrapping.
@@ -502,7 +528,17 @@ fn compute_table_cell_addresses(table: &Table) -> Vec<Vec<u16>> {
     for placed in &placements.cells {
         row_addrs[placed.row_idx].push(placed.at.col.min(u32::from(u16::MAX)) as u16);
     }
-    row_addrs
+    Some(row_addrs)
+}
+
+/// Positional fallback when the covered-area cap refuses the placement scan:
+/// each cell reports its in-row index as the column address.
+fn positional_cell_addresses(table: &Table) -> Vec<Vec<u16>> {
+    table
+        .rows
+        .iter()
+        .map(|row| (0..row.cells.len()).map(|i| i.min(usize::from(u16::MAX)) as u16).collect())
+        .collect()
 }
 
 fn structural_table_width_hwp(table: &Table) -> Option<i32> {
@@ -523,4 +559,59 @@ fn structural_row_max_cell_heights_hwp(table: &Table) -> Vec<i32> {
                 .max()
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hwpforge_core::table::TableRow;
+    use hwpforge_foundation::HwpUnit;
+
+    fn spanned_cell(col_span: u16, row_span: u16) -> TableCell {
+        TableCell::with_span(vec![], HwpUnit::new(3000).unwrap(), col_span, row_span)
+    }
+
+    #[test]
+    fn pathological_span_table_degrades_to_positional_addresses() {
+        // Covered area 1025×1024 > MAX_GRID_POSITIONS: the scan is skipped,
+        // addresses fall back to in-row positions, and the skip surfaces
+        // through the notes channel instead of silently degrading.
+        let table = Table::new(vec![TableRow::new(vec![spanned_cell(1025, 1024)])]);
+        assert!(compute_table_cell_addresses(&table).is_none());
+        assert_eq!(positional_cell_addresses(&table), vec![vec![0]]);
+
+        let mut summary = DeepTablePropertiesSummary::default();
+        let mut next_ordinal = 1;
+        summary.observe_table(0, 0, &table, &mut next_ordinal);
+        assert_eq!(summary.cell_addr_scan_skipped_tables, 1);
+
+        let mut notes = Vec::new();
+        append_table_property_notes(&mut notes, &summary);
+        assert!(
+            notes.iter().any(|note| note == "table-cell-addr-scan-skipped: 1"),
+            "missing skip note in: {notes:?}"
+        );
+    }
+
+    #[test]
+    fn normal_table_keeps_grid_addresses_without_skip_note() {
+        // Merged first cell (row_span 2) shifts the second row's only cell to
+        // column 1 — the grid-aware address, not the positional fallback
+        // (which would report 0).
+        let table = Table::new(vec![
+            TableRow::new(vec![spanned_cell(1, 2), spanned_cell(1, 1)]),
+            TableRow::new(vec![spanned_cell(1, 1)]),
+        ]);
+        let addrs = compute_table_cell_addresses(&table).expect("well under the cap");
+        assert_eq!(addrs, vec![vec![0, 1], vec![1]]);
+
+        let mut summary = DeepTablePropertiesSummary::default();
+        let mut next_ordinal = 1;
+        summary.observe_table(0, 0, &table, &mut next_ordinal);
+        assert_eq!(summary.cell_addr_scan_skipped_tables, 0);
+
+        let mut notes = Vec::new();
+        append_table_property_notes(&mut notes, &summary);
+        assert!(notes.iter().all(|note| !note.contains("cell-addr-scan-skipped")));
+    }
 }

--- a/crates/hwpforge-bindings-cli/src/commands/structural.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/structural.rs
@@ -3,7 +3,8 @@
 use std::path::PathBuf;
 
 use hwpforge_smithy_hwpx::{
-    HwpxStructuralEditor, InsertPosition, Insertion, ParagraphLocator, StructuralEditError,
+    scan_delete_warnings, HwpxStructuralEditor, InsertPosition, ParagraphLocator,
+    StructuralEditError,
 };
 
 use crate::error::{check_file_size, CliError};
@@ -22,16 +23,28 @@ pub fn run_delete(
     let bytes = read_input(file, json_mode);
     let targets: Vec<ParagraphLocator> =
         indices.iter().map(|&index| ParagraphLocator { section, index }).collect();
+    // Advisory scan (shared library messages — never a refusal): surfaced
+    // only alongside a successful edit.
+    let warnings: Vec<String> =
+        scan_delete_warnings(&bytes, &targets).iter().map(ToString::to_string).collect();
     match HwpxStructuralEditor::delete_paragraphs(&bytes, &targets) {
-        Ok(out) => write_output(&out, output, json_mode, |v| {
-            *v = serde_json::json!({
-                "status": "ok",
-                "deleted": indices.len(),
-                "section": section,
-                "indices": indices,
-                "output": output.display().to_string(),
+        Ok(out) => {
+            if !json_mode {
+                for warning in &warnings {
+                    eprintln!("warning: {warning}");
+                }
+            }
+            write_output(&out, output, json_mode, |v| {
+                *v = serde_json::json!({
+                    "status": "ok",
+                    "deleted": indices.len(),
+                    "section": section,
+                    "indices": indices,
+                    "warnings": warnings,
+                    "output": output.display().to_string(),
+                });
             });
-        }),
+        }
         Err(e) => exit_structural_error(e, json_mode),
     }
 }
@@ -43,21 +56,18 @@ pub fn run_insert(
     section: usize,
     anchor: usize,
     before: bool,
-    text: &str,
+    texts: &[String],
     output: &PathBuf,
     json_mode: bool,
 ) {
     let bytes = read_input(file, json_mode);
     let position = if before { InsertPosition::Before } else { InsertPosition::After };
-    let insertion = Insertion {
-        anchor: ParagraphLocator { section, index: anchor },
-        position,
-        text: text.to_string(),
-    };
-    match HwpxStructuralEditor::insert_paragraph(&bytes, &insertion) {
+    let anchor_loc = ParagraphLocator { section, index: anchor };
+    match HwpxStructuralEditor::insert_paragraphs(&bytes, anchor_loc, position, texts) {
         Ok(out) => write_output(&out, output, json_mode, |v| {
             *v = serde_json::json!({
                 "status": "ok",
+                "inserted": texts.len(),
                 "section": section,
                 "anchor": anchor,
                 "position": if before { "before" } else { "after" },

--- a/crates/hwpforge-bindings-cli/src/main.rs
+++ b/crates/hwpforge-bindings-cli/src/main.rs
@@ -182,7 +182,7 @@ enum Commands {
 
     /// Insert a new paragraph relative to an anchor (structural edit, E4).
     #[command(
-        long_about = "Insert one new top-level paragraph before or after an anchor paragraph, preserving every other byte.\n\nThe new paragraph inherits the anchor's paragraph and character shape (no style is invented); --text is a single line of plain text (the encoder escapes it). Insert-before the section's first paragraph (secPr carrier) is refused. Only round-trip-safe inputs are editable. Verify with `diff base out`."
+        long_about = "Insert new top-level paragraph(s) before or after an anchor paragraph, preserving every other byte.\n\nEach new paragraph uniformly inherits the anchor's paragraph and character shape (no style is invented); --text is a single line of plain text (the encoder escapes it) and may be repeated to insert a contiguous block in one verified edit. Insert-before the section's first paragraph (secPr carrier) is refused. Only round-trip-safe inputs are editable. Verify with `diff base out`."
     )]
     InsertPara {
         /// HWPX file to edit.
@@ -200,9 +200,10 @@ enum Commands {
         #[arg(long)]
         before: bool,
 
-        /// Plain text of the new paragraph (single line).
-        #[arg(long)]
-        text: String,
+        /// Plain text of a new paragraph (single line). Repeat the flag to
+        /// insert a contiguous block of paragraphs in one verified edit.
+        #[arg(long = "text", required = true)]
+        texts: Vec<String>,
 
         /// Output HWPX file path.
         #[arg(short, long)]
@@ -420,9 +421,9 @@ fn main() {
         Commands::DeletePara { file, section, indices, output } => {
             commands::structural::run_delete(&file, section, &indices, &output, cli.json);
         }
-        Commands::InsertPara { file, section, anchor, before, text, output } => {
+        Commands::InsertPara { file, section, anchor, before, texts, output } => {
             commands::structural::run_insert(
-                &file, section, anchor, before, &text, &output, cli.json,
+                &file, section, anchor, before, &texts, &output, cli.json,
             );
         }
         Commands::Read { file, section, paras, table, field } => {

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -3377,6 +3377,44 @@ fn insert_para_adds_paragraph_and_diff_confirms_delta() {
 }
 
 #[test]
+fn insert_para_batch_adds_block_and_diff_confirms_delta() {
+    // Repeated --text inserts a contiguous block in one verified edit; the
+    // E5 diff must report exactly the declared block, in order.
+    let f = fixture("plain_paragraphs.hwpx");
+    let tmp = test_tmp();
+    let out = tmp.join("inserted-batch.hwpx");
+    let (value, _, code) = run_json(&[
+        "insert-para",
+        f.to_str().unwrap(),
+        "--section",
+        "0",
+        "--anchor",
+        "1",
+        "--text",
+        "블록 하나",
+        "--text",
+        "블록 둘",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    assert_eq!(value["status"], "ok");
+    assert_eq!(value["inserted"], 2);
+
+    let (d, _, dc) = run_json(&["diff", f.to_str().unwrap(), out.to_str().unwrap()]);
+    assert_eq!(dc, 0);
+    let added: Vec<_> = d["diff"]["semantic"]["paragraphs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|p| p["kind"] == "added")
+        .collect();
+    assert_eq!(added.len(), 2);
+    assert_eq!(added[0]["after"], "블록 하나");
+    assert_eq!(added[1]["after"], "블록 둘");
+}
+
+#[test]
 fn delete_para_removes_paragraph_and_rejects_section_properties() {
     let f = fixture("plain_paragraphs.hwpx");
     let tmp = test_tmp();
@@ -3393,6 +3431,8 @@ fn delete_para_removes_paragraph_and_rejects_section_properties() {
     ]);
     assert_eq!(code, 0);
     assert_eq!(value["deleted"], 1);
+    // Plain paragraphs produce no advisories; the field is always present.
+    assert_eq!(value["warnings"].as_array().map(Vec::len), Some(0));
 
     // Deleting paragraph 0 (secPr carrier) is refused.
     let (err, _, ec) = run_json(&[

--- a/crates/hwpforge-bindings-mcp/src/server.rs
+++ b/crates/hwpforge-bindings-mcp/src/server.rs
@@ -117,8 +117,15 @@ pub struct InsertParaRequest {
     /// Insert before the anchor instead of after.
     #[serde(default)]
     pub before: bool,
-    /// Plain text of the new paragraph (single line).
-    pub text: String,
+    /// Plain text of the new paragraph (single line). Provide exactly one of
+    /// `text` or `texts`.
+    #[serde(default)]
+    pub text: Option<String>,
+    /// Plain texts of a contiguous block of new paragraphs (one single-line
+    /// entry per paragraph, inserted in order in one verified edit). Provide
+    /// exactly one of `text` or `texts`.
+    #[serde(default)]
+    pub texts: Option<Vec<String>>,
     /// Output HWPX file path.
     pub output_path: String,
 }
@@ -590,7 +597,8 @@ impl HwpForgeServer {
                 req.section,
                 req.anchor,
                 req.before,
-                &req.text,
+                req.text.as_deref(),
+                req.texts.as_deref(),
                 &req.output_path,
             )
         })

--- a/crates/hwpforge-bindings-mcp/src/tools/structural.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/structural.rs
@@ -3,7 +3,8 @@
 use serde::Serialize;
 
 use hwpforge_smithy_hwpx::{
-    HwpxStructuralEditor, InsertPosition, Insertion, ParagraphLocator, StructuralEditError,
+    scan_delete_warnings, HwpxStructuralEditor, InsertPosition, ParagraphLocator,
+    StructuralEditError,
 };
 
 use crate::output::{read_file_bytes, ToolErrorInfo};
@@ -15,6 +16,9 @@ pub struct StructuralData {
     pub output_path: String,
     /// Human-readable description of what changed.
     pub change: String,
+    /// Non-blocking advisories (e.g. index-mark removal). Omitted when empty.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 /// Delete top-level paragraphs, all-or-nothing.
@@ -34,36 +38,57 @@ pub fn run_delete_para(
     let bytes = read_file_bytes(file_path)?;
     let targets: Vec<ParagraphLocator> =
         indices.iter().map(|&index| ParagraphLocator { section, index }).collect();
+    // Advisory scan (shared library messages — never a refusal): surfaced
+    // only alongside a successful edit.
+    let warnings: Vec<String> =
+        scan_delete_warnings(&bytes, &targets).iter().map(ToString::to_string).collect();
     let out = HwpxStructuralEditor::delete_paragraphs(&bytes, &targets).map_err(map_error)?;
     write_bytes(&out, output_path)?;
     Ok(StructuralData {
         output_path: output_path.to_string(),
         change: format!("deleted {} paragraph(s) from section {section}", indices.len()),
+        warnings,
     })
 }
 
-/// Insert one paragraph relative to an anchor.
+/// Insert a contiguous block of paragraphs relative to an anchor.
+///
+/// Exactly one of `text` (single paragraph) or `texts` (block) must be
+/// provided.
 pub fn run_insert_para(
     file_path: &str,
     section: usize,
     anchor: usize,
     before: bool,
-    text: &str,
+    text: Option<&str>,
+    texts: Option<&[String]>,
     output_path: &str,
 ) -> Result<StructuralData, ToolErrorInfo> {
+    let block: Vec<String> = match (text, texts) {
+        (Some(t), None) => vec![t.to_string()],
+        (None, Some(ts)) if !ts.is_empty() => ts.to_vec(),
+        _ => {
+            return Err(ToolErrorInfo::new(
+                "INSERT_TEXT_REQUIRED",
+                "Provide exactly one of `text` or `texts` (non-empty)",
+                "Use `text` for a single paragraph or `texts` for a contiguous block.",
+            ));
+        }
+    };
     let bytes = read_file_bytes(file_path)?;
     let position = if before { InsertPosition::Before } else { InsertPosition::After };
-    let insertion = Insertion {
-        anchor: ParagraphLocator { section, index: anchor },
-        position,
-        text: text.to_string(),
-    };
-    let out = HwpxStructuralEditor::insert_paragraph(&bytes, &insertion).map_err(map_error)?;
+    let anchor_loc = ParagraphLocator { section, index: anchor };
+    let out = HwpxStructuralEditor::insert_paragraphs(&bytes, anchor_loc, position, &block)
+        .map_err(map_error)?;
     write_bytes(&out, output_path)?;
     let where_ = if before { "before" } else { "after" };
     Ok(StructuralData {
         output_path: output_path.to_string(),
-        change: format!("inserted a paragraph {where_} section {section} paragraph {anchor}"),
+        change: format!(
+            "inserted {} paragraph(s) {where_} section {section} paragraph {anchor}",
+            block.len()
+        ),
+        warnings: Vec::new(),
     })
 }
 
@@ -140,9 +165,44 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let base = base_doc(&dir);
         let out = dir.path().join("out.hwpx");
-        let data = run_insert_para(&base, 0, 1, false, "삽입", out.to_str().unwrap()).unwrap();
-        assert!(data.change.contains("inserted"));
+        let data =
+            run_insert_para(&base, 0, 1, false, Some("삽입"), None, out.to_str().unwrap()).unwrap();
+        assert!(data.change.contains("inserted 1 paragraph"));
         assert!(out.exists());
+    }
+
+    #[test]
+    fn insert_para_batch_via_texts() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = base_doc(&dir);
+        let out = dir.path().join("out.hwpx");
+        let block = vec!["하나.".to_string(), "둘.".to_string()];
+        let data =
+            run_insert_para(&base, 0, 1, false, None, Some(&block), out.to_str().unwrap()).unwrap();
+        assert!(data.change.contains("inserted 2 paragraph"));
+        assert!(out.exists());
+    }
+
+    #[test]
+    fn insert_para_requires_exactly_one_text_form() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = base_doc(&dir);
+        let out = dir.path().join("out.hwpx");
+        let block = vec!["x".to_string()];
+
+        // Neither form.
+        let err =
+            run_insert_para(&base, 0, 1, false, None, None, out.to_str().unwrap()).unwrap_err();
+        assert_eq!(err.code, "INSERT_TEXT_REQUIRED");
+        // Both forms (ambiguous).
+        let err =
+            run_insert_para(&base, 0, 1, false, Some("x"), Some(&block), out.to_str().unwrap())
+                .unwrap_err();
+        assert_eq!(err.code, "INSERT_TEXT_REQUIRED");
+        // Empty block.
+        let err = run_insert_para(&base, 0, 1, false, None, Some(&[]), out.to_str().unwrap())
+            .unwrap_err();
+        assert_eq!(err.code, "INSERT_TEXT_REQUIRED");
     }
 
     #[test]
@@ -152,6 +212,7 @@ mod tests {
         let out = dir.path().join("out.hwpx");
         let data = run_delete_para(&base, 0, &[1], out.to_str().unwrap()).unwrap();
         assert!(data.change.contains("deleted"));
+        assert!(data.warnings.is_empty(), "plain paragraph must not warn: {:?}", data.warnings);
 
         let err = run_delete_para(&base, 0, &[0], out.to_str().unwrap()).unwrap_err();
         assert_eq!(err.code, "SECTION_PROPERTIES_PARAGRAPH");
@@ -173,13 +234,15 @@ mod tests {
         let out = dir.path().join("out.hwpx");
 
         // out-of-range anchor / index.
-        let err = run_insert_para(&base, 0, 99, false, "x", out.to_str().unwrap()).unwrap_err();
+        let err = run_insert_para(&base, 0, 99, false, Some("x"), None, out.to_str().unwrap())
+            .unwrap_err();
         assert_eq!(err.code, "INDEX_OUT_OF_RANGE");
         let err = run_delete_para(&base, 9, &[0], out.to_str().unwrap()).unwrap_err();
         assert_eq!(err.code, "INDEX_OUT_OF_RANGE");
 
         // multiline text.
-        let err = run_insert_para(&base, 0, 1, false, "a\nb", out.to_str().unwrap()).unwrap_err();
+        let err = run_insert_para(&base, 0, 1, false, Some("a\nb"), None, out.to_str().unwrap())
+            .unwrap_err();
         assert_eq!(err.code, "MULTI_PARAGRAPH_TEXT");
 
         // duplicate target in a batch.
@@ -208,7 +271,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let base = base_doc(&dir);
         let err =
-            run_insert_para(&base, 0, 1, false, "x", "/nonexistent-dir-e4/o.hwpx").unwrap_err();
+            run_insert_para(&base, 0, 1, false, Some("x"), None, "/nonexistent-dir-e4/o.hwpx")
+                .unwrap_err();
         assert_eq!(err.code, "FILE_WRITE_FAILED");
         let err = run_delete_para(&base, 0, &[1], "/nonexistent-dir-e4/o.hwpx").unwrap_err();
         assert_eq!(err.code, "FILE_WRITE_FAILED");

--- a/crates/hwpforge-bindings-mcp/src/tools/structural.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/structural.rs
@@ -11,6 +11,7 @@ use crate::output::{read_file_bytes, ToolErrorInfo};
 
 /// Output of a structural edit.
 #[derive(Debug, Serialize)]
+#[non_exhaustive]
 pub struct StructuralData {
     /// Path the edited HWPX was written to.
     pub output_path: String,

--- a/crates/hwpforge-core/src/table/grid.rs
+++ b/crates/hwpforge-core/src/table/grid.rs
@@ -191,6 +191,26 @@ pub fn grid_placements(table: &Table) -> GridPlacements {
     GridPlacements { cells, cols }
 }
 
+/// Sums the grid area covered by every cell's span (`col_span × row_span`,
+/// each floored at 1), saturating at `u64::MAX`.
+///
+/// This is the O(cells) pre-check that strict [`TableGrid::from_table`]
+/// performs before scanning; lenient call sites compare the result against
+/// [`MAX_GRID_POSITIONS`] to refuse or degrade **before** [`grid_placements`]
+/// allocates per-position state. For overlapping spans the sum over-counts
+/// actual coverage, which is the conservative direction for a cap guard.
+#[must_use]
+pub fn covered_area(table: &Table) -> u64 {
+    let mut covered: u64 = 0;
+    for row in &table.rows {
+        for cell in &row.cells {
+            let area = u64::from(cell.col_span.max(1)) * u64::from(cell.row_span.max(1));
+            covered = covered.saturating_add(area);
+        }
+    }
+    covered
+}
+
 /// Interval of covered columns within one logical row: `[start, end)` maps to
 /// `anchors[idx]`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -224,15 +244,9 @@ impl TableGrid {
 
         // Pre-check total covered area before any per-position allocation so
         // pathological spans cannot exhaust memory while scanning.
-        let mut covered_area: u64 = 0;
-        for row in &table.rows {
-            for cell in &row.cells {
-                let area = u64::from(cell.col_span.max(1)) * u64::from(cell.row_span.max(1));
-                covered_area = covered_area.saturating_add(area);
-            }
-        }
-        if covered_area > MAX_GRID_POSITIONS {
-            return Err(GridError::TooLarge { rows: u64::from(rows), cols: covered_area });
+        let area = covered_area(table);
+        if area > MAX_GRID_POSITIONS {
+            return Err(GridError::TooLarge { rows: u64::from(rows), cols: area });
         }
 
         let mut anchors: Vec<GridCell> = Vec::new();
@@ -508,5 +522,40 @@ mod tests {
         assert_eq!(placements.cells.len(), 4);
         assert_eq!(placements.cells[3].at, GridCoord::new(1, 1));
         assert_eq!(placements.cols, 3);
+    }
+
+    // === covered_area pre-check primitive ===
+
+    #[test]
+    fn covered_area_sums_span_areas() {
+        // rs2×cs1 + rs1×cs2 + two 1×1 = 2 + 2 + 1 + 1 = 6.
+        let t = table(vec![vec![cell(2, 1), cell(1, 2)], vec![cell(1, 1), cell(1, 1)]]);
+        assert_eq!(covered_area(&t), 6);
+        // Empty table covers nothing.
+        assert_eq!(covered_area(&table(vec![])), 0);
+    }
+
+    #[test]
+    fn covered_area_floors_zero_spans_at_one() {
+        // Mirrors the placement scan's `.max(1)` so the guard and the scan
+        // agree on what a degenerate span occupies.
+        let t = table(vec![vec![cell(0, 0), cell(0, 3)]]);
+        assert_eq!(covered_area(&t), 1 + 3);
+    }
+
+    #[test]
+    fn covered_area_boundary_sits_exactly_at_cap() {
+        // 1024×1024 = MAX_GRID_POSITIONS exactly; guards use strict `>` so
+        // this table is still allowed.
+        let t = table(vec![vec![cell(1024, 1024)]]);
+        assert_eq!(covered_area(&t), MAX_GRID_POSITIONS);
+    }
+
+    #[test]
+    fn covered_area_saturates_instead_of_overflowing() {
+        let row: Vec<TableCell> = (0..8).map(|_| cell(u16::MAX, u16::MAX)).collect();
+        let t = table(vec![row]);
+        assert_eq!(covered_area(&t), 8 * 4_294_836_225u64);
+        assert!(covered_area(&t) > MAX_GRID_POSITIONS);
     }
 }

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -1644,6 +1644,27 @@ mod tests {
     }
 
     #[test]
+    fn pathological_span_table_rejected_before_placement() {
+        // Covered area 1025×1024 = 1_049_600 > MAX_GRID_POSITIONS
+        // (1_048_576): the encoder must fail fast instead of feeding the
+        // lenient placement scan per-position state.
+        let cell = TableCell::with_span(
+            vec![text_paragraph("x", 0, 0)],
+            HwpUnit::new(3000).unwrap(),
+            1025,
+            1024,
+        );
+        let table = Table::new(vec![TableRow::new(vec![cell])]);
+        let err = build_table(&table, 0, &mut Vec::new()).unwrap_err();
+        match &err {
+            HwpxError::InvalidStructure { detail } => {
+                assert!(detail.contains("covered area"), "unexpected detail: {detail}");
+            }
+            _ => panic!("expected InvalidStructure, got: {err:?}"),
+        }
+    }
+
+    #[test]
     fn image_without_bindata_prefix() {
         let img = Image::new(
             "image.jpg",

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/table.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/table.rs
@@ -17,6 +17,20 @@ pub(super) fn build_table(
         });
     }
 
+    // Guard the lenient placement scan before it allocates per-position
+    // state: pathological spans (e.g. 65535×65535) cover billions of grid
+    // positions. Same O(cells) pre-check the strict grid runs internally.
+    let area = hwpforge_core::table::grid::covered_area(table);
+    if area > hwpforge_core::table::grid::MAX_GRID_POSITIONS {
+        return Err(HwpxError::InvalidStructure {
+            detail: format!(
+                "table covered area {} exceeds the {}-position placement cap",
+                area,
+                hwpforge_core::table::grid::MAX_GRID_POSITIONS,
+            ),
+        });
+    }
+
     // Grid placement computes correct cellAddr for merged cells. The lenient
     // scan is shared with `hwpforge_core::table::grid` and keeps historical
     // output even for tables that do not tile a well-formed grid.

--- a/crates/hwpforge-smithy-hwpx/src/grid_addr.rs
+++ b/crates/hwpforge-smithy-hwpx/src/grid_addr.rs
@@ -391,6 +391,29 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "perf probe (E3 L5): run manually — numbers recorded in the planning doc"]
+    fn perf_probe_annotate_and_verify_on_large_table() {
+        // 100×100 = 10,000 cells — well above the largest corpus table
+        // (414 logical positions). Probes the per-cell root-`nav` cost that
+        // the E3 review flagged; refactor only if these numbers matter.
+        let big = Table::new(
+            (0..100).map(|_| TableRow::new((0..100).map(|_| cell(1, 1)).collect())).collect(),
+        );
+        let doc = doc_with(big);
+        let mut root = export_value(&doc);
+
+        let t0 = std::time::Instant::now();
+        annotate_document_addresses(&mut root, &doc).expect("annotate");
+        let annotate = t0.elapsed();
+
+        let t1 = std::time::Instant::now();
+        verify_document_addresses(&root, &doc).expect("verify");
+        let verify = t1.elapsed();
+
+        eprintln!("perf-probe 10k cells: annotate={annotate:?} verify={verify:?}");
+    }
+
+    #[test]
     fn verify_accepts_annotated_export_and_absent_addrs() {
         let doc = doc_with(merged_table());
         let mut root = export_value(&doc);

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -105,7 +105,8 @@ pub use section_workflow::{
     SectionExportOutcome, SectionPatchOutcome, SectionWorkflowError, SectionWorkflowWarning,
 };
 pub use structural::{
-    HwpxStructuralEditor, InsertPosition, Insertion, ParagraphLocator, StructuralEditError,
+    scan_delete_warnings, HwpxStructuralEditor, InsertPosition, Insertion, ParagraphLocator,
+    StructuralEditError, StructuralWarning,
 };
 pub use style_lookup_bridge::HwpxStyleLookup;
 pub use style_store::{

--- a/crates/hwpforge-smithy-hwpx/src/structural.rs
+++ b/crates/hwpforge-smithy-hwpx/src/structural.rs
@@ -409,13 +409,8 @@ impl HwpxStructuralEditor {
 
     /// Inserts one new paragraph, preserving every other byte of the package.
     ///
-    /// The new paragraph inherits the anchor's paragraph and character shape
-    /// (no style is invented); only its text is new. The paragraph is encoded
-    /// by the real encoder — so escaping and element order are correct — and
-    /// its bytes are spliced into the original section XML, leaving untouched
-    /// paragraphs (and their Hancom line-layout caches) exactly as they were.
-    /// Paragraphs from the insertion point down have their now-stale caches
-    /// stripped so the renderer recomputes them.
+    /// Delegates to [`Self::insert_paragraphs`] with a single-text batch —
+    /// one implementation, two surfaces.
     ///
     /// # Errors
     ///
@@ -424,14 +419,56 @@ impl HwpxStructuralEditor {
         base: &[u8],
         insertion: &Insertion,
     ) -> Result<Vec<u8>, StructuralEditError> {
-        if insertion.text.contains('\n') || insertion.text.contains('\r') {
-            return Err(StructuralEditError::MultiParagraphText);
+        Self::insert_paragraphs(
+            base,
+            insertion.anchor,
+            insertion.position,
+            std::slice::from_ref(&insertion.text),
+        )
+    }
+
+    /// Inserts a contiguous block of new paragraphs at one anchor, preserving
+    /// every other byte of the package (batch form of
+    /// [`Self::insert_paragraph`]).
+    ///
+    /// Every inserted paragraph **uniformly** inherits the anchor's paragraph
+    /// and character shape (no per-paragraph override — this is a block of
+    /// sibling paragraphs, not the Markdown task-item continuation bridge of
+    /// gotcha #11); only the texts are new. `texts[0]` lands first, the rest
+    /// follow in order. The paragraphs are encoded by the real encoder — so
+    /// escaping and element order are correct — and their bytes are spliced
+    /// into the original section XML in one splice, leaving untouched
+    /// paragraphs (and their Hancom line-layout caches) exactly as they were.
+    /// Paragraphs from the insertion point down have their now-stale caches
+    /// stripped so the renderer recomputes them.
+    ///
+    /// An empty `texts` is a byte-identical no-op.
+    ///
+    /// # Errors
+    ///
+    /// See [`StructuralEditError`]; each text must be a single paragraph
+    /// (no newline), else [`StructuralEditError::MultiParagraphText`].
+    pub fn insert_paragraphs(
+        base: &[u8],
+        anchor: ParagraphLocator,
+        position: InsertPosition,
+        texts: &[String],
+    ) -> Result<Vec<u8>, StructuralEditError> {
+        for text in texts {
+            if text.contains('\n') || text.contains('\r') {
+                return Err(StructuralEditError::MultiParagraphText);
+            }
+        }
+        // Inserting nothing is a byte-identical no-op (mirrors delete's
+        // empty-target behaviour; binding surfaces nudge with their own
+        // "no text" errors).
+        if texts.is_empty() {
+            return Ok(base.to_vec());
         }
 
         // ── input admission ──
         let d0 = admit(base)?;
 
-        let anchor = insertion.anchor;
         let sections = d0.document.sections();
         let section =
             sections.get(anchor.section).ok_or(StructuralEditError::SectionOutOfRange {
@@ -446,26 +483,37 @@ impl HwpxStructuralEditor {
             },
         )?;
 
-        // The new paragraph inherits the anchor's shapes; it is a plain text
-        // paragraph (no inherited breaks, heading, or controls).
+        // Every new paragraph uniformly inherits the anchor's shapes; each is
+        // a plain text paragraph (no inherited breaks, heading, or controls).
         let char_shape = anchor_para
             .runs
             .first()
             .map_or(hwpforge_foundation::CharShapeIndex::new(0), |r| r.char_shape_id);
-        let mut new_para = Paragraph::with_runs(
-            vec![Run::text(&insertion.text, char_shape)],
-            anchor_para.para_shape_id,
-        );
-        new_para.style_id = anchor_para.style_id;
+        let new_paras: Vec<Paragraph> = texts
+            .iter()
+            .map(|text| {
+                let mut p = Paragraph::with_runs(
+                    vec![Run::text(text, char_shape)],
+                    anchor_para.para_shape_id,
+                );
+                p.style_id = anchor_para.style_id;
+                p
+            })
+            .collect();
 
-        let insert_index = match insertion.position {
+        let insert_index = match position {
             InsertPosition::Before => anchor.index,
             InsertPosition::After => anchor.index + 1,
         };
 
-        // ── declared delta: the new paragraph spliced into the Core doc ──
+        // ── declared delta: the new paragraphs spliced into the Core doc ──
         let mut expected = d0.document.clone();
-        expected.sections_mut()[anchor.section].paragraphs.insert(insert_index, new_para);
+        {
+            let paragraphs = &mut expected.sections_mut()[anchor.section].paragraphs;
+            for (offset, new_para) in new_paras.into_iter().enumerate() {
+                paragraphs.insert(insert_index + offset, new_para);
+            }
+        }
         expected
             .clone()
             .validate()
@@ -486,16 +534,23 @@ impl HwpxStructuralEditor {
             .read_text_entry(&path)
             .map_err(|e| StructuralEditError::Codec(e.to_string()))?;
         let encoded_spans = paragraph_spans(&encoded_xml)?;
-        // The encoded doc has one more paragraph than the base; guard the index
-        // so an encoder invariant break fails gracefully instead of panicking.
-        if insert_index >= encoded_spans.len() {
+        // The encoded doc has `texts.len()` more paragraphs than the base;
+        // guard the whole block range (`insert_index + N`, not `insert_index`
+        // — off-by-one) so an encoder invariant break fails gracefully
+        // instead of panicking.
+        if insert_index + texts.len() > encoded_spans.len() {
             return Err(StructuralEditError::SpanCountMismatch {
                 section: anchor.section,
-                decoded: section.paragraphs.len() + 1,
+                decoded: section.paragraphs.len() + texts.len(),
                 wire: encoded_spans.len(),
             });
         }
-        let new_para_bytes = encoded_xml[encoded_spans[insert_index].clone()].to_string();
+        // Sibling `<hp:p>` elements are adjacent with no separator bytes, so
+        // the block splices as one contiguous string.
+        let new_para_bytes: String = encoded_spans[insert_index..insert_index + texts.len()]
+            .iter()
+            .map(|span| &encoded_xml[span.clone()])
+            .collect();
 
         // ── splice the new paragraph's bytes into the ORIGINAL section XML ──
         let mut package =
@@ -513,7 +568,7 @@ impl HwpxStructuralEditor {
         }
         // Guard section properties: inserting before the secPr carrier would
         // displace it from first position.
-        if insertion.position == InsertPosition::Before
+        if position == InsertPosition::Before
             && xml[spans[anchor.index].clone()].contains("<hp:secPr")
         {
             return Err(StructuralEditError::InsertBeforeSectionProperties {
@@ -522,7 +577,7 @@ impl HwpxStructuralEditor {
             });
         }
 
-        let at = match insertion.position {
+        let at = match position {
             InsertPosition::Before => spans[anchor.index].start,
             InsertPosition::After => spans[anchor.index].end,
         };
@@ -690,6 +745,102 @@ pub(crate) fn scan_paragraph_references(paragraph: &Paragraph) -> ReferenceScan 
         Err(_) => scan.object_id = true, // unknown ⇒ reject (fail-closed)
     }
     scan
+}
+
+/// A non-blocking advisory for a planned structural edit.
+///
+/// Produced by [`scan_delete_warnings`]; shared by the CLI and MCP surfaces
+/// (via [`std::fmt::Display`]) so their messages cannot drift.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StructuralWarning {
+    /// The paragraph at `section:index` contains `count` index-mark
+    /// control(s); deleting it removes those entries from any generated
+    /// index (찾아보기). Local content removal is an intended part of
+    /// deletion — advisory only, never a refusal.
+    IndexMarkRemoved {
+        /// Section the paragraph lives in.
+        section: usize,
+        /// Zero-based paragraph index inside the section.
+        index: usize,
+        /// Number of index-mark controls in the paragraph subtree.
+        count: usize,
+    },
+}
+
+impl std::fmt::Display for StructuralWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IndexMarkRemoved { section, index, count } => write!(
+                f,
+                "deleting paragraph {section}:{index} removes {count} index-mark entr{} from the document index",
+                if *count == 1 { "y" } else { "ies" }
+            ),
+        }
+    }
+}
+
+/// Best-effort advisory scan for a planned paragraph deletion.
+///
+/// Decode failures and out-of-range targets yield no warnings — the editor
+/// itself refuses those inputs with hard errors, so this scan never needs to
+/// fail. Call it before [`HwpxStructuralEditor::delete_paragraphs`] and
+/// surface the warnings alongside a successful edit.
+#[must_use]
+pub fn scan_delete_warnings(base: &[u8], targets: &[ParagraphLocator]) -> Vec<StructuralWarning> {
+    let Ok(d0) = HwpxDecoder::decode(base) else {
+        return Vec::new();
+    };
+    let sections = d0.document.sections();
+    let mut warnings = Vec::new();
+    for t in targets {
+        let Some(para) = sections.get(t.section).and_then(|s| s.paragraphs.get(t.index)) else {
+            continue;
+        };
+        let count = count_index_marks(para);
+        if count > 0 {
+            warnings.push(StructuralWarning::IndexMarkRemoved {
+                section: t.section,
+                index: t.index,
+                count,
+            });
+        }
+    }
+    warnings
+}
+
+/// Counts `Control::IndexMark` occurrences in a paragraph subtree via the
+/// same serde walk as [`scan_paragraph_references`] (externally tagged:
+/// `{"IndexMark": {..}}`), so nested containers are covered identically.
+fn count_index_marks(paragraph: &Paragraph) -> usize {
+    match serde_json::to_value(paragraph) {
+        Ok(value) => {
+            let mut count = 0usize;
+            count_index_mark_keys(&value, &mut count);
+            count
+        }
+        // Advisory only — a serialization failure just means no warning.
+        Err(_) => 0,
+    }
+}
+
+fn count_index_mark_keys(value: &Value, count: &mut usize) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if key == "IndexMark" {
+                    *count += 1;
+                }
+                count_index_mark_keys(child, count);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                count_index_mark_keys(item, count);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn walk_value(value: &Value, scan: &mut ReferenceScan) {
@@ -1339,5 +1490,150 @@ mod tests {
         for v in &variants {
             assert!(!v.to_string().is_empty(), "variant {v:?} must render");
         }
+    }
+
+    // -- followups W2: batch insert + delete warnings ---------------------
+
+    #[test]
+    fn insert_batch_matches_sequential_single_inserts() {
+        // Differential lock (Codex Q2): batch-N must equal N sequential
+        // single inserts byte-for-byte — same splice product, one admission.
+        let base = fixture("plain_paragraphs.hwpx");
+        let texts = vec!["추가 하나.".to_string(), "추가 둘.".to_string()];
+        let batch = HwpxStructuralEditor::insert_paragraphs(
+            &base,
+            loc(0, 1),
+            InsertPosition::After,
+            &texts,
+        )
+        .expect("batch insert");
+
+        let s1 = HwpxStructuralEditor::insert_paragraph(
+            &base,
+            &insertion(0, 1, InsertPosition::After, "추가 하나."),
+        )
+        .expect("single 1");
+        let s2 = HwpxStructuralEditor::insert_paragraph(
+            &s1,
+            &insertion(0, 2, InsertPosition::After, "추가 둘."),
+        )
+        .expect("single 2");
+
+        assert_eq!(batch, s2, "batch must equal sequential singles byte-for-byte");
+        assert_eq!(
+            body_texts(&batch),
+            vec![
+                "첫째 문단입니다.",
+                "둘째 문단입니다.",
+                "추가 하나.",
+                "추가 둘.",
+                "셋째 문단입니다.",
+                "넷째 문단입니다."
+            ]
+        );
+    }
+
+    #[test]
+    fn insert_batch_after_last_paragraph_appends() {
+        // Boundary: anchoring After the final paragraph must land the block
+        // at the section tail (off-by-one guard exercises the upper edge).
+        let base = fixture("plain_paragraphs.hwpx");
+        let texts = vec!["꼬리 하나.".to_string(), "꼬리 둘.".to_string()];
+        let out = HwpxStructuralEditor::insert_paragraphs(
+            &base,
+            loc(0, 3),
+            InsertPosition::After,
+            &texts,
+        )
+        .expect("append");
+        assert_eq!(
+            body_texts(&out),
+            vec![
+                "첫째 문단입니다.",
+                "둘째 문단입니다.",
+                "셋째 문단입니다.",
+                "넷째 문단입니다.",
+                "꼬리 하나.",
+                "꼬리 둘."
+            ]
+        );
+    }
+
+    #[test]
+    fn insert_batch_empty_texts_is_byte_identical_noop() {
+        let base = fixture("plain_paragraphs.hwpx");
+        let out =
+            HwpxStructuralEditor::insert_paragraphs(&base, loc(0, 1), InsertPosition::After, &[])
+                .expect("noop");
+        assert_eq!(out, base, "empty batch must return the input unchanged");
+    }
+
+    #[test]
+    fn insert_batch_rejects_multiline_item() {
+        let base = fixture("plain_paragraphs.hwpx");
+        let texts = vec!["정상.".to_string(), "줄\n바꿈".to_string()];
+        assert!(matches!(
+            HwpxStructuralEditor::insert_paragraphs(
+                &base,
+                loc(0, 1),
+                InsertPosition::After,
+                &texts
+            ),
+            Err(StructuralEditError::MultiParagraphText)
+        ));
+    }
+
+    #[test]
+    fn insert_batch_keeps_paragraph_ids_unique_and_contiguous() {
+        // Review H1 extended to the batch surface: the transplanted block
+        // must renumber into one contiguous id space.
+        let base = fixture("plain_paragraphs.hwpx");
+        let texts = vec!["일.".to_string(), "이.".to_string(), "삼.".to_string()];
+        let out = HwpxStructuralEditor::insert_paragraphs(
+            &base,
+            loc(0, 2),
+            InsertPosition::Before,
+            &texts,
+        )
+        .expect("batch insert");
+        let ids = paragraph_ids(&out);
+        assert_eq!(ids, (0..ids.len() as u32).collect::<Vec<_>>(), "ids must be 0..N contiguous");
+    }
+
+    #[test]
+    fn scan_delete_warnings_flags_index_mark_paragraphs() {
+        // Build a package whose paragraph 2 carries an index mark, then scan
+        // a mixed target set: only the index-mark paragraph warns; the plain
+        // paragraph and the out-of-range target stay silent (best-effort).
+        let base = fixture("plain_paragraphs.hwpx");
+        let d0 = HwpxDecoder::decode(&base).expect("decode");
+        let mut document = d0.document.clone();
+        document.sections_mut()[0].paragraphs[2].add_run(Run::control(
+            Control::IndexMark { primary: "색인어".to_string(), secondary: None },
+            hwpforge_foundation::CharShapeIndex::new(0),
+        ));
+        let bytes = encode_hwpx(&HwpxDocument {
+            document,
+            style_store: d0.style_store.clone(),
+            image_store: d0.image_store.clone(),
+        })
+        .expect("encode");
+
+        let warnings = scan_delete_warnings(&bytes, &[loc(0, 1), loc(0, 2), loc(0, 99)]);
+        assert_eq!(
+            warnings,
+            vec![StructuralWarning::IndexMarkRemoved { section: 0, index: 2, count: 1 }]
+        );
+
+        // Undecodable input: advisory scan stays silent (editor errors later).
+        assert!(scan_delete_warnings(b"not a package", &[loc(0, 0)]).is_empty());
+    }
+
+    #[test]
+    fn structural_warning_renders_a_message() {
+        let one = StructuralWarning::IndexMarkRemoved { section: 0, index: 2, count: 1 };
+        let many = StructuralWarning::IndexMarkRemoved { section: 1, index: 3, count: 2 };
+        assert!(one.to_string().contains("index-mark entry"), "{one}");
+        assert!(many.to_string().contains("index-mark entries"), "{many}");
     }
 }


### PR DESCRIPTION
## 요약

v0.11.6 이후 E3·E4 독립 리뷰에서 후속으로 미뤄진 소형 상환 작업 묶음. 정식 워크플로우(`.claude/rules/epic-workflow.md`) 전 게이트 통과 — Codex 적대 리뷰 반영·사용자 승인·TDD·시각 게이트(사용자 스크린샷 대조) 완료. 계획 문서 = `.docs/planning/2026-07-25-e3-e4-followups.md`.

## W1 — E3 잔금

### L3: lenient 격자 배치 span-폭주 사전 가드 (`fix:`)
- **취약점**: `grid_placements`(lenient)는 가드 전무 — 병리적 span(65535×65535) 1셀이면 HashSet ~43억 엔트리 = 메모리 고갈. 취약 호출부 **2곳** (인코더 + **`inspect` CLI 분석 경로** — Codex 리뷰가 발견한 신뢰 안 되는 입력 직격 경로).
- **수정**: strict의 covered_area O(cells) 사전 검사를 core `covered_area()` pub 프리미티브로 승격(중복 제거·포화 합산) → 인코더 = `InvalidStructure` 거부(정직한 실패) · inspect = 해당 표 주소 생략 + 위치 폴백 + `table-cell-addr-scan-skipped: N` note(기존 notes 채널 — 무음 저하 아님).
- **byte-neutral**: 정상 문서(≤ cap) 경로 자체 불변 — golden/round-trip 985/985 통과. `grid_placements` 시그니처 불변(semver 무풍).

### L5: verify perf = 실측 종결 (리팩터 안 함)
- perf 프로브(`#[ignore]`, 측정 방법 잠금) 실측: **10,000셀(코퍼스 최대 414 위치의 ~24배)에서 annotate 9.04ms · verify 7.18ms** → 셀별 root-nav 비용은 실문서 스케일에서 무의미. YAGNI 종결.
- 커버리지 관측 2종(Endnote 미러·글상자-내-표 e2e)은 **이미 E3 상환 시 완료**로 실측 확인 — 계획 오독 정정만.

## W2 — E4 소소

### 배치 삽입 `insert_paragraphs` (`feat:`)
- 한 앵커에 **연속 블록 N문단** 삽입 — 스플라이스 1회, 앵커 shape **균일 상속**(MD continuation과 별개 축 명문화), off-by-one 가드(insert_index+N), 빈 배열 = byte-identical no-op. 단건 `insert_paragraph`는 위임으로 축소(구현 단일화).
- **차분 잠금**: batch-N == 단건 N회 순차 결과 **바이트 동일** (Codex 보완 채택).
- CLI: `--text` 반복 = 블록(단건 하위호환) · MCP: `text`/`texts` exactly-one 검증(`INSERT_TEXT_REQUIRED`, additive 호환).
- 통합 게이트: batch 삽입 후 E5 diff = 선언 블록 정확 일치(순서 포함).

### IndexMark 삭제 경고 `scan_delete_warnings` (`feat:`)
- IndexMark 든 문단 삭제 = 의도된 content 제거(거부 아님, E4 판정 유지) — **advisory 경고**로 색인 항목 소멸을 노출.
- CLI/MCP가 **additive 라이브러리 공유 함수**를 공동 소비(각자 구현 금지 — drift 차단, `GridAddrWarning` 선례) — Codex Q4 MODIFY 반영. best-effort(디코드 실패·범위 외 = 무음, 편집기 하드 에러가 후속 처리).
- CLI: JSON `warnings` 배열/텍스트 모드 stderr · MCP: `StructuralData.warnings`(빈 배열 생략).

## 스코프 제외 (Codex 권고로 분리)

**W3(정밀 dangling)는 별도 슬라이스로 분리** — Codex 적대 리뷰가 3개 사각(북마크 SpanStart/SpanEnd 반쪽 삭제 = 참조 무관 자체 손상 · Hyperlink 내부 북마크 링크 · `RefTarget::Raw` fail-closed) 확정, '소소'가 아님.

## 검증

- core 476/476 · smithy-hwpx 985/985(byte-neutral) · structural 48/48(신규 7) · CLI 11/11 + 4/4 · MCP 8/8
- 시각 게이트: 사용자 스크린샷 대조 통과 (삽입 위치·순서·균일 상속·나머지 레이아웃 불변)
- semver: 전부 additive — 기존 pub fn 시그니처 불변, 예상 **0.11.7 patch**

## 커밋

- `dc49635` docs(claude): 세션 학습 2건 (이전 세션 보류분)
- `a320bf2` fix: L3 span-폭주 사전 가드
- `05685a5` test: L5 perf 프로브 잠금
- `9caecf8` feat: insert_paragraphs + scan_delete_warnings 라이브러리
- `5303003` feat: CLI/MCP 표면 노출