### PR TITLE
feat(hwpx): 시각 객체 수식 sidecar와 렌더 기하 보존

### DIFF
--- a/crates/hwpforge-bindings-cli/Cargo.toml
+++ b/crates/hwpforge-bindings-cli/Cargo.toml
@@ -27,6 +27,7 @@ quick-xml = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = "3"
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/hwpforge-bindings-cli/src/commands/to_md.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_md.rs
@@ -1,16 +1,15 @@
 //! `to-md` subcommand: convert HWPX to Markdown.
 
 use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use hwpforge_smithy_hwpx::{HwpxDecoder, HwpxStyleLookup};
 use hwpforge_smithy_md::{hancom_eqn_to_latex, MdEncoder};
 
 use crate::error::{check_file_size, CliError};
 use crate::MdMode;
-
-static SIDECAR_TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Run the to-md command.
 pub fn run(input: &PathBuf, output: &Option<PathBuf>, mode: &MdMode, json_mode: bool) {
@@ -188,14 +187,12 @@ pub fn run(input: &PathBuf, output: &Option<PathBuf>, mode: &MdMode, json_mode: 
 
 fn write_atomic(path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("sidecar.json");
-    let attempt = SIDECAR_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let temp_path =
-        path.with_file_name(format!(".{file_name}.{}.{}.tmp", std::process::id(), attempt));
-
-    std::fs::write(&temp_path, contents)?;
-    if let Err(error) = std::fs::rename(&temp_path, path) {
-        let _ = std::fs::remove_file(&temp_path);
-        return Err(error);
-    }
-    Ok(())
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut temporary = tempfile::Builder::new()
+        .prefix(&format!(".{file_name}."))
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+    temporary.write_all(contents)?;
+    temporary.as_file().sync_all()?;
+    temporary.persist(path).map(|_| ()).map_err(|error| error.error)
 }

--- a/crates/hwpforge-bindings-cli/src/commands/to_md.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_md.rs
@@ -16,7 +16,12 @@ pub fn run(input: &PathBuf, output: &Option<PathBuf>, mode: &MdMode, json_mode: 
     check_file_size(input, json_mode);
 
     // 1. Decode HWPX
-    let (hwpx_doc, mut visual_equations) = match HwpxDecoder::decode_file_with_report(input) {
+    let decoded = if matches!(mode, MdMode::Styled) {
+        HwpxDecoder::decode_file_with_report(input)
+    } else {
+        HwpxDecoder::decode_file(input).map(|document| (document, Default::default()))
+    };
+    let (hwpx_doc, mut visual_equations) = match decoded {
         Ok(result) => result,
         Err(e) => {
             CliError::new("DECODE_FAILED", format!("HWPX decode error: {e}")).exit(json_mode, 2);

--- a/crates/hwpforge-bindings-cli/src/commands/to_md.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_md.rs
@@ -161,6 +161,16 @@ pub fn run(input: &PathBuf, output: &Option<PathBuf>, mode: &MdMode, json_mode: 
             "count": visual_equations.equations.len(),
         }))
     } else {
+        let sidecar_path = md_path.with_extension("visual-equations.json");
+        if let Err(e) = std::fs::remove_file(&sidecar_path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                CliError::new(
+                    "FILE_WRITE_FAILED",
+                    format!("Cannot remove stale '{}': {e}", sidecar_path.display()),
+                )
+                .exit(json_mode, 1);
+            }
+        }
         None
     };
 

--- a/crates/hwpforge-bindings-cli/src/commands/to_md.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_md.rs
@@ -2,24 +2,31 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use hwpforge_smithy_hwpx::{HwpxDecoder, HwpxStyleLookup};
-use hwpforge_smithy_md::MdEncoder;
+use hwpforge_smithy_md::{hancom_eqn_to_latex, MdEncoder};
 
 use crate::error::{check_file_size, CliError};
 use crate::MdMode;
+
+static SIDECAR_TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Run the to-md command.
 pub fn run(input: &PathBuf, output: &Option<PathBuf>, mode: &MdMode, json_mode: bool) {
     check_file_size(input, json_mode);
 
     // 1. Decode HWPX
-    let hwpx_doc = match HwpxDecoder::decode_file(input) {
-        Ok(d) => d,
+    let (hwpx_doc, mut visual_equations) = match HwpxDecoder::decode_file_with_report(input) {
+        Ok(result) => result,
         Err(e) => {
             CliError::new("DECODE_FAILED", format!("HWPX decode error: {e}")).exit(json_mode, 2);
         }
     };
+
+    for equation in &mut visual_equations.equations {
+        equation.latex = Some(hancom_eqn_to_latex(&equation.script));
+    }
 
     // 2. Validate document (Draft → Validated)
     let document = match hwpx_doc.document.validate() {
@@ -125,12 +132,46 @@ pub fn run(input: &PathBuf, output: &Option<PathBuf>, mode: &MdMode, json_mode: 
         }
     }
 
-    // 8. Print result
-    let result = serde_json::json!({
+    // 8. Write the styled-mode structural sidecar before reporting success.
+    let visual_equations_result = if matches!(mode, MdMode::Styled) {
+        let sidecar_path = md_path.with_extension("visual-equations.json");
+        let sidecar_json = match serde_json::to_vec_pretty(&visual_equations) {
+            Ok(json) => json,
+            Err(e) => {
+                CliError::new(
+                    "ENCODE_FAILED",
+                    format!("Visual-equations sidecar encode error: {e}"),
+                )
+                .exit(json_mode, 2);
+            }
+        };
+        if let Err(e) = write_atomic(&sidecar_path, &sidecar_json) {
+            CliError::new(
+                "FILE_WRITE_FAILED",
+                format!("Cannot write '{}': {e}", sidecar_path.display()),
+            )
+            .exit(json_mode, 1);
+        }
+        Some(serde_json::json!({
+            "output": sidecar_path.display().to_string(),
+            "count": visual_equations.equations.len(),
+        }))
+    } else {
+        None
+    };
+
+    // 9. Print result
+    let mut result = serde_json::json!({
         "status": "ok",
         "output": md_path.display().to_string(),
         "images": image_count,
     });
+    if let Some(visual_equations_result) = visual_equations_result {
+        result
+            .as_object_mut()
+            .expect("JSON object literal must remain an object")
+            .insert("visual_equations".to_string(), visual_equations_result);
+    }
 
     if json_mode {
         println!("{}", serde_json::to_string(&result).unwrap());
@@ -143,4 +184,18 @@ pub fn run(input: &PathBuf, output: &Option<PathBuf>, mode: &MdMode, json_mode: 
             if image_count == 1 { "" } else { "s" }
         );
     }
+}
+
+fn write_atomic(path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("sidecar.json");
+    let attempt = SIDECAR_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let temp_path =
+        path.with_file_name(format!(".{file_name}.{}.{}.tmp", std::process::id(), attempt));
+
+    std::fs::write(&temp_path, contents)?;
+    if let Err(error) = std::fs::rename(&temp_path, path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(error);
+    }
+    Ok(())
 }

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -4336,7 +4336,7 @@ fn to_md_json_visual_equations_reports_sidecar() {
     assert!(Path::new(sidecar).starts_with(&output_dir));
     let report: serde_json::Value =
         serde_json::from_slice(&std::fs::read(sidecar).unwrap()).unwrap();
-    assert_eq!(report["schema_version"], 3);
+    assert_eq!(report["schema_version"], 4);
     assert_eq!(report["equations"].as_array().unwrap().len(), 2);
     assert_eq!(report["equations"][0]["domain"], "picture_caption");
     assert_eq!(report["equations"][0]["latex"], r"$\frac{a}{b}$");
@@ -4366,7 +4366,8 @@ fn to_md_json_visual_equations_reports_sidecar() {
     assert_eq!(report["equations"][1]["geometry"]["raw_base_unit"], 900);
     assert_eq!(report["equations"][1]["geometry"]["scale"]["horz"], "1");
     assert_eq!(report["equations"][1]["geometry"]["display_box_size"]["width"], 2000);
-    assert_eq!(report["equations"][1]["geometry"]["display_base_unit"], 900);
+    assert_eq!(report["equations"][1]["geometry"]["render_base_unit"], 900);
+    assert!(report["equations"][1]["geometry"].get("display_base_unit").is_none());
 }
 
 #[test]

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -362,6 +362,38 @@ fn create_visual_equations_hwpx(dir: &Path) -> PathBuf {
     path
 }
 
+fn create_visual_equation_overflow_hwpx(dir: &Path) -> PathBuf {
+    const HEADER: &str = r##"<head version="1.4" secCnt="1"><refList>
+      <fontfaces itemCnt="1"><fontface lang="HANGUL" fontCnt="1"><font id="0" face="함초롬돋움" type="TTF" isEmbedded="0"/></fontface></fontfaces>
+      <charProperties itemCnt="1"><charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE" borderFillIDRef="0"><fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/></charPr></charProperties>
+      <paraProperties itemCnt="1"><paraPr id="0"><align horizontal="LEFT" vertical="BASELINE"/><switch><default><lineSpacing type="PERCENT" value="160"/></default></switch></paraPr></paraProperties>
+    </refList></head>"##;
+    const SECTION: &str = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <t>legacy conversion remains valid</t>
+      <container instid="group-inst"><rect id="overflow-rect" instid="overflow-rect-inst">
+        <offset x="2147483647" y="0"/>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="overflow-equation"><pos horzOffset="1" vertOffset="0"/><script>x</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let path = dir.join("visual-overflow-input.hwpx");
+    let file = std::fs::File::create(&path).expect("create visual-overflow fixture");
+    let mut writer = zip::ZipWriter::new(file);
+    let stored =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let deflated = zip::write::SimpleFileOptions::default();
+    writer.start_file("mimetype", stored).unwrap();
+    writer.write_all(b"application/hwp+zip").unwrap();
+    writer.start_file("Contents/header.xml", deflated).unwrap();
+    writer.write_all(HEADER.as_bytes()).unwrap();
+    writer.start_file("Contents/section0.xml", deflated).unwrap();
+    writer.write_all(SECTION.as_bytes()).unwrap();
+    writer.finish().unwrap();
+    path
+}
+
 /// Run hwpforge with given args, return (stdout, stderr, exit_code).
 fn run(args: &[&str]) -> (String, String, i32) {
     let output =
@@ -4303,6 +4335,34 @@ fn to_md_lossless_mode_runs() {
         run(&["to-md", f.to_str().unwrap(), "-o", tmp.to_str().unwrap(), "--mode", "lossless"]);
     assert_eq!(code, 0);
     assert!(tmp.join("merged_grid_form.md").exists());
+}
+
+#[test]
+fn to_md_legacy_modes_ignore_visual_report_projection_overflow() {
+    let tmp = test_tmp();
+    let input = create_visual_equation_overflow_hwpx(&tmp);
+
+    for mode in ["lossy", "lossless"] {
+        let output_dir = tmp.join(mode);
+        let (_, stderr, code) = run(&[
+            "to-md",
+            input.to_str().unwrap(),
+            "-o",
+            output_dir.to_str().unwrap(),
+            "--mode",
+            mode,
+        ]);
+
+        assert!(!stderr.contains("DECODE_FAILED"), "{mode} must use legacy decode: {stderr}");
+        if mode == "lossy" {
+            assert_eq!(code, 0, "lossy conversion must complete: {stderr}");
+            assert!(output_dir.join("visual-overflow-input.md").is_file());
+        } else {
+            assert_eq!(code, 2, "lossless must reach its encoder: {stderr}");
+            assert!(stderr.contains("ENCODE_FAILED"), "{stderr}");
+        }
+        assert!(!output_dir.join("visual-overflow-input.visual-equations.json").exists());
+    }
 }
 
 #[test]

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -4453,6 +4453,34 @@ fn to_md_json_visual_equations_replaces_existing_sidecar() {
 }
 
 #[test]
+fn to_md_non_styled_modes_remove_stale_visual_equations_sidecar() {
+    let input = fixture("tables/merged_grid_form.hwpx");
+
+    for mode in ["lossy", "lossless"] {
+        let tmp = test_tmp();
+        let markdown_path = tmp.join("same-output.md");
+        let sidecar_path = markdown_path.with_extension("visual-equations.json");
+        let (_, stderr, code) =
+            run(&["to-md", input.to_str().unwrap(), "-o", markdown_path.to_str().unwrap()]);
+        assert_eq!(code, 0, "styled setup failed: {stderr}");
+        assert!(sidecar_path.is_file());
+
+        let (_, stderr, code) = run(&[
+            "to-md",
+            input.to_str().unwrap(),
+            "-o",
+            markdown_path.to_str().unwrap(),
+            "--mode",
+            mode,
+        ]);
+
+        assert_eq!(code, 0, "{mode} conversion failed: {stderr}");
+        assert!(markdown_path.is_file());
+        assert!(!sidecar_path.exists(), "{mode} left a stale sidecar");
+    }
+}
+
+#[test]
 fn to_md_json_visual_equations_sidecar_write_failure_is_fail_closed() {
     let tmp = test_tmp();
     let input = create_visual_equations_hwpx(&tmp);

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -4371,6 +4371,28 @@ fn to_md_json_visual_equations_reports_sidecar() {
 }
 
 #[test]
+fn to_md_json_visual_equations_replaces_existing_sidecar() {
+    let tmp = test_tmp();
+    let input = create_visual_equations_hwpx(&tmp);
+    let markdown_path = tmp.join("result.md");
+    let sidecar_path = tmp.join("result.visual-equations.json");
+
+    let (_first, first_stderr, first_code) =
+        run_json(&["to-md", input.to_str().unwrap(), "-o", markdown_path.to_str().unwrap()]);
+    assert_eq!(first_code, 0, "{first_stderr}");
+    std::fs::write(&sidecar_path, b"stale sidecar").unwrap();
+
+    let (second, second_stderr, second_code) =
+        run_json(&["to-md", input.to_str().unwrap(), "-o", markdown_path.to_str().unwrap()]);
+    assert_eq!(second_code, 0, "{second_stderr}");
+    assert_eq!(second["visual_equations"]["count"], 2);
+    let replaced: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(sidecar_path).unwrap()).unwrap();
+    assert_eq!(replaced["schema_version"], 4);
+    assert_eq!(replaced["equations"].as_array().unwrap().len(), 2);
+}
+
+#[test]
 fn to_md_json_visual_equations_sidecar_write_failure_is_fail_closed() {
     let tmp = test_tmp();
     let input = create_visual_equations_hwpx(&tmp);

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -342,7 +342,7 @@ fn create_visual_equations_hwpx(dir: &Path) -> PathBuf {
         </run></p></subList></caption></pic>
       </run></p></subList></endNote></ctrl>
       <container id="group-1" instid="group-inst" zOrder="8"><orgSz width="3000" height="2000"/><rect id="9007199254740999" instid="9007199254741000" zOrder="41"><orgSz width="2000" height="1000"/><pos horzOffset="201" vertOffset="202"/><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
-        <equation id="9007199254741001" zOrder="42"><sz width="1000" height="1000"/><pos horzOffset="211" vertOffset="212"/><script>x ^{2}</script></equation>
+          <equation id="9007199254741001" zOrder="42" baseUnit="900"><sz width="1000" height="1000"/><pos horzOffset="211" vertOffset="212"/><script>x ^{2}</script></equation>
       </run></p></subList></drawText></rect></container>
     </run></p></sec>"#;
 
@@ -4336,12 +4336,20 @@ fn to_md_json_visual_equations_reports_sidecar() {
     assert!(Path::new(sidecar).starts_with(&output_dir));
     let report: serde_json::Value =
         serde_json::from_slice(&std::fs::read(sidecar).unwrap()).unwrap();
-    assert_eq!(report["schema_version"], 1);
+    assert_eq!(report["schema_version"], 2);
     assert_eq!(report["equations"].as_array().unwrap().len(), 2);
     assert_eq!(report["equations"][0]["domain"], "picture_caption");
     assert_eq!(report["equations"][0]["latex"], r"$\frac{a}{b}$");
+    assert_eq!(report["equations"][0]["geometry"]["raw_box_size"]["width"], 1000);
+    assert_eq!(report["equations"][0]["geometry"]["display_box_size"]["height"], 1000);
     assert_eq!(report["equations"][1]["domain"], "group_draw_text");
     assert_eq!(report["equations"][1]["latex"], "$x^{2}$");
+    assert_eq!(report["equations"][1]["geometry"]["raw_box_size"]["width"], 2000);
+    assert_eq!(report["equations"][1]["geometry"]["raw_equation_size"]["height"], 1000);
+    assert_eq!(report["equations"][1]["geometry"]["raw_base_unit"], 900);
+    assert_eq!(report["equations"][1]["geometry"]["scale"]["horz"], "1");
+    assert_eq!(report["equations"][1]["geometry"]["display_box_size"]["width"], 2000);
+    assert_eq!(report["equations"][1]["geometry"]["display_base_unit"], 900);
 }
 
 #[test]

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -4336,14 +4336,31 @@ fn to_md_json_visual_equations_reports_sidecar() {
     assert!(Path::new(sidecar).starts_with(&output_dir));
     let report: serde_json::Value =
         serde_json::from_slice(&std::fs::read(sidecar).unwrap()).unwrap();
-    assert_eq!(report["schema_version"], 2);
+    assert_eq!(report["schema_version"], 3);
     assert_eq!(report["equations"].as_array().unwrap().len(), 2);
     assert_eq!(report["equations"][0]["domain"], "picture_caption");
     assert_eq!(report["equations"][0]["latex"], r"$\frac{a}{b}$");
+    assert_eq!(
+        report["equations"][0]["raw_position"],
+        json!({"horz_offset": 111, "vert_offset": 112})
+    );
+    assert_eq!(report["equations"][0]["translation"], json!({"horz": "0", "vert": "0"}));
+    assert_eq!(
+        report["equations"][0]["display_position"],
+        json!({"horz_offset": 111, "vert_offset": 112})
+    );
     assert_eq!(report["equations"][0]["geometry"]["raw_box_size"]["width"], 1000);
     assert_eq!(report["equations"][0]["geometry"]["display_box_size"]["height"], 1000);
     assert_eq!(report["equations"][1]["domain"], "group_draw_text");
     assert_eq!(report["equations"][1]["latex"], "$x^{2}$");
+    assert_eq!(
+        report["equations"][1]["raw_position"],
+        json!({"horz_offset": 412, "vert_offset": 414})
+    );
+    assert_eq!(
+        report["equations"][1]["display_position"],
+        json!({"horz_offset": 412, "vert_offset": 414})
+    );
     assert_eq!(report["equations"][1]["geometry"]["raw_box_size"]["width"], 2000);
     assert_eq!(report["equations"][1]["geometry"]["raw_equation_size"]["height"], 1000);
     assert_eq!(report["equations"][1]["geometry"]["raw_base_unit"], 900);

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -11,7 +11,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use hwpforge_core::control::Control;
 use hwpforge_core::paragraph::Paragraph;
 use hwpforge_core::run::RunContent;
-use hwpforge_smithy_hwpx::ExportedSection;
+use hwpforge_smithy_hwpx::{ExportedSection, HwpxDecoder, HwpxStyleLookup};
+use hwpforge_smithy_md::MdEncoder;
 use serde_json::json;
 use zip::ZipArchive;
 
@@ -322,6 +323,42 @@ fn csv_to_json_array(csv: &str) -> serde_json::Value {
 fn create_test_md(dir: &Path, content: &str) -> PathBuf {
     let path = dir.join("input.md");
     std::fs::write(&path, content).expect("write test md");
+    path
+}
+
+fn create_visual_equations_hwpx(dir: &Path) -> PathBuf {
+    const HEADER: &str = r##"<head version="1.4" secCnt="1"><refList>
+      <fontfaces itemCnt="1"><fontface lang="HANGUL" fontCnt="1"><font id="0" face="함초롬돋움" type="TTF" isEmbedded="0"/></fontface></fontfaces>
+      <charProperties itemCnt="1"><charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE" borderFillIDRef="0"><fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/></charPr></charProperties>
+      <paraProperties itemCnt="1"><paraPr id="0"><align horizontal="LEFT" vertical="BASELINE"/><switch><default><lineSpacing type="PERCENT" value="160"/></default></switch></paraPr></paraProperties>
+    </refList></head>"##;
+    const SECTION: &str = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <t>visible markdown</t>
+      <equation id="ordinary-1"><sz width="1000" height="1000"/><script>ordinary</script></equation>
+      <rect id="textbox-1" instid="textbox-inst"><orgSz width="2000" height="1000"/><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="textbox-eq"><sz width="1000" height="1000"/><script>textbox</script></equation></run></p></subList></drawText></rect>
+      <ctrl><endNote instId="9007199254740993"><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <pic id="9007199254740995" instid="9007199254740996" zOrder="7"><pos horzOffset="101" vertOffset="102"/><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="9007199254740997" zOrder="31"><sz width="1000" height="1000"/><pos horzOffset="111" vertOffset="112"/><script>{a} over {b}</script></equation>
+        </run></p></subList></caption></pic>
+      </run></p></subList></endNote></ctrl>
+      <container id="group-1" instid="group-inst" zOrder="8"><orgSz width="3000" height="2000"/><rect id="9007199254740999" instid="9007199254741000" zOrder="41"><orgSz width="2000" height="1000"/><pos horzOffset="201" vertOffset="202"/><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <equation id="9007199254741001" zOrder="42"><sz width="1000" height="1000"/><pos horzOffset="211" vertOffset="212"/><script>x ^{2}</script></equation>
+      </run></p></subList></drawText></rect></container>
+    </run></p></sec>"#;
+
+    let path = dir.join("visual-input.hwpx");
+    let file = std::fs::File::create(&path).expect("create visual-equations fixture");
+    let mut writer = zip::ZipWriter::new(file);
+    let stored =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let deflated = zip::write::SimpleFileOptions::default();
+    writer.start_file("mimetype", stored).unwrap();
+    writer.write_all(b"application/hwp+zip").unwrap();
+    writer.start_file("Contents/header.xml", deflated).unwrap();
+    writer.write_all(HEADER.as_bytes()).unwrap();
+    writer.start_file("Contents/section0.xml", deflated).unwrap();
+    writer.write_all(SECTION.as_bytes()).unwrap();
+    writer.finish().unwrap();
     path
 }
 
@@ -4266,6 +4303,62 @@ fn to_md_lossless_mode_runs() {
         run(&["to-md", f.to_str().unwrap(), "-o", tmp.to_str().unwrap(), "--mode", "lossless"]);
     assert_eq!(code, 0);
     assert!(tmp.join("merged_grid_form.md").exists());
+}
+
+#[test]
+fn to_md_json_visual_equations_reports_sidecar() {
+    let tmp = test_tmp();
+    let input = create_visual_equations_hwpx(&tmp);
+    let output_dir = tmp.join("out");
+
+    let decoded = HwpxDecoder::decode_file(&input).unwrap();
+    let lookup = HwpxStyleLookup::new(&decoded.style_store, &decoded.image_store);
+    let expected_markdown =
+        MdEncoder::encode_styled(&decoded.document.validate().unwrap(), &lookup).markdown;
+
+    let (result, stderr, code) =
+        run_json(&["to-md", input.to_str().unwrap(), "-o", output_dir.to_str().unwrap()]);
+
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["images"], 0);
+    assert_eq!(result["visual_equations"]["count"], 2);
+    let markdown_path = Path::new(result["output"].as_str().unwrap());
+    assert_eq!(
+        std::fs::read(markdown_path).unwrap(),
+        expected_markdown.as_bytes(),
+        "sidecar reporting must not change the existing styled Markdown bytes"
+    );
+    let sidecar = result["visual_equations"]["output"]
+        .as_str()
+        .expect("styled JSON output must report the visual-equations sidecar");
+    assert!(Path::new(sidecar).exists(), "reported sidecar must exist: {sidecar}");
+    assert!(Path::new(sidecar).starts_with(&output_dir));
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(sidecar).unwrap()).unwrap();
+    assert_eq!(report["schema_version"], 1);
+    assert_eq!(report["equations"].as_array().unwrap().len(), 2);
+    assert_eq!(report["equations"][0]["domain"], "picture_caption");
+    assert_eq!(report["equations"][0]["latex"], r"$\frac{a}{b}$");
+    assert_eq!(report["equations"][1]["domain"], "group_draw_text");
+    assert_eq!(report["equations"][1]["latex"], "$x^{2}$");
+}
+
+#[test]
+fn to_md_json_visual_equations_sidecar_write_failure_is_fail_closed() {
+    let tmp = test_tmp();
+    let input = create_visual_equations_hwpx(&tmp);
+    let markdown_path = tmp.join("result.md");
+    let blocked_sidecar = tmp.join("result.visual-equations.json");
+    std::fs::create_dir(&blocked_sidecar).unwrap();
+
+    let (error, _stderr, code) =
+        run_json(&["to-md", input.to_str().unwrap(), "-o", markdown_path.to_str().unwrap()]);
+
+    assert_ne!(code, 0, "sidecar failure must not report success");
+    assert_eq!(error["status"], "error");
+    assert_eq!(error["code"], "FILE_WRITE_FAILED");
+    assert!(blocked_sidecar.is_dir(), "failed write must not replace the blocking target");
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
@@ -72,7 +72,7 @@ impl HwpxDecoder {
     /// 3. Parse `Contents/section*.xml` → paragraphs + page settings
     /// 4. Assemble `Document<Draft>` with sections
     pub fn decode(bytes: &[u8]) -> HwpxResult<HwpxDocument> {
-        Self::decode_with_report(bytes).map(|(document, _report)| document)
+        Self::decode_internal(bytes, false).map(|(document, _report)| document)
     }
 
     /// Decodes an HWPX file and preserves equations embedded in visual objects.
@@ -82,6 +82,13 @@ impl HwpxDecoder {
     /// remain part of the decoded Core document and are not duplicated there.
     pub fn decode_with_report(
         bytes: &[u8],
+    ) -> HwpxResult<(HwpxDocument, HwpxVisualEquationReport)> {
+        Self::decode_internal(bytes, true)
+    }
+
+    fn decode_internal(
+        bytes: &[u8],
+        include_visual_equations: bool,
     ) -> HwpxResult<(HwpxDocument, HwpxVisualEquationReport)> {
         // Step 1: Open package
         let mut pkg = package::PackageReader::new(bytes)?;
@@ -117,7 +124,11 @@ impl HwpxDecoder {
 
         for i in 0..section_count {
             let section_xml = pkg.read_section_xml(i)?;
-            let result = section::parse_section(&section_xml, i, &chart_xmls)?;
+            let result = if include_visual_equations {
+                section::parse_section_with_visual_equations(&section_xml, i, &chart_xmls)?
+            } else {
+                section::parse_section(&section_xml, i, &chart_xmls)?
+            };
 
             visual_equations.extend(result.visual_equations.iter().cloned());
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
@@ -25,8 +25,9 @@ use crate::error::HwpxResult;
 use crate::style_store::HwpxStyleStore;
 
 pub use visual_equations::{
-    HwpxVisualEquation, HwpxVisualEquationDomain, HwpxVisualEquationParentKind,
-    HwpxVisualEquationPosition, HwpxVisualEquationReport,
+    HwpxVisualEquation, HwpxVisualEquationDomain, HwpxVisualEquationGeometry,
+    HwpxVisualEquationParentKind, HwpxVisualEquationPosition, HwpxVisualEquationReport,
+    HwpxVisualEquationScale, HwpxVisualEquationSize,
 };
 
 // ── HwpxDocument ─────────────────────────────────────────────────
@@ -187,7 +188,10 @@ impl HwpxDecoder {
 
         Ok((
             HwpxDocument { document, style_store, image_store },
-            HwpxVisualEquationReport { schema_version: 1, equations: visual_equations },
+            HwpxVisualEquationReport {
+                schema_version: visual_equations::HWPX_VISUAL_EQUATION_SCHEMA_VERSION,
+                equations: visual_equations,
+            },
         ))
     }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
@@ -27,7 +27,7 @@ use crate::style_store::HwpxStyleStore;
 pub use visual_equations::{
     HwpxVisualEquation, HwpxVisualEquationDomain, HwpxVisualEquationGeometry,
     HwpxVisualEquationParentKind, HwpxVisualEquationPosition, HwpxVisualEquationReport,
-    HwpxVisualEquationScale, HwpxVisualEquationSize,
+    HwpxVisualEquationScale, HwpxVisualEquationSize, HwpxVisualEquationTranslation,
 };
 
 // ── HwpxDocument ─────────────────────────────────────────────────

--- a/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod metadata;
 pub(crate) mod package;
 pub(crate) mod section;
 pub(crate) mod shapes;
+mod visual_equations;
 
 use std::path::Path;
 
@@ -22,6 +23,11 @@ use hwpforge_foundation::ApplyPageType;
 
 use crate::error::HwpxResult;
 use crate::style_store::HwpxStyleStore;
+
+pub use visual_equations::{
+    HwpxVisualEquation, HwpxVisualEquationDomain, HwpxVisualEquationParentKind,
+    HwpxVisualEquationPosition, HwpxVisualEquationReport,
+};
 
 // ── HwpxDocument ─────────────────────────────────────────────────
 
@@ -65,6 +71,17 @@ impl HwpxDecoder {
     /// 3. Parse `Contents/section*.xml` → paragraphs + page settings
     /// 4. Assemble `Document<Draft>` with sections
     pub fn decode(bytes: &[u8]) -> HwpxResult<HwpxDocument> {
+        Self::decode_with_report(bytes).map(|(document, _report)| document)
+    }
+
+    /// Decodes an HWPX file and preserves equations embedded in visual objects.
+    ///
+    /// The returned report contains only picture-caption and grouped-drawing
+    /// text equations. Ordinary prose, table, and top-level textbox equations
+    /// remain part of the decoded Core document and are not duplicated there.
+    pub fn decode_with_report(
+        bytes: &[u8],
+    ) -> HwpxResult<(HwpxDocument, HwpxVisualEquationReport)> {
         // Step 1: Open package
         let mut pkg = package::PackageReader::new(bytes)?;
 
@@ -93,12 +110,15 @@ impl HwpxDecoder {
         // Step 5: Parse sections
         let mut document = Document::<Draft>::with_metadata(metadata);
         let section_count = pkg.section_count();
+        let mut visual_equations = Vec::new();
         // Track how many masterpages have been assigned across sections
         let mut masterpage_cursor = 0usize;
 
         for i in 0..section_count {
             let section_xml = pkg.read_section_xml(i)?;
             let result = section::parse_section(&section_xml, i, &chart_xmls)?;
+
+            visual_equations.extend(result.visual_equations.iter().cloned());
 
             let page_settings = result.page_settings.unwrap_or_else(PageSettings::a4);
 
@@ -161,13 +181,27 @@ impl HwpxDecoder {
         // Step 6: Extract binary image data from BinData/
         let image_store = pkg.read_all_bindata()?;
 
-        Ok(HwpxDocument { document, style_store, image_store })
+        for (document_order, equation) in visual_equations.iter_mut().enumerate() {
+            equation.document_order = document_order;
+        }
+
+        Ok((
+            HwpxDocument { document, style_store, image_store },
+            HwpxVisualEquationReport { schema_version: 1, equations: visual_equations },
+        ))
     }
 
     /// Decodes an HWPX file from a filesystem path.
     pub fn decode_file(path: impl AsRef<Path>) -> HwpxResult<HwpxDocument> {
+        Self::decode_file_with_report(path).map(|(document, _report)| document)
+    }
+
+    /// Decodes an HWPX file from a filesystem path and returns its visual-equation report.
+    pub fn decode_file_with_report(
+        path: impl AsRef<Path>,
+    ) -> HwpxResult<(HwpxDocument, HwpxVisualEquationReport)> {
         let bytes = std::fs::read(path.as_ref()).map_err(crate::error::HwpxError::Io)?;
-        Self::decode(&bytes)
+        Self::decode_with_report(&bytes)
     }
 }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
@@ -208,7 +208,8 @@ impl HwpxDecoder {
 
     /// Decodes an HWPX file from a filesystem path.
     pub fn decode_file(path: impl AsRef<Path>) -> HwpxResult<HwpxDocument> {
-        Self::decode_file_with_report(path).map(|(document, _report)| document)
+        let bytes = std::fs::read(path.as_ref()).map_err(crate::error::HwpxError::Io)?;
+        Self::decode(&bytes)
     }
 
     /// Decodes an HWPX file from a filesystem path and returns its visual-equation report.

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -123,6 +123,8 @@ pub struct SectionParseResult {
     pub text_direction: TextDirection,
     /// Starting numbers extracted from `<hp:startNum>` in secPr.
     pub begin_num: Option<hwpforge_core::section::BeginNum>,
+    /// Equations embedded in picture captions and grouped drawing text.
+    pub visual_equations: Vec<crate::decoder::HwpxVisualEquation>,
 }
 
 /// Parses a section XML string into paragraphs and optional page settings.
@@ -137,6 +139,8 @@ pub fn parse_section(
     let file_hint = format!("Contents/section{section_index}.xml");
     let section: HxSection = from_str(xml)
         .map_err(|e| HwpxError::XmlParse { file: file_hint, detail: e.to_string() })?;
+    let visual_equations =
+        crate::decoder::visual_equations::collect_section(&section.paragraphs, section_index);
 
     let mut page_settings = None;
     let mut header = None;
@@ -245,6 +249,7 @@ pub fn parse_section(
         master_pages: None,
         text_direction,
         begin_num,
+        visual_equations,
     })
 }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -374,212 +374,173 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
     let has_field_pair = hx.ctrls.iter().any(|c| c.field_begin.is_some())
         && hx.ctrls.iter().any(|c| c.field_end.is_some());
 
-    let inline_only = !hx.child_order.is_empty()
-        && hx
-            .child_order
-            .iter()
-            .all(|child| matches!(child, HxRunChildOrder::Text(_) | HxRunChildOrder::Equation(_)));
-    if inline_only {
-        for child in &hx.child_order {
-            match *child {
-                HxRunChildOrder::Text(index) if !has_field_pair => {
-                    let content = hx.texts[index].to_run_content();
-                    let keep = match &content {
-                        RunContent::Text(value) => !value.is_empty(),
-                        RunContent::InlineText(value) => !value.segments.is_empty(),
-                        _ => true,
-                    };
-                    if keep {
-                        runs.push(Run { content, char_shape_id });
-                    }
-                }
-                HxRunChildOrder::Equation(index) => {
-                    runs.push(decode_equation(&hx.equations[index], char_shape_id)?);
-                }
-                _ => {}
-            }
-        }
-        return Ok(runs);
+    // Parsed HWPX runs carry their direct wire order in `child_order`. Internal
+    // callers can still construct `HxRun` without it, so synthesize the legacy
+    // grouped order only for that fallback case and use one dispatch path for
+    // every supported child variant.
+    let mut fallback_order = Vec::new();
+    if hx.child_order.is_empty() {
+        fallback_order.extend((0..hx.texts.len()).map(HxRunChildOrder::Text));
+        fallback_order.extend((0..hx.tables.len()).map(HxRunChildOrder::Table));
+        fallback_order.extend((0..hx.pictures.len()).map(HxRunChildOrder::Picture));
+        fallback_order.extend((0..hx.ctrls.len()).map(HxRunChildOrder::Ctrl));
+        fallback_order.extend((0..hx.rects.len()).map(HxRunChildOrder::Rect));
+        fallback_order.extend((0..hx.lines.len()).map(HxRunChildOrder::Line));
+        fallback_order.extend((0..hx.ellipses.len()).map(HxRunChildOrder::Ellipse));
+        fallback_order.extend((0..hx.polygons.len()).map(HxRunChildOrder::Polygon));
+        fallback_order.extend((0..hx.curves.len()).map(HxRunChildOrder::Curve));
+        fallback_order.extend((0..hx.textarts.len()).map(HxRunChildOrder::TextArt));
+        fallback_order.extend((0..hx.connect_lines.len()).map(HxRunChildOrder::ConnectLine));
+        fallback_order.extend((0..hx.containers.len()).map(HxRunChildOrder::Container));
+        fallback_order.extend((0..hx.equations.len()).map(HxRunChildOrder::Equation));
+        fallback_order.extend((0..hx.switches.len()).map(HxRunChildOrder::Switch));
+        fallback_order.extend((0..hx.dutmals.len()).map(HxRunChildOrder::Dutmal));
+        fallback_order.extend((0..hx.composes.len()).map(HxRunChildOrder::Compose));
     }
+    let child_order = if hx.child_order.is_empty() { &fallback_order } else { &hx.child_order };
 
-    // Text runs — skip if consumed by field controls.
-    //
-    // `HxText::to_run_content` preserves any `<hp:tab>` attribute payload
-    // (`width` / `leader` / `tab_type`) as `RunContent::InlineText`,
-    // falling back to the existing `RunContent::Text(String)` when every
-    // tab is attribute-less. This closes the HWPX-decode side of the
-    // inline tab carry — see
-    // `.docs/debug/2026-05-27_hwpx_decoder_inline_tab_attrs_lost.md`.
-    if !has_field_pair {
-        for text in &hx.texts {
-            let content = text.to_run_content();
-            let keep = match &content {
-                RunContent::Text(s) => !s.is_empty(),
-                RunContent::InlineText(it) => !it.segments.is_empty(),
-                _ => true,
-            };
-            if keep {
-                runs.push(Run { content, char_shape_id });
-            }
-        }
-    }
-
-    // Table runs
-    for table in &hx.tables {
-        let core_table = convert_table(table, depth)?;
-        runs.push(Run { content: RunContent::Table(Box::new(core_table)), char_shape_id });
-    }
-
-    // Image runs
-    for pic in &hx.pictures {
-        if let Some(image) = convert_picture(pic, depth)? {
-            runs.push(Run { content: RunContent::Image(image), char_shape_id });
-        }
-    }
-
-    // Footnote / Endnote / Bookmark / IndexMark / Field runs (from <hp:ctrl>)
-    //
-    // Field controls use fieldBegin/fieldEnd pairs. We collect fieldBegin ctrls
-    // and match them with fieldEnd ctrls to extract the field's text from
-    // intervening <hp:t> elements. The text runs between begin and end are
-    // consumed as the field's display text.
     let mut field_begin: Option<&HxFieldBegin> = None;
     let mut field_begin_char_shape: CharShapeIndex = char_shape_id;
 
-    for ctrl in &hx.ctrls {
-        if let Some(run) = decode_footnote(ctrl, char_shape_id, depth)? {
-            runs.push(run);
-        }
-        if let Some(run) = decode_endnote(ctrl, char_shape_id, depth)? {
-            runs.push(run);
-        }
-        if let Some(run) = decode_bookmark(ctrl, char_shape_id) {
-            runs.push(run);
-        }
-        if let Some(run) = decode_indexmark(ctrl, char_shape_id) {
-            runs.push(run);
-        }
-        // Field begin: remember for pairing with fieldEnd
-        if let Some(fb) = &ctrl.field_begin {
-            field_begin = Some(fb);
-            field_begin_char_shape = char_shape_id;
-        }
-        // Field end: pair with remembered fieldBegin and emit control
-        if ctrl.field_end.is_some() {
-            if let Some(fb) = field_begin.take() {
-                let field_text = collect_run_text(hx);
-                // `HxRun` 은 자식 순서(texts/ctrls interleaving)를 보존하지
-                // 않으므로, run 에 `<hp:t>` 가 정확히 1개일 때만 그 텍스트가
-                // 마커 사이 본문이라고 무모호하게 귀속할 수 있다. 한컴은
-                // 재저장 시 라벨 run 과 필드 run 을 병합하기도 한다
-                // (fixture `fields/clickhere_filled.hwpx`: t·fieldBegin·
-                // t·fieldEnd·t 한 run) — 그 경우 연결 텍스트를 본문으로
-                // 오귀속하는 대신 미채움으로 다운그레이드한다 (warning-first).
-                let unambiguous_body = hx.texts.len() == 1;
-                if let Some(run) = decode_field_control(
-                    fb,
-                    &field_text,
-                    field_begin_char_shape,
-                    depth,
-                    unambiguous_body,
-                )? {
+    for child in child_order {
+        match *child {
+            HxRunChildOrder::Text(index) if !has_field_pair => {
+                // `HxText::to_run_content` preserves attributed inline tabs.
+                let content = hx.texts[index].to_run_content();
+                let keep = match &content {
+                    RunContent::Text(value) => !value.is_empty(),
+                    RunContent::InlineText(value) => !value.segments.is_empty(),
+                    _ => true,
+                };
+                if keep {
+                    runs.push(Run { content, char_shape_id });
+                }
+            }
+            HxRunChildOrder::Text(_) | HxRunChildOrder::Switch(_) => {}
+            HxRunChildOrder::Table(index) => {
+                let table = convert_table(&hx.tables[index], depth)?;
+                runs.push(Run { content: RunContent::Table(Box::new(table)), char_shape_id });
+            }
+            HxRunChildOrder::Picture(index) => {
+                if let Some(image) = convert_picture(&hx.pictures[index], depth)? {
+                    runs.push(Run { content: RunContent::Image(image), char_shape_id });
+                }
+            }
+            HxRunChildOrder::Ctrl(index) => {
+                let ctrl = &hx.ctrls[index];
+                if let Some(run) = decode_footnote(ctrl, char_shape_id, depth)? {
+                    runs.push(run);
+                }
+                if let Some(run) = decode_endnote(ctrl, char_shape_id, depth)? {
+                    runs.push(run);
+                }
+                if let Some(run) = decode_bookmark(ctrl, char_shape_id) {
+                    runs.push(run);
+                }
+                if let Some(run) = decode_indexmark(ctrl, char_shape_id) {
+                    runs.push(run);
+                }
+                if let Some(begin) = &ctrl.field_begin {
+                    if !has_field_pair && begin.field_type == "BOOKMARK" {
+                        runs.push(Run {
+                            content: RunContent::Control(Box::new(Control::Bookmark {
+                                name: begin.name.clone(),
+                                bookmark_type: hwpforge_foundation::BookmarkType::SpanStart,
+                            })),
+                            char_shape_id,
+                        });
+                    } else {
+                        field_begin = Some(begin);
+                        field_begin_char_shape = char_shape_id;
+                    }
+                }
+                if ctrl.field_end.is_some() {
+                    if let Some(begin) = field_begin.take() {
+                        let field_text = collect_run_text(hx);
+                        let unambiguous_body = hx.texts.len() == 1;
+                        if let Some(run) = decode_field_control(
+                            begin,
+                            &field_text,
+                            field_begin_char_shape,
+                            depth,
+                            unambiguous_body,
+                        )? {
+                            runs.push(run);
+                        }
+                    }
+                }
+                if let Some(auto_num) = &ctrl.auto_num {
+                    let kind = match auto_num.num_type.as_str() {
+                        "PAGE" => Some(hwpforge_core::control::InlinePageKind::CurrentPage),
+                        "TOTAL_PAGE" => Some(hwpforge_core::control::InlinePageKind::TotalPages),
+                        _ => None,
+                    };
+                    if let Some(kind) = kind {
+                        runs.push(Run {
+                            content: RunContent::Control(Box::new(Control::InlinePageNumber {
+                                kind,
+                            })),
+                            char_shape_id,
+                        });
+                    }
+                }
+            }
+            HxRunChildOrder::Rect(index) => {
+                if let Some(run) = decode_textbox(&hx.rects[index], char_shape_id, depth)? {
                     runs.push(run);
                 }
             }
-        }
-        // AutoNum (inline page number) — Wave 12n: routed to
-        // Control::InlinePageNumber. Architect review CRITICAL: keep
-        // current-page (`PAGE`) and total-page (`TOTAL_PAGE`) distinct;
-        // collapsing them would lose user-visible semantics.
-        if let Some(an) = &ctrl.auto_num {
-            let kind = match an.num_type.as_str() {
-                "PAGE" => Some(hwpforge_core::control::InlinePageKind::CurrentPage),
-                "TOTAL_PAGE" => Some(hwpforge_core::control::InlinePageKind::TotalPages),
-                _ => None,
-            };
-            if let Some(kind) = kind {
-                runs.push(Run {
-                    content: RunContent::Control(Box::new(Control::InlinePageNumber { kind })),
-                    char_shape_id,
+            HxRunChildOrder::Line(index) => {
+                runs.push(decode_line(&hx.lines[index], char_shape_id, depth)?);
+            }
+            HxRunChildOrder::Ellipse(index) => {
+                let ellipse = &hx.ellipses[index];
+                runs.push(if ellipse.has_arc_pr == 1 {
+                    decode_arc(ellipse, char_shape_id, depth)?
+                } else {
+                    decode_ellipse(ellipse, char_shape_id, depth)?
                 });
+            }
+            HxRunChildOrder::Polygon(index) => {
+                runs.push(decode_polygon(&hx.polygons[index], char_shape_id, depth)?);
+            }
+            HxRunChildOrder::Curve(index) => {
+                runs.push(decode_curve(&hx.curves[index], char_shape_id, depth)?);
+            }
+            HxRunChildOrder::ConnectLine(index) => {
+                runs.push(decode_connect_line(&hx.connect_lines[index], char_shape_id, depth)?);
+            }
+            HxRunChildOrder::Equation(index) => {
+                runs.push(decode_equation(&hx.equations[index], char_shape_id)?);
+            }
+            HxRunChildOrder::Dutmal(index) => {
+                runs.push(decode_dutmal(&hx.dutmals[index], char_shape_id));
+            }
+            HxRunChildOrder::Compose(index) => {
+                runs.push(decode_compose(&hx.composes[index], char_shape_id));
+            }
+            HxRunChildOrder::Container(index) => {
+                if let Some(run) = decode_container(&hx.containers[index], char_shape_id, depth)? {
+                    runs.push(run);
+                }
+            }
+            HxRunChildOrder::TextArt(index) => {
+                runs.push(decode_textart(&hx.textarts[index], char_shape_id, depth)?);
             }
         }
     }
 
-    // Handle self-closing fieldBegin without a matching fieldEnd (e.g. bookmark span start)
-    if let Some(fb) = field_begin.take() {
-        if fb.field_type == "BOOKMARK" {
+    // Handle a self-closing fieldBegin without a matching fieldEnd.
+    if let Some(begin) = field_begin {
+        if begin.field_type == "BOOKMARK" {
             runs.push(Run {
                 content: RunContent::Control(Box::new(Control::Bookmark {
-                    name: fb.name.clone(),
+                    name: begin.name.clone(),
                     bookmark_type: hwpforge_foundation::BookmarkType::SpanStart,
                 })),
                 char_shape_id: field_begin_char_shape,
             });
         }
-    }
-
-    // Textbox runs (from <hp:rect>)
-    for rect in &hx.rects {
-        if let Some(run) = decode_textbox(rect, char_shape_id, depth)? {
-            runs.push(run);
-        }
-    }
-
-    // Line runs (from <hp:line>)
-    for line in &hx.lines {
-        runs.push(decode_line(line, char_shape_id, depth)?);
-    }
-
-    // Ellipse and Arc runs (from <hp:ellipse>)
-    for ellipse in &hx.ellipses {
-        if ellipse.has_arc_pr == 1 {
-            runs.push(decode_arc(ellipse, char_shape_id, depth)?);
-        } else {
-            runs.push(decode_ellipse(ellipse, char_shape_id, depth)?);
-        }
-    }
-
-    // Polygon runs (from <hp:polygon>)
-    for polygon in &hx.polygons {
-        runs.push(decode_polygon(polygon, char_shape_id, depth)?);
-    }
-
-    // Curve runs (from <hp:curve>)
-    for curve in &hx.curves {
-        runs.push(decode_curve(curve, char_shape_id, depth)?);
-    }
-
-    // TextArt runs (from <hp:textart>)
-    for text_art in &hx.textarts {
-        runs.push(decode_textart(text_art, char_shape_id, depth)?);
-    }
-
-    // ConnectLine runs (from <hp:connectLine>)
-    for connect_line in &hx.connect_lines {
-        runs.push(decode_connect_line(connect_line, char_shape_id, depth)?);
-    }
-
-    // Group runs (from <hp:container>) — Wave A flat children.
-    for container in &hx.containers {
-        if let Some(run) = decode_container(container, char_shape_id, depth)? {
-            runs.push(run);
-        }
-    }
-
-    // Equation runs (from <hp:equation>)
-    for equation in &hx.equations {
-        runs.push(decode_equation(equation, char_shape_id)?);
-    }
-
-    // Dutmal runs (from <hp:dutmal>)
-    for dutmal in &hx.dutmals {
-        runs.push(decode_dutmal(dutmal, char_shape_id));
-    }
-
-    // Compose runs (from <hp:compose>)
-    for compose in &hx.composes {
-        runs.push(decode_compose(compose, char_shape_id));
     }
 
     Ok(runs)
@@ -1675,6 +1636,41 @@ mod tests {
             other => panic!("expected control, got {other:?}"),
         }
         assert_eq!(runs[2].content.as_text(), Some("를 간단히 하면?"));
+    }
+
+    #[test]
+    fn parse_heterogeneous_run_children_in_source_order() {
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <t>before</t>
+                    <equation id="1"><script>A+B</script></equation>
+                    <pic id="pic1">
+                        <img binaryItemIDRef="logo.png" bright="0" contrast="0"/>
+                        <curSz width="10000" height="5000"/>
+                    </pic>
+                    <t>after</t>
+                </run>
+            </p>
+        </sec>"#;
+
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        let runs = &result.paragraphs[0].runs;
+
+        assert_eq!(runs.len(), 4);
+        assert_eq!(runs[0].content.as_text(), Some("before"));
+        match &runs[1].content {
+            RunContent::Control(control) => match control.as_ref() {
+                Control::Equation { script, .. } => assert_eq!(script, "A+B"),
+                other => panic!("expected equation, got {other:?}"),
+            },
+            other => panic!("expected control, got {other:?}"),
+        }
+        match &runs[2].content {
+            RunContent::Image(image) => assert_eq!(image.path, "BinData/logo.png"),
+            other => panic!("expected image, got {other:?}"),
+        }
+        assert_eq!(runs[3].content.as_text(), Some("after"));
     }
 
     #[test]

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -28,8 +28,8 @@ use crate::color::parse_hex_color_raw;
 use crate::error::{HwpxError, HwpxResult};
 use crate::schema::section::{
     HxCaption, HxChart, HxCompose, HxCtrl, HxDutmal, HxEquation, HxFieldBegin, HxFootNote,
-    HxHeaderFooter, HxPageNum, HxParagraph, HxPic, HxRun, HxSection, HxSubList, HxTable,
-    HxTableCell, HxTableRow,
+    HxHeaderFooter, HxPageNum, HxParagraph, HxPic, HxRun, HxRunChildOrder, HxSection, HxSubList,
+    HxTable, HxTableCell, HxTableRow,
 };
 
 /// Maximum nesting depth for tables-within-tables.
@@ -348,6 +348,34 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
     // is consumed by the field control and should NOT be emitted separately.
     let has_field_pair = hx.ctrls.iter().any(|c| c.field_begin.is_some())
         && hx.ctrls.iter().any(|c| c.field_end.is_some());
+
+    let inline_only = !hx.child_order.is_empty()
+        && hx
+            .child_order
+            .iter()
+            .all(|child| matches!(child, HxRunChildOrder::Text(_) | HxRunChildOrder::Equation(_)));
+    if inline_only {
+        for child in &hx.child_order {
+            match *child {
+                HxRunChildOrder::Text(index) if !has_field_pair => {
+                    let content = hx.texts[index].to_run_content();
+                    let keep = match &content {
+                        RunContent::Text(value) => !value.is_empty(),
+                        RunContent::InlineText(value) => !value.segments.is_empty(),
+                        _ => true,
+                    };
+                    if keep {
+                        runs.push(Run { content, char_shape_id });
+                    }
+                }
+                HxRunChildOrder::Equation(index) => {
+                    runs.push(decode_equation(&hx.equations[index], char_shape_id)?);
+                }
+                _ => {}
+            }
+        }
+        return Ok(runs);
+    }
 
     // Text runs — skip if consumed by field controls.
     //
@@ -1595,6 +1623,33 @@ mod tests {
         assert_eq!(para.runs[0].content.as_text(), Some("Hello "));
         assert_eq!(para.runs[1].char_shape_id.get(), 1);
         assert_eq!(para.runs[1].content.as_text(), Some("World"));
+    }
+
+    #[test]
+    fn parse_mixed_text_and_equation_in_source_order() {
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <t>에 대하여 </t>
+                    <equation id="1"><script>A+B</script></equation>
+                    <t>를 간단히 하면?</t>
+                </run>
+            </p>
+        </sec>"#;
+
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        let runs = &result.paragraphs[0].runs;
+
+        assert_eq!(runs.len(), 3);
+        assert_eq!(runs[0].content.as_text(), Some("에 대하여 "));
+        match &runs[1].content {
+            RunContent::Control(control) => match control.as_ref() {
+                Control::Equation { script, .. } => assert_eq!(script, "A+B"),
+                other => panic!("expected equation, got {other:?}"),
+            },
+            other => panic!("expected control, got {other:?}"),
+        }
+        assert_eq!(runs[2].content.as_text(), Some("를 간단히 하면?"));
     }
 
     #[test]

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -136,11 +136,31 @@ pub fn parse_section(
     section_index: usize,
     chart_xmls: &HashMap<String, String>,
 ) -> HwpxResult<SectionParseResult> {
+    parse_section_impl(xml, section_index, chart_xmls, false)
+}
+
+pub(crate) fn parse_section_with_visual_equations(
+    xml: &str,
+    section_index: usize,
+    chart_xmls: &HashMap<String, String>,
+) -> HwpxResult<SectionParseResult> {
+    parse_section_impl(xml, section_index, chart_xmls, true)
+}
+
+fn parse_section_impl(
+    xml: &str,
+    section_index: usize,
+    chart_xmls: &HashMap<String, String>,
+    include_visual_equations: bool,
+) -> HwpxResult<SectionParseResult> {
     let file_hint = format!("Contents/section{section_index}.xml");
     let section: HxSection = from_str(xml)
         .map_err(|e| HwpxError::XmlParse { file: file_hint, detail: e.to_string() })?;
-    let visual_equations =
-        crate::decoder::visual_equations::collect_section(&section.paragraphs, section_index)?;
+    let visual_equations = if include_visual_equations {
+        crate::decoder::visual_equations::collect_section(&section.paragraphs, section_index)?
+    } else {
+        Vec::new()
+    };
 
     let mut page_settings = None;
     let mut header = None;

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -140,7 +140,7 @@ pub fn parse_section(
     let section: HxSection = from_str(xml)
         .map_err(|e| HwpxError::XmlParse { file: file_hint, detail: e.to_string() })?;
     let visual_equations =
-        crate::decoder::visual_equations::collect_section(&section.paragraphs, section_index);
+        crate::decoder::visual_equations::collect_section(&section.paragraphs, section_index)?;
 
     let mut page_settings = None;
     let mut header = None;

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 
 use crate::error::{HwpxError, HwpxResult};
 use crate::schema::section::{
-    HxContainer, HxContainerChildOrder, HxCtrl, HxEquation, HxOffset, HxParagraph, HxPic, HxRect,
-    HxRun, HxRunChildOrder, HxSizeAttr, HxSubList, HxTable, HxTablePos, HxTableSz,
+    HxContainer, HxContainerChildOrder, HxCtrl, HxDrawText, HxEquation, HxOffset, HxParagraph,
+    HxPic, HxRect, HxRun, HxRunChildOrder, HxSizeAttr, HxSubList, HxTable, HxTablePos, HxTableSz,
 };
 
 pub(crate) const HWPX_VISUAL_EQUATION_SCHEMA_VERSION: u32 = 4;
@@ -527,11 +527,37 @@ fn collect_equations_from_paragraphs<'a>(
                         HxRunChildOrder::Ctrl(index) => {
                             collect_equations_from_ctrl(&run.ctrls[index], depth, equations)?;
                         }
+                        HxRunChildOrder::Rect(index) => collect_equations_from_draw_text(
+                            run.rects[index].draw_text.as_ref(),
+                            depth,
+                            equations,
+                        )?,
+                        HxRunChildOrder::Ellipse(index) => collect_equations_from_draw_text(
+                            run.ellipses[index].draw_text.as_ref(),
+                            depth,
+                            equations,
+                        )?,
+                        HxRunChildOrder::Polygon(index) => collect_equations_from_draw_text(
+                            run.polygons[index].draw_text.as_ref(),
+                            depth,
+                            equations,
+                        )?,
                         _ => {}
                     }
                 }
             }
         }
+    }
+    Ok(())
+}
+
+fn collect_equations_from_draw_text<'a>(
+    draw_text: Option<&'a HxDrawText>,
+    depth: usize,
+    equations: &mut Vec<&'a HxEquation>,
+) -> HwpxResult<()> {
+    if let Some(draw_text) = draw_text {
+        collect_equations_from_paragraphs(&draw_text.sub_list.paragraphs, depth + 1, equations)?;
     }
     Ok(())
 }

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -4,8 +4,9 @@ use serde::Serialize;
 
 use crate::error::{HwpxError, HwpxResult};
 use crate::schema::section::{
-    HxContainer, HxContainerChildOrder, HxCtrl, HxDrawText, HxEquation, HxOffset, HxParagraph,
-    HxPic, HxRect, HxRun, HxRunChildOrder, HxSizeAttr, HxSubList, HxTable, HxTablePos, HxTableSz,
+    HxContainer, HxContainerChildOrder, HxCtrl, HxDrawText, HxEllipse, HxEquation, HxOffset,
+    HxParagraph, HxPic, HxPolygon, HxRect, HxRenderingInfo, HxRun, HxRunChildOrder, HxSizeAttr,
+    HxSubList, HxTable, HxTablePos, HxTableSz,
 };
 
 pub(crate) const HWPX_VISUAL_EQUATION_SCHEMA_VERSION: u32 = 4;
@@ -446,6 +447,20 @@ fn collect_container(
                     container_position,
                     equations,
                 )?,
+                HxContainerChildOrder::Ellipse(ellipse_index) => collect_group_ellipse(
+                    &container.ellipses[ellipse_index],
+                    &format!("{path}/ellipse[{ellipse_index}]"),
+                    depth,
+                    container_position,
+                    equations,
+                )?,
+                HxContainerChildOrder::Polygon(polygon_index) => collect_group_polygon(
+                    &container.polygons[polygon_index],
+                    &format!("{path}/polygon[{polygon_index}]"),
+                    depth,
+                    container_position,
+                    equations,
+                )?,
                 HxContainerChildOrder::Container(container_index) => collect_container(
                     &container.containers[container_index],
                     &format!("{path}/container[{container_index}]"),
@@ -462,6 +477,24 @@ fn collect_container(
         collect_group_rect(
             rect,
             &format!("{path}/rect[{rect_index}]"),
+            depth,
+            container_position,
+            equations,
+        )?;
+    }
+    for (ellipse_index, ellipse) in container.ellipses.iter().enumerate() {
+        collect_group_ellipse(
+            ellipse,
+            &format!("{path}/ellipse[{ellipse_index}]"),
+            depth,
+            container_position,
+            equations,
+        )?;
+    }
+    for (polygon_index, polygon) in container.polygons.iter().enumerate() {
+        collect_group_polygon(
+            polygon,
+            &format!("{path}/polygon[{polygon_index}]"),
             depth,
             container_position,
             equations,
@@ -486,31 +519,101 @@ fn collect_group_rect(
     container_position: Option<HwpxVisualEquationPosition>,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
-    let Some(draw_text) = &rect.draw_text else { return Ok(()) };
-    let rect_position = rect
-        .offset
-        .as_ref()
-        .map(position_from_offset)
-        .or_else(|| rect.pos.as_ref().map(position_from_table));
+    collect_group_shape(
+        rect.draw_text.as_ref(),
+        &rect.id,
+        &rect.instid,
+        rect.z_order,
+        rect.offset.as_ref(),
+        rect.pos.as_ref(),
+        rect.org_sz.as_ref(),
+        rect.rendering_info.as_ref(),
+        path,
+        depth,
+        container_position,
+        equations,
+    )
+}
+
+fn collect_group_ellipse(
+    ellipse: &HxEllipse,
+    path: &str,
+    depth: usize,
+    container_position: Option<HwpxVisualEquationPosition>,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
+    collect_group_shape(
+        ellipse.draw_text.as_ref(),
+        &ellipse.id,
+        &ellipse.instid,
+        ellipse.z_order,
+        ellipse.offset.as_ref(),
+        ellipse.pos.as_ref(),
+        ellipse.org_sz.as_ref(),
+        ellipse.rendering_info.as_ref(),
+        path,
+        depth,
+        container_position,
+        equations,
+    )
+}
+
+fn collect_group_polygon(
+    polygon: &HxPolygon,
+    path: &str,
+    depth: usize,
+    container_position: Option<HwpxVisualEquationPosition>,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
+    collect_group_shape(
+        polygon.draw_text.as_ref(),
+        &polygon.id,
+        &polygon.instid,
+        polygon.z_order,
+        polygon.offset.as_ref(),
+        polygon.pos.as_ref(),
+        polygon.org_sz.as_ref(),
+        polygon.rendering_info.as_ref(),
+        path,
+        depth,
+        container_position,
+        equations,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_group_shape(
+    draw_text: Option<&HxDrawText>,
+    object_id: &str,
+    instance_id: &str,
+    z_order: u32,
+    offset: Option<&HxOffset>,
+    position: Option<&HxTablePos>,
+    original_size: Option<&HxSizeAttr>,
+    rendering_info: Option<&HxRenderingInfo>,
+    path: &str,
+    depth: usize,
+    container_position: Option<HwpxVisualEquationPosition>,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
+    let Some(draw_text) = draw_text else { return Ok(()) };
+    let shape_position =
+        offset.map(position_from_offset).or_else(|| position.map(position_from_table));
     let parent = VisualParent {
         domain: HwpxVisualEquationDomain::GroupDrawText,
         kind: HwpxVisualEquationParentKind::Container,
-        object_id: &rect.id,
-        instance_id: &rect.instid,
-        z_order: rect.z_order,
-        position: add_optional_positions(container_position, rect_position)?,
-        raw_box_size: rect.org_sz.as_ref().map(size_from_original),
-        scale: rect
-            .rendering_info
-            .as_ref()
+        object_id,
+        instance_id,
+        z_order,
+        position: add_optional_positions(container_position, shape_position)?,
+        raw_box_size: original_size.map(size_from_original),
+        scale: rendering_info
             .map(|rendering| VisualScale {
                 horz: rendering.sca_matrix.e1.as_str(),
                 vert: rendering.sca_matrix.e5.as_str(),
             })
             .unwrap_or_default(),
-        translation: rect
-            .rendering_info
-            .as_ref()
+        translation: rendering_info
             .map(|rendering| VisualTranslation {
                 horz: rendering.sca_matrix.e3.as_str(),
                 vert: rendering.sca_matrix.e6.as_str(),
@@ -527,76 +630,175 @@ fn collect_parent_equations(
     depth: usize,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
-    let mut occurrences = Vec::new();
-    collect_equations_from_paragraphs(&sub_list.paragraphs, depth, &mut occurrences)?;
-    for (parent_order, equation) in occurrences.into_iter().enumerate() {
-        let equation_object_id = nonempty(&equation.id);
-        let id = equation_object_id
-            .clone()
-            .unwrap_or_else(|| format!("{parent_path}/equation[{parent_order}]"));
-        let raw_position = equation_position(equation, parent)?;
-        let translation = HwpxVisualEquationTranslation {
-            horz: parent.translation.horz.to_string(),
-            vert: parent.translation.vert.to_string(),
-        };
-        let display_position = translate_position(raw_position, parent.translation);
-        let geometry = equation_geometry(equation, parent);
-        let z_order = equation.z_order.unwrap_or(parent.z_order);
-        equations.push(HwpxVisualEquation {
-            id,
-            domain: parent.domain,
-            equation_object_id,
-            parent_object_id: nonempty(parent.object_id),
-            parent_instance_id: nonempty(parent.instance_id),
-            parent_kind: parent.kind,
-            parent_path: parent_path.to_string(),
-            document_order: 0,
-            parent_order,
-            z_order,
-            raw_position,
-            translation,
-            display_position,
-            geometry,
-            script: equation.script.as_ref().map(|script| script.text.clone()).unwrap_or_default(),
-            latex: None,
-        });
-    }
-    Ok(())
+    let mut parent_order = 0;
+    collect_owned_visual_paragraphs(
+        &sub_list.paragraphs,
+        parent,
+        parent_path,
+        parent_path,
+        depth,
+        &mut parent_order,
+        equations,
+    )
 }
 
-fn collect_equations_from_paragraphs<'a>(
-    paragraphs: &'a [HxParagraph],
+#[allow(clippy::too_many_arguments)]
+fn collect_owned_visual_paragraphs(
+    paragraphs: &[HxParagraph],
+    parent: VisualParent<'_>,
+    parent_path: &str,
+    prefix: &str,
     depth: usize,
-    equations: &mut Vec<&'a HxEquation>,
+    parent_order: &mut usize,
+    equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     ensure_depth(depth)?;
-    for paragraph in paragraphs {
-        for run in &paragraph.runs {
+    for (paragraph_index, paragraph) in paragraphs.iter().enumerate() {
+        let paragraph_path = format!("{prefix}/paragraph[{paragraph_index}]");
+        for (run_index, run) in paragraph.runs.iter().enumerate() {
+            let run_path = format!("{paragraph_path}/run[{run_index}]");
             if run.child_order.is_empty() {
-                equations.extend(&run.equations);
+                for equation in &run.equations {
+                    push_parent_equation(equation, parent, parent_path, parent_order, equations)?;
+                }
+                for (index, table) in run.tables.iter().enumerate() {
+                    collect_owned_visual_table(
+                        table,
+                        parent,
+                        parent_path,
+                        &format!("{run_path}/table[{index}]"),
+                        depth,
+                        parent_order,
+                        equations,
+                    )?;
+                }
+                for (index, ctrl) in run.ctrls.iter().enumerate() {
+                    collect_owned_visual_ctrl(
+                        ctrl,
+                        parent,
+                        parent_path,
+                        &format!("{run_path}/ctrl[{index}]"),
+                        depth,
+                        parent_order,
+                        equations,
+                    )?;
+                }
+                for (index, rect) in run.rects.iter().enumerate() {
+                    collect_owned_shape_text(
+                        rect.draw_text.as_ref(),
+                        parent,
+                        parent_path,
+                        &format!("{run_path}/rect[{index}]"),
+                        depth,
+                        parent_order,
+                        equations,
+                    )?;
+                }
+                for (index, ellipse) in run.ellipses.iter().enumerate() {
+                    collect_owned_shape_text(
+                        ellipse.draw_text.as_ref(),
+                        parent,
+                        parent_path,
+                        &format!("{run_path}/ellipse[{index}]"),
+                        depth,
+                        parent_order,
+                        equations,
+                    )?;
+                }
+                for (index, polygon) in run.polygons.iter().enumerate() {
+                    collect_owned_shape_text(
+                        polygon.draw_text.as_ref(),
+                        parent,
+                        parent_path,
+                        &format!("{run_path}/polygon[{index}]"),
+                        depth,
+                        parent_order,
+                        equations,
+                    )?;
+                }
+                for (index, picture) in run.pictures.iter().enumerate() {
+                    collect_picture(
+                        picture,
+                        &format!("{run_path}/picture[{index}]"),
+                        depth,
+                        equations,
+                    )?;
+                }
+                for (index, container) in run.containers.iter().enumerate() {
+                    collect_container(
+                        container,
+                        &format!("{run_path}/container[{index}]"),
+                        depth,
+                        None,
+                        equations,
+                    )?;
+                }
             } else {
                 for child in &run.child_order {
                     match *child {
-                        HxRunChildOrder::Equation(index) => equations.push(&run.equations[index]),
-                        HxRunChildOrder::Table(index) => {
-                            collect_equations_from_table(&run.tables[index], depth, equations)?;
-                        }
-                        HxRunChildOrder::Ctrl(index) => {
-                            collect_equations_from_ctrl(&run.ctrls[index], depth, equations)?;
-                        }
-                        HxRunChildOrder::Rect(index) => collect_equations_from_draw_text(
+                        HxRunChildOrder::Equation(index) => push_parent_equation(
+                            &run.equations[index],
+                            parent,
+                            parent_path,
+                            parent_order,
+                            equations,
+                        )?,
+                        HxRunChildOrder::Table(index) => collect_owned_visual_table(
+                            &run.tables[index],
+                            parent,
+                            parent_path,
+                            &format!("{run_path}/table[{index}]"),
+                            depth,
+                            parent_order,
+                            equations,
+                        )?,
+                        HxRunChildOrder::Ctrl(index) => collect_owned_visual_ctrl(
+                            &run.ctrls[index],
+                            parent,
+                            parent_path,
+                            &format!("{run_path}/ctrl[{index}]"),
+                            depth,
+                            parent_order,
+                            equations,
+                        )?,
+                        HxRunChildOrder::Rect(index) => collect_owned_shape_text(
                             run.rects[index].draw_text.as_ref(),
+                            parent,
+                            parent_path,
+                            &format!("{run_path}/rect[{index}]"),
                             depth,
+                            parent_order,
                             equations,
                         )?,
-                        HxRunChildOrder::Ellipse(index) => collect_equations_from_draw_text(
+                        HxRunChildOrder::Ellipse(index) => collect_owned_shape_text(
                             run.ellipses[index].draw_text.as_ref(),
+                            parent,
+                            parent_path,
+                            &format!("{run_path}/ellipse[{index}]"),
+                            depth,
+                            parent_order,
+                            equations,
+                        )?,
+                        HxRunChildOrder::Polygon(index) => collect_owned_shape_text(
+                            run.polygons[index].draw_text.as_ref(),
+                            parent,
+                            parent_path,
+                            &format!("{run_path}/polygon[{index}]"),
+                            depth,
+                            parent_order,
+                            equations,
+                        )?,
+                        HxRunChildOrder::Picture(index) => collect_picture(
+                            &run.pictures[index],
+                            &format!("{run_path}/picture[{index}]"),
                             depth,
                             equations,
                         )?,
-                        HxRunChildOrder::Polygon(index) => collect_equations_from_draw_text(
-                            run.polygons[index].draw_text.as_ref(),
+                        HxRunChildOrder::Container(index) => collect_container(
+                            &run.containers[index],
+                            &format!("{run_path}/container[{index}]"),
                             depth,
+                            None,
                             equations,
                         )?,
                         _ => {}
@@ -608,53 +810,158 @@ fn collect_equations_from_paragraphs<'a>(
     Ok(())
 }
 
-fn collect_equations_from_draw_text<'a>(
-    draw_text: Option<&'a HxDrawText>,
+#[allow(clippy::too_many_arguments)]
+fn collect_owned_shape_text(
+    draw_text: Option<&HxDrawText>,
+    parent: VisualParent<'_>,
+    parent_path: &str,
+    path: &str,
     depth: usize,
-    equations: &mut Vec<&'a HxEquation>,
+    parent_order: &mut usize,
+    equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     if let Some(draw_text) = draw_text {
-        collect_equations_from_paragraphs(&draw_text.sub_list.paragraphs, depth + 1, equations)?;
+        collect_owned_visual_paragraphs(
+            &draw_text.sub_list.paragraphs,
+            parent,
+            parent_path,
+            &format!("{path}/drawText"),
+            depth + 1,
+            parent_order,
+            equations,
+        )?;
     }
     Ok(())
 }
 
-fn collect_equations_from_table<'a>(
-    table: &'a HxTable,
+#[allow(clippy::too_many_arguments)]
+fn collect_owned_visual_table(
+    table: &HxTable,
+    parent: VisualParent<'_>,
+    parent_path: &str,
+    path: &str,
     depth: usize,
-    equations: &mut Vec<&'a HxEquation>,
+    parent_order: &mut usize,
+    equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
-    for row in &table.rows {
-        for cell in &row.cells {
+    for (row_index, row) in table.rows.iter().enumerate() {
+        for (cell_index, cell) in row.cells.iter().enumerate() {
             if let Some(sub_list) = &cell.sub_list {
-                collect_equations_from_paragraphs(&sub_list.paragraphs, depth + 1, equations)?;
+                collect_owned_visual_paragraphs(
+                    &sub_list.paragraphs,
+                    parent,
+                    parent_path,
+                    &format!("{path}/row[{row_index}]/cell[{cell_index}]"),
+                    depth + 1,
+                    parent_order,
+                    equations,
+                )?;
             }
         }
     }
     Ok(())
 }
 
-fn collect_equations_from_ctrl<'a>(
-    ctrl: &'a HxCtrl,
+#[allow(clippy::too_many_arguments)]
+fn collect_owned_visual_ctrl(
+    ctrl: &HxCtrl,
+    parent: VisualParent<'_>,
+    parent_path: &str,
+    path: &str,
     depth: usize,
-    equations: &mut Vec<&'a HxEquation>,
+    parent_order: &mut usize,
+    equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     if let Some(header) = &ctrl.header {
         if let Some(sub_list) = &header.sub_list {
-            collect_equations_from_paragraphs(&sub_list.paragraphs, depth + 1, equations)?;
+            collect_owned_visual_paragraphs(
+                &sub_list.paragraphs,
+                parent,
+                parent_path,
+                &format!("{path}/header"),
+                depth + 1,
+                parent_order,
+                equations,
+            )?;
         }
     }
     if let Some(footer) = &ctrl.footer {
         if let Some(sub_list) = &footer.sub_list {
-            collect_equations_from_paragraphs(&sub_list.paragraphs, depth + 1, equations)?;
+            collect_owned_visual_paragraphs(
+                &sub_list.paragraphs,
+                parent,
+                parent_path,
+                &format!("{path}/footer"),
+                depth + 1,
+                parent_order,
+                equations,
+            )?;
         }
     }
     if let Some(footnote) = &ctrl.foot_note {
-        collect_equations_from_paragraphs(&footnote.sub_list.paragraphs, depth + 1, equations)?;
+        collect_owned_visual_paragraphs(
+            &footnote.sub_list.paragraphs,
+            parent,
+            parent_path,
+            &format!("{path}/footnote"),
+            depth + 1,
+            parent_order,
+            equations,
+        )?;
     }
     if let Some(endnote) = &ctrl.end_note {
-        collect_equations_from_paragraphs(&endnote.sub_list.paragraphs, depth + 1, equations)?;
+        collect_owned_visual_paragraphs(
+            &endnote.sub_list.paragraphs,
+            parent,
+            parent_path,
+            &format!("{path}/endnote"),
+            depth + 1,
+            parent_order,
+            equations,
+        )?;
     }
+    Ok(())
+}
+
+fn push_parent_equation(
+    equation: &HxEquation,
+    parent: VisualParent<'_>,
+    parent_path: &str,
+    parent_order: &mut usize,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
+    let current_parent_order = *parent_order;
+    let equation_object_id = nonempty(&equation.id);
+    let id = equation_object_id
+        .clone()
+        .unwrap_or_else(|| format!("{parent_path}/equation[{current_parent_order}]"));
+    let raw_position = equation_position(equation, parent)?;
+    let translation = HwpxVisualEquationTranslation {
+        horz: parent.translation.horz.to_string(),
+        vert: parent.translation.vert.to_string(),
+    };
+    let display_position = translate_position(raw_position, parent.translation);
+    let geometry = equation_geometry(equation, parent);
+    let z_order = equation.z_order.unwrap_or(parent.z_order);
+    equations.push(HwpxVisualEquation {
+        id,
+        domain: parent.domain,
+        equation_object_id,
+        parent_object_id: nonempty(parent.object_id),
+        parent_instance_id: nonempty(parent.instance_id),
+        parent_kind: parent.kind,
+        parent_path: parent_path.to_string(),
+        document_order: 0,
+        parent_order: current_parent_order,
+        z_order,
+        raw_position,
+        translation,
+        display_position,
+        geometry,
+        script: equation.script.as_ref().map(|script| script.text.clone()).unwrap_or_default(),
+        latex: None,
+    });
+    *parent_order += 1;
     Ok(())
 }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -8,7 +8,7 @@ use crate::schema::section::{
     HxSizeAttr, HxSubList, HxTable, HxTablePos, HxTableSz,
 };
 
-pub(crate) const HWPX_VISUAL_EQUATION_SCHEMA_VERSION: u32 = 3;
+pub(crate) const HWPX_VISUAL_EQUATION_SCHEMA_VERSION: u32 = 4;
 
 /// Versioned report of equations that styled Markdown intentionally leaves
 /// inside picture captions and grouped drawing text.
@@ -111,14 +111,14 @@ pub struct HwpxVisualEquationGeometry {
     pub raw_equation_size: Option<HwpxVisualEquationSize>,
     /// Equation `baseUnit` before its parent rendering scale is applied.
     pub raw_base_unit: Option<u32>,
+    /// Canonical equation font base for rendering, falling back to raw equation height.
+    pub render_base_unit: Option<u32>,
     /// Exact wire scale selected from the visual parent's final `scaMatrix`.
     pub scale: HwpxVisualEquationScale,
     /// Parent box size after applying the wire scale, rounded to HWP units.
     pub display_box_size: Option<HwpxVisualEquationSize>,
     /// Equation size after applying the wire scale, rounded to HWP units.
     pub display_equation_size: Option<HwpxVisualEquationSize>,
-    /// Equation `baseUnit` after applying the vertical wire scale.
-    pub display_base_unit: Option<u32>,
 }
 
 /// Width and height in HWP units.
@@ -569,13 +569,18 @@ fn equation_geometry(
         horz: parent.scale.horz.to_string(),
         vert: parent.scale.vert.to_string(),
     };
+    let raw_base_unit = (equation.base_unit > 0).then_some(equation.base_unit);
+    let render_base_unit = raw_base_unit.or_else(|| {
+        raw_equation_size
+            .and_then(|size| u32::try_from(size.height).ok().filter(|height| *height > 0))
+    });
     HwpxVisualEquationGeometry {
         raw_box_size,
         raw_equation_size,
-        raw_base_unit: (equation.base_unit > 0).then_some(equation.base_unit),
+        raw_base_unit,
+        render_base_unit,
         display_box_size: scale_size(raw_box_size, parent.scale),
         display_equation_size: scale_size(raw_equation_size, parent.scale),
-        display_base_unit: scale_base_unit(equation.base_unit, parent.scale.vert),
         scale,
     }
 }
@@ -604,21 +609,6 @@ fn scale_dimension(raw: i32, scale: &str) -> Option<i32> {
         return None;
     }
     Some(display.max(1.0) as i32)
-}
-
-fn scale_base_unit(raw: u32, scale: &str) -> Option<u32> {
-    if raw == 0 {
-        return None;
-    }
-    let scale = scale.parse::<f64>().ok()?;
-    if !scale.is_finite() || scale <= 0.0 {
-        return None;
-    }
-    let display = (f64::from(raw) * scale).round();
-    if !display.is_finite() || display > f64::from(u32::MAX) {
-        return None;
-    }
-    Some(display.max(1.0) as u32)
 }
 
 fn translate_position(

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -230,6 +230,7 @@ fn walk_visual_run(
                     &run.pictures[index],
                     &format!("{path}/picture[{index}]"),
                     depth,
+                    None,
                     equations,
                 )?;
             }
@@ -241,6 +242,7 @@ fn walk_visual_run(
                     &run.containers[index],
                     &format!("{path}/container[{index}]"),
                     depth,
+                    None,
                     None,
                     equations,
                 )?;
@@ -279,7 +281,7 @@ fn walk_run_by_type(
         walk_table(table, &format!("{path}/table[{index}]"), depth, equations)?;
     }
     for (index, picture) in run.pictures.iter().enumerate() {
-        collect_picture(picture, &format!("{path}/picture[{index}]"), depth, equations)?;
+        collect_picture(picture, &format!("{path}/picture[{index}]"), depth, None, equations)?;
     }
     for (index, ctrl) in run.ctrls.iter().enumerate() {
         walk_ctrl(ctrl, &format!("{path}/ctrl[{index}]"), depth, equations)?;
@@ -289,6 +291,7 @@ fn walk_run_by_type(
             container,
             &format!("{path}/container[{index}]"),
             depth,
+            None,
             None,
             equations,
         )?;
@@ -413,38 +416,64 @@ fn collect_picture(
     pic: &HxPic,
     path: &str,
     depth: usize,
+    ancestor: Option<VisualParent<'_>>,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     let Some(caption) = &pic.caption else { return Ok(()) };
-    let parent = VisualParent {
+    let child_position = pic
+        .pos
+        .as_ref()
+        .map(position_from_table)
+        .or_else(|| pic.offset.as_ref().map(position_from_offset));
+    let child_scale = pic
+        .rendering_info
+        .as_ref()
+        .map(|rendering| VisualScale {
+            horz: rendering.sca_matrix.e1.as_str(),
+            vert: rendering.sca_matrix.e5.as_str(),
+        })
+        .unwrap_or_default();
+    let child_translation = pic
+        .rendering_info
+        .as_ref()
+        .map(|rendering| VisualTranslation {
+            horz: rendering.sca_matrix.e3.as_str(),
+            vert: rendering.sca_matrix.e6.as_str(),
+        })
+        .unwrap_or_default();
+    let parent_base = VisualParent {
         domain: HwpxVisualEquationDomain::PictureCaption,
         kind: HwpxVisualEquationParentKind::Picture,
         object_id: &pic.id,
         instance_id: &pic.instid,
         z_order: pic.z_order,
-        position: pic
-            .pos
-            .as_ref()
-            .map(position_from_table)
-            .or_else(|| pic.offset.as_ref().map(position_from_offset)),
+        position: child_position,
         raw_box_size: None,
-        scale: pic
-            .rendering_info
-            .as_ref()
-            .map(|rendering| VisualScale {
-                horz: rendering.sca_matrix.e1.as_str(),
-                vert: rendering.sca_matrix.e5.as_str(),
-            })
-            .unwrap_or_default(),
-        translation: pic
-            .rendering_info
-            .as_ref()
-            .map(|rendering| VisualTranslation {
-                horz: rendering.sca_matrix.e3.as_str(),
-                vert: rendering.sca_matrix.e6.as_str(),
-            })
-            .unwrap_or_default(),
+        scale: child_scale,
+        translation: child_translation,
         compose_child_position: false,
+    };
+    let Some(ancestor) = ancestor else {
+        return collect_parent_equations(&caption.sub_list, parent_base, path, depth, equations);
+    };
+    let scale_horz = compose_scale(ancestor.scale.horz, child_scale.horz)?;
+    let scale_vert = compose_scale(ancestor.scale.vert, child_scale.vert)?;
+    let translation_horz = compose_translation(
+        ancestor.translation.horz,
+        ancestor.scale.horz,
+        child_translation.horz,
+    )?;
+    let translation_vert = compose_translation(
+        ancestor.translation.vert,
+        ancestor.scale.vert,
+        child_translation.vert,
+    )?;
+    let parent = VisualParent {
+        position: add_optional_positions(ancestor.position, child_position)?,
+        scale: VisualScale { horz: &scale_horz, vert: &scale_vert },
+        translation: VisualTranslation { horz: &translation_horz, vert: &translation_vert },
+        compose_child_position: true,
+        ..parent_base
     };
     collect_parent_equations(&caption.sub_list, parent, path, depth, equations)
 }
@@ -454,11 +483,12 @@ fn collect_container(
     path: &str,
     depth: usize,
     inherited_position: Option<HwpxVisualEquationPosition>,
+    ancestor: Option<VisualParent<'_>>,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     ensure_depth(depth)?;
     let container_position = add_optional_positions(
-        inherited_position,
+        inherited_position.or_else(|| ancestor.and_then(|parent| parent.position)),
         container.pos.as_ref().map(position_from_table),
     )?;
     if !container.child_order.is_empty() {
@@ -469,6 +499,7 @@ fn collect_container(
                     &format!("{path}/rect[{rect_index}]"),
                     depth,
                     container_position,
+                    ancestor,
                     equations,
                 )?,
                 HxContainerChildOrder::Ellipse(ellipse_index) => collect_group_ellipse(
@@ -476,6 +507,7 @@ fn collect_container(
                     &format!("{path}/ellipse[{ellipse_index}]"),
                     depth,
                     container_position,
+                    ancestor,
                     equations,
                 )?,
                 HxContainerChildOrder::Polygon(polygon_index) => collect_group_polygon(
@@ -483,6 +515,7 @@ fn collect_container(
                     &format!("{path}/polygon[{polygon_index}]"),
                     depth,
                     container_position,
+                    ancestor,
                     equations,
                 )?,
                 HxContainerChildOrder::Container(container_index) => collect_container(
@@ -490,6 +523,7 @@ fn collect_container(
                     &format!("{path}/container[{container_index}]"),
                     depth + 1,
                     container_position,
+                    ancestor,
                     equations,
                 )?,
                 _ => {}
@@ -503,6 +537,7 @@ fn collect_container(
             &format!("{path}/rect[{rect_index}]"),
             depth,
             container_position,
+            ancestor,
             equations,
         )?;
     }
@@ -512,6 +547,7 @@ fn collect_container(
             &format!("{path}/ellipse[{ellipse_index}]"),
             depth,
             container_position,
+            ancestor,
             equations,
         )?;
     }
@@ -521,6 +557,7 @@ fn collect_container(
             &format!("{path}/polygon[{polygon_index}]"),
             depth,
             container_position,
+            ancestor,
             equations,
         )?;
     }
@@ -530,6 +567,7 @@ fn collect_container(
             &format!("{path}/container[{container_index}]"),
             depth + 1,
             container_position,
+            ancestor,
             equations,
         )?;
     }
@@ -541,6 +579,7 @@ fn collect_group_rect(
     path: &str,
     depth: usize,
     container_position: Option<HwpxVisualEquationPosition>,
+    ancestor: Option<VisualParent<'_>>,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     collect_group_shape(
@@ -555,6 +594,7 @@ fn collect_group_rect(
         path,
         depth,
         container_position,
+        ancestor,
         equations,
     )
 }
@@ -564,6 +604,7 @@ fn collect_group_ellipse(
     path: &str,
     depth: usize,
     container_position: Option<HwpxVisualEquationPosition>,
+    ancestor: Option<VisualParent<'_>>,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     collect_group_shape(
@@ -578,6 +619,7 @@ fn collect_group_ellipse(
         path,
         depth,
         container_position,
+        ancestor,
         equations,
     )
 }
@@ -587,6 +629,7 @@ fn collect_group_polygon(
     path: &str,
     depth: usize,
     container_position: Option<HwpxVisualEquationPosition>,
+    ancestor: Option<VisualParent<'_>>,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     collect_group_shape(
@@ -601,6 +644,7 @@ fn collect_group_polygon(
         path,
         depth,
         container_position,
+        ancestor,
         equations,
     )
 }
@@ -618,12 +662,25 @@ fn collect_group_shape(
     path: &str,
     depth: usize,
     container_position: Option<HwpxVisualEquationPosition>,
+    ancestor: Option<VisualParent<'_>>,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     let Some(draw_text) = draw_text else { return Ok(()) };
     let shape_position =
         offset.map(position_from_offset).or_else(|| position.map(position_from_table));
-    let parent = VisualParent {
+    let child_scale = rendering_info
+        .map(|rendering| VisualScale {
+            horz: rendering.sca_matrix.e1.as_str(),
+            vert: rendering.sca_matrix.e5.as_str(),
+        })
+        .unwrap_or_default();
+    let child_translation = rendering_info
+        .map(|rendering| VisualTranslation {
+            horz: rendering.sca_matrix.e3.as_str(),
+            vert: rendering.sca_matrix.e6.as_str(),
+        })
+        .unwrap_or_default();
+    let parent_base = VisualParent {
         domain: HwpxVisualEquationDomain::GroupDrawText,
         kind: HwpxVisualEquationParentKind::Container,
         object_id,
@@ -631,19 +688,29 @@ fn collect_group_shape(
         z_order,
         position: add_optional_positions(container_position, shape_position)?,
         raw_box_size: original_size.map(size_from_original),
-        scale: rendering_info
-            .map(|rendering| VisualScale {
-                horz: rendering.sca_matrix.e1.as_str(),
-                vert: rendering.sca_matrix.e5.as_str(),
-            })
-            .unwrap_or_default(),
-        translation: rendering_info
-            .map(|rendering| VisualTranslation {
-                horz: rendering.sca_matrix.e3.as_str(),
-                vert: rendering.sca_matrix.e6.as_str(),
-            })
-            .unwrap_or_default(),
+        scale: child_scale,
+        translation: child_translation,
         compose_child_position: true,
+    };
+    let Some(ancestor) = ancestor else {
+        return collect_parent_equations(&draw_text.sub_list, parent_base, path, depth, equations);
+    };
+    let scale_horz = compose_scale(ancestor.scale.horz, child_scale.horz)?;
+    let scale_vert = compose_scale(ancestor.scale.vert, child_scale.vert)?;
+    let translation_horz = compose_translation(
+        ancestor.translation.horz,
+        ancestor.scale.horz,
+        child_translation.horz,
+    )?;
+    let translation_vert = compose_translation(
+        ancestor.translation.vert,
+        ancestor.scale.vert,
+        child_translation.vert,
+    )?;
+    let parent = VisualParent {
+        scale: VisualScale { horz: &scale_horz, vert: &scale_vert },
+        translation: VisualTranslation { horz: &translation_horz, vert: &translation_vert },
+        ..parent_base
     };
     collect_parent_equations(&draw_text.sub_list, parent, path, depth, equations)
 }
@@ -758,6 +825,7 @@ fn collect_owned_visual_paragraphs(
                         picture,
                         &format!("{run_path}/picture[{index}]"),
                         depth,
+                        Some(parent),
                         equations,
                     )?;
                 }
@@ -767,6 +835,7 @@ fn collect_owned_visual_paragraphs(
                         &format!("{run_path}/container[{index}]"),
                         depth,
                         None,
+                        Some(parent),
                         equations,
                     )?;
                 }
@@ -841,6 +910,7 @@ fn collect_owned_visual_paragraphs(
                             &run.pictures[index],
                             &format!("{run_path}/picture[{index}]"),
                             depth,
+                            Some(parent),
                             equations,
                         )?,
                         HxRunChildOrder::Container(index) => collect_container(
@@ -848,6 +918,7 @@ fn collect_owned_visual_paragraphs(
                             &format!("{run_path}/container[{index}]"),
                             depth,
                             None,
+                            Some(parent),
                             equations,
                         )?,
                         _ => {}

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -175,6 +175,7 @@ struct VisualParent<'a> {
     raw_box_size: Option<HwpxVisualEquationSize>,
     scale: VisualScale<'a>,
     translation: VisualTranslation<'a>,
+    compose_child_position: bool,
 }
 
 pub(crate) fn collect_section(
@@ -421,6 +422,7 @@ fn collect_picture(
         raw_box_size: None,
         scale: VisualScale::default(),
         translation: VisualTranslation::default(),
+        compose_child_position: false,
     };
     collect_parent_equations(&caption.sub_list, parent, path, depth, equations)
 }
@@ -619,6 +621,7 @@ fn collect_group_shape(
                 vert: rendering.sca_matrix.e6.as_str(),
             })
             .unwrap_or_default(),
+        compose_child_position: true,
     };
     collect_parent_equations(&draw_text.sub_list, parent, path, depth, equations)
 }
@@ -686,6 +689,10 @@ fn collect_owned_visual_paragraphs(
                 for (index, rect) in run.rects.iter().enumerate() {
                     collect_owned_shape_text(
                         rect.draw_text.as_ref(),
+                        rect.offset.as_ref(),
+                        rect.pos.as_ref(),
+                        rect.org_sz.as_ref(),
+                        rect.rendering_info.as_ref(),
                         parent,
                         parent_path,
                         &format!("{run_path}/rect[{index}]"),
@@ -697,6 +704,10 @@ fn collect_owned_visual_paragraphs(
                 for (index, ellipse) in run.ellipses.iter().enumerate() {
                     collect_owned_shape_text(
                         ellipse.draw_text.as_ref(),
+                        ellipse.offset.as_ref(),
+                        ellipse.pos.as_ref(),
+                        ellipse.org_sz.as_ref(),
+                        ellipse.rendering_info.as_ref(),
                         parent,
                         parent_path,
                         &format!("{run_path}/ellipse[{index}]"),
@@ -708,6 +719,10 @@ fn collect_owned_visual_paragraphs(
                 for (index, polygon) in run.polygons.iter().enumerate() {
                     collect_owned_shape_text(
                         polygon.draw_text.as_ref(),
+                        polygon.offset.as_ref(),
+                        polygon.pos.as_ref(),
+                        polygon.org_sz.as_ref(),
+                        polygon.rendering_info.as_ref(),
                         parent,
                         parent_path,
                         &format!("{run_path}/polygon[{index}]"),
@@ -763,6 +778,10 @@ fn collect_owned_visual_paragraphs(
                         )?,
                         HxRunChildOrder::Rect(index) => collect_owned_shape_text(
                             run.rects[index].draw_text.as_ref(),
+                            run.rects[index].offset.as_ref(),
+                            run.rects[index].pos.as_ref(),
+                            run.rects[index].org_sz.as_ref(),
+                            run.rects[index].rendering_info.as_ref(),
                             parent,
                             parent_path,
                             &format!("{run_path}/rect[{index}]"),
@@ -772,6 +791,10 @@ fn collect_owned_visual_paragraphs(
                         )?,
                         HxRunChildOrder::Ellipse(index) => collect_owned_shape_text(
                             run.ellipses[index].draw_text.as_ref(),
+                            run.ellipses[index].offset.as_ref(),
+                            run.ellipses[index].pos.as_ref(),
+                            run.ellipses[index].org_sz.as_ref(),
+                            run.ellipses[index].rendering_info.as_ref(),
                             parent,
                             parent_path,
                             &format!("{run_path}/ellipse[{index}]"),
@@ -781,6 +804,10 @@ fn collect_owned_visual_paragraphs(
                         )?,
                         HxRunChildOrder::Polygon(index) => collect_owned_shape_text(
                             run.polygons[index].draw_text.as_ref(),
+                            run.polygons[index].offset.as_ref(),
+                            run.polygons[index].pos.as_ref(),
+                            run.polygons[index].org_sz.as_ref(),
+                            run.polygons[index].rendering_info.as_ref(),
                             parent,
                             parent_path,
                             &format!("{run_path}/polygon[{index}]"),
@@ -813,6 +840,10 @@ fn collect_owned_visual_paragraphs(
 #[allow(clippy::too_many_arguments)]
 fn collect_owned_shape_text(
     draw_text: Option<&HxDrawText>,
+    offset: Option<&HxOffset>,
+    position: Option<&HxTablePos>,
+    original_size: Option<&HxSizeAttr>,
+    rendering_info: Option<&HxRenderingInfo>,
     parent: VisualParent<'_>,
     parent_path: &str,
     path: &str,
@@ -821,9 +852,43 @@ fn collect_owned_shape_text(
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     if let Some(draw_text) = draw_text {
+        let child_position =
+            offset.map(position_from_offset).or_else(|| position.map(position_from_table));
+        let child_scale = rendering_info
+            .map(|rendering| VisualScale {
+                horz: rendering.sca_matrix.e1.as_str(),
+                vert: rendering.sca_matrix.e5.as_str(),
+            })
+            .unwrap_or_default();
+        let child_translation = rendering_info
+            .map(|rendering| VisualTranslation {
+                horz: rendering.sca_matrix.e3.as_str(),
+                vert: rendering.sca_matrix.e6.as_str(),
+            })
+            .unwrap_or_default();
+        let scale_horz = compose_scale(parent.scale.horz, child_scale.horz)?;
+        let scale_vert = compose_scale(parent.scale.vert, child_scale.vert)?;
+        let translation_horz = compose_translation(
+            parent.translation.horz,
+            parent.scale.horz,
+            child_translation.horz,
+        )?;
+        let translation_vert = compose_translation(
+            parent.translation.vert,
+            parent.scale.vert,
+            child_translation.vert,
+        )?;
+        let nested_parent = VisualParent {
+            position: add_optional_positions(parent.position, child_position)?,
+            raw_box_size: original_size.map(size_from_original).or(parent.raw_box_size),
+            scale: VisualScale { horz: &scale_horz, vert: &scale_vert },
+            translation: VisualTranslation { horz: &translation_horz, vert: &translation_vert },
+            compose_child_position: true,
+            ..parent
+        };
         collect_owned_visual_paragraphs(
             &draw_text.sub_list.paragraphs,
-            parent,
+            nested_parent,
             parent_path,
             &format!("{path}/drawText"),
             depth + 1,
@@ -1083,6 +1148,12 @@ fn equation_position(
     parent: VisualParent<'_>,
 ) -> HwpxResult<HwpxVisualEquationPosition> {
     let child_position = equation.pos.as_ref().map(position_from_table);
+    if parent.compose_child_position {
+        return add_positions(
+            parent.position.unwrap_or_default(),
+            child_position.unwrap_or_default(),
+        );
+    }
     match parent.domain {
         HwpxVisualEquationDomain::PictureCaption => {
             Ok(child_position.or(parent.position).unwrap_or_default())
@@ -1090,6 +1161,39 @@ fn equation_position(
         HwpxVisualEquationDomain::GroupDrawText => {
             add_positions(parent.position.unwrap_or_default(), child_position.unwrap_or_default())
         }
+    }
+}
+
+fn compose_scale(parent: &str, child: &str) -> HwpxResult<String> {
+    let parent = parse_transform(parent)?;
+    let child = parse_transform(child)?;
+    Ok(format_transform(parent * child))
+}
+
+fn compose_translation(
+    parent_translation: &str,
+    parent_scale: &str,
+    child_translation: &str,
+) -> HwpxResult<String> {
+    let parent_translation = parse_transform(parent_translation)?;
+    let parent_scale = parse_transform(parent_scale)?;
+    let child_translation = parse_transform(child_translation)?;
+    Ok(format_transform(parent_translation + parent_scale * child_translation))
+}
+
+fn parse_transform(value: &str) -> HwpxResult<f64> {
+    value.parse::<f64>().ok().filter(|value| value.is_finite()).ok_or_else(|| {
+        HwpxError::InvalidStructure {
+            detail: format!("visual-equation transform is not finite: {value}"),
+        }
+    })
+}
+
+fn format_transform(value: f64) -> String {
+    if value == 0.0 {
+        "0".to_string()
+    } else {
+        value.to_string()
     }
 }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -5,8 +5,10 @@ use serde::Serialize;
 use crate::error::{HwpxError, HwpxResult};
 use crate::schema::section::{
     HxContainer, HxCtrl, HxEquation, HxOffset, HxParagraph, HxPic, HxRect, HxRun, HxRunChildOrder,
-    HxSubList, HxTable, HxTablePos,
+    HxSizeAttr, HxSubList, HxTable, HxTablePos, HxTableSz,
 };
+
+pub(crate) const HWPX_VISUAL_EQUATION_SCHEMA_VERSION: u32 = 2;
 
 /// Versioned report of equations that styled Markdown intentionally leaves
 /// inside picture captions and grouped drawing text.
@@ -20,7 +22,7 @@ pub struct HwpxVisualEquationReport {
 
 impl Default for HwpxVisualEquationReport {
     fn default() -> Self {
-        Self { schema_version: 1, equations: Vec::new() }
+        Self { schema_version: HWPX_VISUAL_EQUATION_SCHEMA_VERSION, equations: Vec::new() }
     }
 }
 
@@ -49,6 +51,8 @@ pub struct HwpxVisualEquation {
     pub z_order: u32,
     /// Equation position, falling back to the nearest visual parent when absent.
     pub position: HwpxVisualEquationPosition,
+    /// Raw and display-space geometry for faithful visual composition.
+    pub geometry: HwpxVisualEquationGeometry,
     /// Original HancomEQN source.
     pub script: String,
     /// Converted LaTeX, populated by a format consumer such as the CLI.
@@ -85,6 +89,55 @@ pub struct HwpxVisualEquationPosition {
     pub vert_offset: i32,
 }
 
+/// Raw wire geometry and scale-applied display geometry for a visual equation.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HwpxVisualEquationGeometry {
+    /// Parent box size before its rendering scale is applied.
+    pub raw_box_size: Option<HwpxVisualEquationSize>,
+    /// Equation size before its parent rendering scale is applied.
+    pub raw_equation_size: Option<HwpxVisualEquationSize>,
+    /// Equation `baseUnit` before its parent rendering scale is applied.
+    pub raw_base_unit: Option<u32>,
+    /// Exact wire scale selected from the visual parent's final `scaMatrix`.
+    pub scale: HwpxVisualEquationScale,
+    /// Parent box size after applying the wire scale, rounded to HWP units.
+    pub display_box_size: Option<HwpxVisualEquationSize>,
+    /// Equation size after applying the wire scale, rounded to HWP units.
+    pub display_equation_size: Option<HwpxVisualEquationSize>,
+    /// Equation `baseUnit` after applying the vertical wire scale.
+    pub display_base_unit: Option<u32>,
+}
+
+/// Width and height in HWP units.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct HwpxVisualEquationSize {
+    /// Horizontal extent.
+    pub width: i32,
+    /// Vertical extent.
+    pub height: i32,
+}
+
+/// Exact horizontal and vertical scale strings preserved from HWPX.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HwpxVisualEquationScale {
+    /// Horizontal scale (`scaMatrix.e1`).
+    pub horz: String,
+    /// Vertical scale (`scaMatrix.e5`).
+    pub vert: String,
+}
+
+#[derive(Clone, Copy)]
+struct VisualScale<'a> {
+    horz: &'a str,
+    vert: &'a str,
+}
+
+impl Default for VisualScale<'_> {
+    fn default() -> Self {
+        Self { horz: "1", vert: "1" }
+    }
+}
+
 #[derive(Clone, Copy)]
 struct VisualParent<'a> {
     domain: HwpxVisualEquationDomain,
@@ -93,6 +146,8 @@ struct VisualParent<'a> {
     instance_id: &'a str,
     z_order: u32,
     position: Option<HwpxVisualEquationPosition>,
+    raw_box_size: Option<HwpxVisualEquationSize>,
+    scale: VisualScale<'a>,
 }
 
 pub(crate) fn collect_section(
@@ -259,6 +314,8 @@ fn collect_picture(
             .as_ref()
             .map(position_from_table)
             .or_else(|| pic.offset.as_ref().map(position_from_offset)),
+        raw_box_size: None,
+        scale: VisualScale::default(),
     };
     collect_parent_equations(&caption.sub_list, parent, path, depth, equations)
 }
@@ -313,6 +370,15 @@ fn collect_group_rect(
             .map(position_from_offset)
             .or_else(|| rect.pos.as_ref().map(position_from_table))
             .or(container_position),
+        raw_box_size: rect.org_sz.as_ref().map(size_from_original),
+        scale: rect
+            .rendering_info
+            .as_ref()
+            .map(|rendering| VisualScale {
+                horz: rendering.sca_matrix.e1.as_str(),
+                vert: rendering.sca_matrix.e5.as_str(),
+            })
+            .unwrap_or_default(),
     };
     collect_parent_equations(&draw_text.sub_list, parent, path, depth, equations)
 }
@@ -332,6 +398,7 @@ fn collect_parent_equations(
             .clone()
             .unwrap_or_else(|| format!("{parent_path}/equation[{parent_order}]"));
         let position = equation_position(equation, parent)?;
+        let geometry = equation_geometry(equation, parent);
         let z_order = equation.z_order.unwrap_or(parent.z_order);
         equations.push(HwpxVisualEquation {
             id,
@@ -345,6 +412,7 @@ fn collect_parent_equations(
             parent_order,
             z_order,
             position,
+            geometry,
             script: equation.script.as_ref().map(|script| script.text.clone()).unwrap_or_default(),
             latex: None,
         });
@@ -436,6 +504,79 @@ fn position_from_table(position: &HxTablePos) -> HwpxVisualEquationPosition {
 
 fn position_from_offset(position: &HxOffset) -> HwpxVisualEquationPosition {
     HwpxVisualEquationPosition { horz_offset: position.x, vert_offset: position.y }
+}
+
+fn size_from_original(size: &HxSizeAttr) -> HwpxVisualEquationSize {
+    HwpxVisualEquationSize { width: size.width, height: size.height }
+}
+
+fn size_from_table(size: &HxTableSz) -> HwpxVisualEquationSize {
+    HwpxVisualEquationSize { width: size.width, height: size.height }
+}
+
+fn equation_geometry(
+    equation: &HxEquation,
+    parent: VisualParent<'_>,
+) -> HwpxVisualEquationGeometry {
+    let raw_equation_size = equation.sz.as_ref().map(size_from_table);
+    let raw_box_size = match parent.domain {
+        HwpxVisualEquationDomain::PictureCaption => raw_equation_size,
+        HwpxVisualEquationDomain::GroupDrawText => parent.raw_box_size,
+    };
+    let scale = HwpxVisualEquationScale {
+        horz: parent.scale.horz.to_string(),
+        vert: parent.scale.vert.to_string(),
+    };
+    HwpxVisualEquationGeometry {
+        raw_box_size,
+        raw_equation_size,
+        raw_base_unit: (equation.base_unit > 0).then_some(equation.base_unit),
+        display_box_size: scale_size(raw_box_size, parent.scale),
+        display_equation_size: scale_size(raw_equation_size, parent.scale),
+        display_base_unit: scale_base_unit(equation.base_unit, parent.scale.vert),
+        scale,
+    }
+}
+
+fn scale_size(
+    raw_size: Option<HwpxVisualEquationSize>,
+    scale: VisualScale<'_>,
+) -> Option<HwpxVisualEquationSize> {
+    let raw_size = raw_size?;
+    Some(HwpxVisualEquationSize {
+        width: scale_dimension(raw_size.width, scale.horz)?,
+        height: scale_dimension(raw_size.height, scale.vert)?,
+    })
+}
+
+fn scale_dimension(raw: i32, scale: &str) -> Option<i32> {
+    if raw <= 0 {
+        return None;
+    }
+    let scale = scale.parse::<f64>().ok()?;
+    if !scale.is_finite() || scale <= 0.0 {
+        return None;
+    }
+    let display = (f64::from(raw) * scale).round();
+    if !display.is_finite() || display > f64::from(i32::MAX) {
+        return None;
+    }
+    Some(display.max(1.0) as i32)
+}
+
+fn scale_base_unit(raw: u32, scale: &str) -> Option<u32> {
+    if raw == 0 {
+        return None;
+    }
+    let scale = scale.parse::<f64>().ok()?;
+    if !scale.is_finite() || scale <= 0.0 {
+        return None;
+    }
+    let display = (f64::from(raw) * scale).round();
+    if !display.is_finite() || display > f64::from(u32::MAX) {
+        return None;
+    }
+    Some(display.max(1.0) as u32)
 }
 
 fn equation_position(

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -2,9 +2,10 @@
 
 use serde::Serialize;
 
+use crate::error::{HwpxError, HwpxResult};
 use crate::schema::section::{
-    HxContainer, HxCtrl, HxEquation, HxParagraph, HxPic, HxRect, HxRun, HxRunChildOrder, HxSubList,
-    HxTable, HxTablePos,
+    HxContainer, HxCtrl, HxEquation, HxOffset, HxParagraph, HxPic, HxRect, HxRun, HxRunChildOrder,
+    HxSubList, HxTable, HxTablePos,
 };
 
 /// Versioned report of equations that styled Markdown intentionally leaves
@@ -91,159 +92,248 @@ struct VisualParent<'a> {
     object_id: &'a str,
     instance_id: &'a str,
     z_order: u32,
-    position: Option<&'a HxTablePos>,
+    position: Option<HwpxVisualEquationPosition>,
 }
 
 pub(crate) fn collect_section(
     paragraphs: &[HxParagraph],
     section_index: usize,
-) -> Vec<HwpxVisualEquation> {
+) -> HwpxResult<Vec<HwpxVisualEquation>> {
     let mut equations = Vec::new();
     let root = format!("section[{section_index}]");
-    walk_visual_paragraphs(paragraphs, &root, &mut equations);
-    equations
+    walk_visual_paragraphs(paragraphs, &root, 0, &mut equations)?;
+    Ok(equations)
 }
 
 fn walk_visual_paragraphs(
     paragraphs: &[HxParagraph],
     prefix: &str,
+    depth: usize,
     equations: &mut Vec<HwpxVisualEquation>,
-) {
+) -> HwpxResult<()> {
+    ensure_depth(depth)?;
     for (paragraph_index, paragraph) in paragraphs.iter().enumerate() {
         let paragraph_path = format!("{prefix}/paragraph[{paragraph_index}]");
         for (run_index, run) in paragraph.runs.iter().enumerate() {
             let run_path = format!("{paragraph_path}/run[{run_index}]");
-            walk_visual_run(run, &run_path, equations);
+            walk_visual_run(run, &run_path, depth, equations)?;
         }
     }
+    Ok(())
 }
 
-fn walk_visual_run(run: &HxRun, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+fn walk_visual_run(
+    run: &HxRun,
+    path: &str,
+    depth: usize,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
     if run.child_order.is_empty() {
-        walk_run_by_type(run, path, equations);
-        return;
+        return walk_run_by_type(run, path, depth, equations);
     }
 
     for child in &run.child_order {
         match *child {
             HxRunChildOrder::Table(index) => {
-                walk_table(&run.tables[index], &format!("{path}/table[{index}]"), equations);
+                walk_table(
+                    &run.tables[index],
+                    &format!("{path}/table[{index}]"),
+                    depth,
+                    equations,
+                )?;
             }
             HxRunChildOrder::Picture(index) => {
                 collect_picture(
                     &run.pictures[index],
                     &format!("{path}/picture[{index}]"),
+                    depth,
                     equations,
-                );
+                )?;
             }
             HxRunChildOrder::Ctrl(index) => {
-                walk_ctrl(&run.ctrls[index], &format!("{path}/ctrl[{index}]"), equations);
+                walk_ctrl(&run.ctrls[index], &format!("{path}/ctrl[{index}]"), depth, equations)?;
             }
             HxRunChildOrder::Container(index) => {
                 collect_container(
                     &run.containers[index],
                     &format!("{path}/container[{index}]"),
+                    depth,
+                    None,
                     equations,
-                );
+                )?;
             }
             _ => {}
         }
     }
+    Ok(())
 }
 
-fn walk_run_by_type(run: &HxRun, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+fn walk_run_by_type(
+    run: &HxRun,
+    path: &str,
+    depth: usize,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
     for (index, table) in run.tables.iter().enumerate() {
-        walk_table(table, &format!("{path}/table[{index}]"), equations);
+        walk_table(table, &format!("{path}/table[{index}]"), depth, equations)?;
     }
     for (index, picture) in run.pictures.iter().enumerate() {
-        collect_picture(picture, &format!("{path}/picture[{index}]"), equations);
+        collect_picture(picture, &format!("{path}/picture[{index}]"), depth, equations)?;
     }
     for (index, ctrl) in run.ctrls.iter().enumerate() {
-        walk_ctrl(ctrl, &format!("{path}/ctrl[{index}]"), equations);
+        walk_ctrl(ctrl, &format!("{path}/ctrl[{index}]"), depth, equations)?;
     }
     for (index, container) in run.containers.iter().enumerate() {
-        collect_container(container, &format!("{path}/container[{index}]"), equations);
+        collect_container(
+            container,
+            &format!("{path}/container[{index}]"),
+            depth,
+            None,
+            equations,
+        )?;
     }
+    Ok(())
 }
 
-fn walk_table(table: &HxTable, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+fn walk_table(
+    table: &HxTable,
+    path: &str,
+    depth: usize,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
     for (row_index, row) in table.rows.iter().enumerate() {
         for (cell_index, cell) in row.cells.iter().enumerate() {
             if let Some(sub_list) = &cell.sub_list {
                 walk_visual_paragraphs(
                     &sub_list.paragraphs,
                     &format!("{path}/row[{row_index}]/cell[{cell_index}]"),
+                    depth + 1,
                     equations,
-                );
+                )?;
             }
         }
     }
+    Ok(())
 }
 
-fn walk_ctrl(ctrl: &HxCtrl, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+fn walk_ctrl(
+    ctrl: &HxCtrl,
+    path: &str,
+    depth: usize,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
     if let Some(footnote) = &ctrl.foot_note {
         walk_visual_paragraphs(
             &footnote.sub_list.paragraphs,
             &format!("{path}/footnote"),
+            depth + 1,
             equations,
-        );
+        )?;
     }
     if let Some(endnote) = &ctrl.end_note {
-        walk_visual_paragraphs(&endnote.sub_list.paragraphs, &format!("{path}/endnote"), equations);
+        walk_visual_paragraphs(
+            &endnote.sub_list.paragraphs,
+            &format!("{path}/endnote"),
+            depth + 1,
+            equations,
+        )?;
     }
+    Ok(())
 }
 
-fn collect_picture(pic: &HxPic, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
-    let Some(caption) = &pic.caption else { return };
+fn collect_picture(
+    pic: &HxPic,
+    path: &str,
+    depth: usize,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
+    let Some(caption) = &pic.caption else { return Ok(()) };
     let parent = VisualParent {
         domain: HwpxVisualEquationDomain::PictureCaption,
         kind: HwpxVisualEquationParentKind::Picture,
         object_id: &pic.id,
         instance_id: &pic.instid,
         z_order: pic.z_order,
-        position: pic.pos.as_ref(),
+        position: pic
+            .pos
+            .as_ref()
+            .map(position_from_table)
+            .or_else(|| pic.offset.as_ref().map(position_from_offset)),
     };
-    collect_parent_equations(&caption.sub_list, parent, path, equations);
+    collect_parent_equations(&caption.sub_list, parent, path, depth, equations)
 }
 
-fn collect_container(container: &HxContainer, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+fn collect_container(
+    container: &HxContainer,
+    path: &str,
+    depth: usize,
+    inherited_position: Option<HwpxVisualEquationPosition>,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
+    ensure_depth(depth)?;
+    let container_position = container.pos.as_ref().map(position_from_table).or(inherited_position);
     for (rect_index, rect) in container.rects.iter().enumerate() {
-        collect_group_rect(rect, &format!("{path}/rect[{rect_index}]"), equations);
+        collect_group_rect(
+            rect,
+            &format!("{path}/rect[{rect_index}]"),
+            depth,
+            container_position,
+            equations,
+        )?;
     }
     for (container_index, nested) in container.containers.iter().enumerate() {
-        collect_container(nested, &format!("{path}/container[{container_index}]"), equations);
+        collect_container(
+            nested,
+            &format!("{path}/container[{container_index}]"),
+            depth + 1,
+            container_position,
+            equations,
+        )?;
     }
+    Ok(())
 }
 
-fn collect_group_rect(rect: &HxRect, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
-    let Some(draw_text) = &rect.draw_text else { return };
+fn collect_group_rect(
+    rect: &HxRect,
+    path: &str,
+    depth: usize,
+    container_position: Option<HwpxVisualEquationPosition>,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
+    let Some(draw_text) = &rect.draw_text else { return Ok(()) };
     let parent = VisualParent {
         domain: HwpxVisualEquationDomain::GroupDrawText,
         kind: HwpxVisualEquationParentKind::Container,
         object_id: &rect.id,
         instance_id: &rect.instid,
         z_order: rect.z_order,
-        position: rect.pos.as_ref(),
+        position: rect
+            .offset
+            .as_ref()
+            .map(position_from_offset)
+            .or_else(|| rect.pos.as_ref().map(position_from_table))
+            .or(container_position),
     };
-    collect_parent_equations(&draw_text.sub_list, parent, path, equations);
+    collect_parent_equations(&draw_text.sub_list, parent, path, depth, equations)
 }
 
 fn collect_parent_equations(
     sub_list: &HxSubList,
     parent: VisualParent<'_>,
     parent_path: &str,
+    depth: usize,
     equations: &mut Vec<HwpxVisualEquation>,
-) {
+) -> HwpxResult<()> {
     let mut occurrences = Vec::new();
-    collect_equations_from_paragraphs(&sub_list.paragraphs, &mut occurrences);
+    collect_equations_from_paragraphs(&sub_list.paragraphs, depth, &mut occurrences)?;
     for (parent_order, equation) in occurrences.into_iter().enumerate() {
         let equation_object_id = nonempty(&equation.id);
         let id = equation_object_id
             .clone()
             .unwrap_or_else(|| format!("{parent_path}/equation[{parent_order}]"));
         let position =
-            equation.pos.as_ref().or(parent.position).map(position_from).unwrap_or_default();
-        let z_order = if equation.z_order == 0 { parent.z_order } else { equation.z_order };
+            equation.pos.as_ref().map(position_from_table).or(parent.position).unwrap_or_default();
+        let z_order = equation.z_order.unwrap_or(parent.z_order);
         equations.push(HwpxVisualEquation {
             id,
             domain: parent.domain,
@@ -260,12 +350,15 @@ fn collect_parent_equations(
             latex: None,
         });
     }
+    Ok(())
 }
 
 fn collect_equations_from_paragraphs<'a>(
     paragraphs: &'a [HxParagraph],
+    depth: usize,
     equations: &mut Vec<&'a HxEquation>,
-) {
+) -> HwpxResult<()> {
+    ensure_depth(depth)?;
     for paragraph in paragraphs {
         for run in &paragraph.runs {
             if run.child_order.is_empty() {
@@ -275,10 +368,10 @@ fn collect_equations_from_paragraphs<'a>(
                     match *child {
                         HxRunChildOrder::Equation(index) => equations.push(&run.equations[index]),
                         HxRunChildOrder::Table(index) => {
-                            collect_equations_from_table(&run.tables[index], equations);
+                            collect_equations_from_table(&run.tables[index], depth, equations)?;
                         }
                         HxRunChildOrder::Ctrl(index) => {
-                            collect_equations_from_ctrl(&run.ctrls[index], equations);
+                            collect_equations_from_ctrl(&run.ctrls[index], depth, equations)?;
                         }
                         _ => {}
                     }
@@ -286,34 +379,62 @@ fn collect_equations_from_paragraphs<'a>(
             }
         }
     }
+    Ok(())
 }
 
-fn collect_equations_from_table<'a>(table: &'a HxTable, equations: &mut Vec<&'a HxEquation>) {
+fn collect_equations_from_table<'a>(
+    table: &'a HxTable,
+    depth: usize,
+    equations: &mut Vec<&'a HxEquation>,
+) -> HwpxResult<()> {
     for row in &table.rows {
         for cell in &row.cells {
             if let Some(sub_list) = &cell.sub_list {
-                collect_equations_from_paragraphs(&sub_list.paragraphs, equations);
+                collect_equations_from_paragraphs(&sub_list.paragraphs, depth + 1, equations)?;
             }
         }
     }
+    Ok(())
 }
 
-fn collect_equations_from_ctrl<'a>(ctrl: &'a HxCtrl, equations: &mut Vec<&'a HxEquation>) {
+fn collect_equations_from_ctrl<'a>(
+    ctrl: &'a HxCtrl,
+    depth: usize,
+    equations: &mut Vec<&'a HxEquation>,
+) -> HwpxResult<()> {
     if let Some(footnote) = &ctrl.foot_note {
-        collect_equations_from_paragraphs(&footnote.sub_list.paragraphs, equations);
+        collect_equations_from_paragraphs(&footnote.sub_list.paragraphs, depth + 1, equations)?;
     }
     if let Some(endnote) = &ctrl.end_note {
-        collect_equations_from_paragraphs(&endnote.sub_list.paragraphs, equations);
+        collect_equations_from_paragraphs(&endnote.sub_list.paragraphs, depth + 1, equations)?;
     }
+    Ok(())
+}
+
+fn ensure_depth(depth: usize) -> HwpxResult<()> {
+    if depth >= crate::decoder::section::MAX_NESTING_DEPTH {
+        return Err(HwpxError::InvalidStructure {
+            detail: format!(
+                "visual-equation nesting depth {} exceeds limit of {}",
+                depth,
+                crate::decoder::section::MAX_NESTING_DEPTH
+            ),
+        });
+    }
+    Ok(())
 }
 
 fn nonempty(value: &str) -> Option<String> {
     (!value.is_empty()).then(|| value.to_string())
 }
 
-fn position_from(position: &HxTablePos) -> HwpxVisualEquationPosition {
+fn position_from_table(position: &HxTablePos) -> HwpxVisualEquationPosition {
     HwpxVisualEquationPosition {
         horz_offset: position.horz_offset,
         vert_offset: position.vert_offset,
     }
+}
+
+fn position_from_offset(position: &HxOffset) -> HwpxVisualEquationPosition {
+    HwpxVisualEquationPosition { horz_offset: position.x, vert_offset: position.y }
 }

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 
 use crate::error::{HwpxError, HwpxResult};
 use crate::schema::section::{
-    HxContainer, HxCtrl, HxEquation, HxOffset, HxParagraph, HxPic, HxRect, HxRun, HxRunChildOrder,
-    HxSizeAttr, HxSubList, HxTable, HxTablePos, HxTableSz,
+    HxContainer, HxContainerChildOrder, HxCtrl, HxEquation, HxOffset, HxParagraph, HxPic, HxRect,
+    HxRun, HxRunChildOrder, HxSizeAttr, HxSubList, HxTable, HxTablePos, HxTableSz,
 };
 
 pub(crate) const HWPX_VISUAL_EQUATION_SCHEMA_VERSION: u32 = 4;
@@ -356,6 +356,28 @@ fn collect_container(
 ) -> HwpxResult<()> {
     ensure_depth(depth)?;
     let container_position = container.pos.as_ref().map(position_from_table).or(inherited_position);
+    if !container.child_order.is_empty() {
+        for child in &container.child_order {
+            match *child {
+                HxContainerChildOrder::Rect(rect_index) => collect_group_rect(
+                    &container.rects[rect_index],
+                    &format!("{path}/rect[{rect_index}]"),
+                    depth,
+                    container_position,
+                    equations,
+                )?,
+                HxContainerChildOrder::Container(container_index) => collect_container(
+                    &container.containers[container_index],
+                    &format!("{path}/container[{container_index}]"),
+                    depth + 1,
+                    container_position,
+                    equations,
+                )?,
+                _ => {}
+            }
+        }
+        return Ok(());
+    }
     for (rect_index, rect) in container.rects.iter().enumerate() {
         collect_group_rect(
             rect,

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -303,6 +303,26 @@ fn walk_ctrl(
     depth: usize,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
+    if let Some(header) = &ctrl.header {
+        if let Some(sub_list) = &header.sub_list {
+            walk_visual_paragraphs(
+                &sub_list.paragraphs,
+                &format!("{path}/header"),
+                depth + 1,
+                equations,
+            )?;
+        }
+    }
+    if let Some(footer) = &ctrl.footer {
+        if let Some(sub_list) = &footer.sub_list {
+            walk_visual_paragraphs(
+                &sub_list.paragraphs,
+                &format!("{path}/footer"),
+                depth + 1,
+                equations,
+            )?;
+        }
+    }
     if let Some(footnote) = &ctrl.foot_note {
         walk_visual_paragraphs(
             &footnote.sub_list.paragraphs,
@@ -533,6 +553,16 @@ fn collect_equations_from_ctrl<'a>(
     depth: usize,
     equations: &mut Vec<&'a HxEquation>,
 ) -> HwpxResult<()> {
+    if let Some(header) = &ctrl.header {
+        if let Some(sub_list) = &header.sub_list {
+            collect_equations_from_paragraphs(&sub_list.paragraphs, depth + 1, equations)?;
+        }
+    }
+    if let Some(footer) = &ctrl.footer {
+        if let Some(sub_list) = &footer.sub_list {
+            collect_equations_from_paragraphs(&sub_list.paragraphs, depth + 1, equations)?;
+        }
+    }
     if let Some(footnote) = &ctrl.foot_note {
         collect_equations_from_paragraphs(&footnote.sub_list.paragraphs, depth + 1, equations)?;
     }

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -409,7 +409,22 @@ fn walk_ctrl(
             equations,
         )?;
     }
+    if let Some(sub_list) = memo_sub_list(ctrl) {
+        walk_visual_paragraphs(
+            &sub_list.paragraphs,
+            &format!("{path}/fieldBegin"),
+            depth + 1,
+            equations,
+        )?;
+    }
     Ok(())
+}
+
+fn memo_sub_list(ctrl: &HxCtrl) -> Option<&HxSubList> {
+    ctrl.field_begin
+        .as_ref()
+        .filter(|field| field.field_type.eq_ignore_ascii_case("MEMO"))
+        .and_then(|field| field.sub_list.as_ref())
 }
 
 fn collect_picture(
@@ -824,7 +839,7 @@ fn collect_owned_visual_paragraphs(
                     collect_picture(
                         picture,
                         &format!("{run_path}/picture[{index}]"),
-                        depth,
+                        depth + 1,
                         Some(parent),
                         equations,
                     )?;
@@ -833,7 +848,7 @@ fn collect_owned_visual_paragraphs(
                     collect_container(
                         container,
                         &format!("{run_path}/container[{index}]"),
-                        depth,
+                        depth + 1,
                         None,
                         Some(parent),
                         equations,
@@ -909,14 +924,14 @@ fn collect_owned_visual_paragraphs(
                         HxRunChildOrder::Picture(index) => collect_picture(
                             &run.pictures[index],
                             &format!("{run_path}/picture[{index}]"),
-                            depth,
+                            depth + 1,
                             Some(parent),
                             equations,
                         )?,
                         HxRunChildOrder::Container(index) => collect_container(
                             &run.containers[index],
                             &format!("{run_path}/container[{index}]"),
-                            depth,
+                            depth + 1,
                             None,
                             Some(parent),
                             equations,
@@ -1084,6 +1099,17 @@ fn collect_owned_visual_ctrl(
             parent,
             parent_path,
             &format!("{path}/endnote"),
+            depth + 1,
+            parent_order,
+            equations,
+        )?;
+    }
+    if let Some(sub_list) = memo_sub_list(ctrl) {
+        collect_owned_visual_paragraphs(
+            &sub_list.paragraphs,
+            parent,
+            parent_path,
+            &format!("{path}/fieldBegin"),
             depth + 1,
             parent_order,
             equations,

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -8,7 +8,7 @@ use crate::schema::section::{
     HxSizeAttr, HxSubList, HxTable, HxTablePos, HxTableSz,
 };
 
-pub(crate) const HWPX_VISUAL_EQUATION_SCHEMA_VERSION: u32 = 2;
+pub(crate) const HWPX_VISUAL_EQUATION_SCHEMA_VERSION: u32 = 3;
 
 /// Versioned report of equations that styled Markdown intentionally leaves
 /// inside picture captions and grouped drawing text.
@@ -49,8 +49,12 @@ pub struct HwpxVisualEquation {
     pub parent_order: usize,
     /// Equation z-order, falling back to the nearest visual parent when absent.
     pub z_order: u32,
-    /// Equation position, falling back to the nearest visual parent when absent.
-    pub position: HwpxVisualEquationPosition,
+    /// Raw equation position before the visual parent's rendering translation.
+    pub raw_position: HwpxVisualEquationPosition,
+    /// Exact translation selected from the visual parent's final `scaMatrix`.
+    pub translation: HwpxVisualEquationTranslation,
+    /// Display-space position after applying the rendering translation.
+    pub display_position: Option<HwpxVisualEquationPosition>,
     /// Raw and display-space geometry for faithful visual composition.
     pub geometry: HwpxVisualEquationGeometry,
     /// Original HancomEQN source.
@@ -87,6 +91,15 @@ pub struct HwpxVisualEquationPosition {
     pub horz_offset: i32,
     /// Vertical offset in HWP units.
     pub vert_offset: i32,
+}
+
+/// Exact horizontal and vertical translation strings preserved from HWPX.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HwpxVisualEquationTranslation {
+    /// Horizontal translation (`scaMatrix.e3`).
+    pub horz: String,
+    /// Vertical translation (`scaMatrix.e6`).
+    pub vert: String,
 }
 
 /// Raw wire geometry and scale-applied display geometry for a visual equation.
@@ -132,6 +145,18 @@ struct VisualScale<'a> {
     vert: &'a str,
 }
 
+#[derive(Clone, Copy)]
+struct VisualTranslation<'a> {
+    horz: &'a str,
+    vert: &'a str,
+}
+
+impl Default for VisualTranslation<'_> {
+    fn default() -> Self {
+        Self { horz: "0", vert: "0" }
+    }
+}
+
 impl Default for VisualScale<'_> {
     fn default() -> Self {
         Self { horz: "1", vert: "1" }
@@ -148,6 +173,7 @@ struct VisualParent<'a> {
     position: Option<HwpxVisualEquationPosition>,
     raw_box_size: Option<HwpxVisualEquationSize>,
     scale: VisualScale<'a>,
+    translation: VisualTranslation<'a>,
 }
 
 pub(crate) fn collect_section(
@@ -316,6 +342,7 @@ fn collect_picture(
             .or_else(|| pic.offset.as_ref().map(position_from_offset)),
         raw_box_size: None,
         scale: VisualScale::default(),
+        translation: VisualTranslation::default(),
     };
     collect_parent_equations(&caption.sub_list, parent, path, depth, equations)
 }
@@ -379,6 +406,14 @@ fn collect_group_rect(
                 vert: rendering.sca_matrix.e5.as_str(),
             })
             .unwrap_or_default(),
+        translation: rect
+            .rendering_info
+            .as_ref()
+            .map(|rendering| VisualTranslation {
+                horz: rendering.sca_matrix.e3.as_str(),
+                vert: rendering.sca_matrix.e6.as_str(),
+            })
+            .unwrap_or_default(),
     };
     collect_parent_equations(&draw_text.sub_list, parent, path, depth, equations)
 }
@@ -397,7 +432,12 @@ fn collect_parent_equations(
         let id = equation_object_id
             .clone()
             .unwrap_or_else(|| format!("{parent_path}/equation[{parent_order}]"));
-        let position = equation_position(equation, parent)?;
+        let raw_position = equation_position(equation, parent)?;
+        let translation = HwpxVisualEquationTranslation {
+            horz: parent.translation.horz.to_string(),
+            vert: parent.translation.vert.to_string(),
+        };
+        let display_position = translate_position(raw_position, parent.translation);
         let geometry = equation_geometry(equation, parent);
         let z_order = equation.z_order.unwrap_or(parent.z_order);
         equations.push(HwpxVisualEquation {
@@ -411,7 +451,9 @@ fn collect_parent_equations(
             document_order: 0,
             parent_order,
             z_order,
-            position,
+            raw_position,
+            translation,
+            display_position,
             geometry,
             script: equation.script.as_ref().map(|script| script.text.clone()).unwrap_or_default(),
             latex: None,
@@ -577,6 +619,28 @@ fn scale_base_unit(raw: u32, scale: &str) -> Option<u32> {
         return None;
     }
     Some(display.max(1.0) as u32)
+}
+
+fn translate_position(
+    raw: HwpxVisualEquationPosition,
+    translation: VisualTranslation<'_>,
+) -> Option<HwpxVisualEquationPosition> {
+    Some(HwpxVisualEquationPosition {
+        horz_offset: translate_coordinate(raw.horz_offset, translation.horz)?,
+        vert_offset: translate_coordinate(raw.vert_offset, translation.vert)?,
+    })
+}
+
+fn translate_coordinate(raw: i32, translation: &str) -> Option<i32> {
+    let translation = translation.parse::<f64>().ok()?;
+    if !translation.is_finite() {
+        return None;
+    }
+    let display = (f64::from(raw) + translation).round();
+    if !display.is_finite() || display < f64::from(i32::MIN) || display > f64::from(i32::MAX) {
+        return None;
+    }
+    Some(display as i32)
 }
 
 fn equation_position(

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -331,8 +331,7 @@ fn collect_parent_equations(
         let id = equation_object_id
             .clone()
             .unwrap_or_else(|| format!("{parent_path}/equation[{parent_order}]"));
-        let position =
-            equation.pos.as_ref().map(position_from_table).or(parent.position).unwrap_or_default();
+        let position = equation_position(equation, parent)?;
         let z_order = equation.z_order.unwrap_or(parent.z_order);
         equations.push(HwpxVisualEquation {
             id,
@@ -437,4 +436,36 @@ fn position_from_table(position: &HxTablePos) -> HwpxVisualEquationPosition {
 
 fn position_from_offset(position: &HxOffset) -> HwpxVisualEquationPosition {
     HwpxVisualEquationPosition { horz_offset: position.x, vert_offset: position.y }
+}
+
+fn equation_position(
+    equation: &HxEquation,
+    parent: VisualParent<'_>,
+) -> HwpxResult<HwpxVisualEquationPosition> {
+    let child_position = equation.pos.as_ref().map(position_from_table);
+    match parent.domain {
+        HwpxVisualEquationDomain::PictureCaption => {
+            Ok(child_position.or(parent.position).unwrap_or_default())
+        }
+        HwpxVisualEquationDomain::GroupDrawText => {
+            add_positions(parent.position.unwrap_or_default(), child_position.unwrap_or_default())
+        }
+    }
+}
+
+fn add_positions(
+    parent: HwpxVisualEquationPosition,
+    child: HwpxVisualEquationPosition,
+) -> HwpxResult<HwpxVisualEquationPosition> {
+    let horz_offset = parent.horz_offset.checked_add(child.horz_offset).ok_or_else(|| {
+        HwpxError::InvalidStructure {
+            detail: "visual-equation horizontal position exceeds i32 range".to_string(),
+        }
+    })?;
+    let vert_offset = parent.vert_offset.checked_add(child.vert_offset).ok_or_else(|| {
+        HwpxError::InvalidStructure {
+            detail: "visual-equation vertical position exceeds i32 range".to_string(),
+        }
+    })?;
+    Ok(HwpxVisualEquationPosition { horz_offset, vert_offset })
 }

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -428,8 +428,22 @@ fn collect_picture(
             .map(position_from_table)
             .or_else(|| pic.offset.as_ref().map(position_from_offset)),
         raw_box_size: None,
-        scale: VisualScale::default(),
-        translation: VisualTranslation::default(),
+        scale: pic
+            .rendering_info
+            .as_ref()
+            .map(|rendering| VisualScale {
+                horz: rendering.sca_matrix.e1.as_str(),
+                vert: rendering.sca_matrix.e5.as_str(),
+            })
+            .unwrap_or_default(),
+        translation: pic
+            .rendering_info
+            .as_ref()
+            .map(|rendering| VisualTranslation {
+                horz: rendering.sca_matrix.e3.as_str(),
+                vert: rendering.sca_matrix.e6.as_str(),
+            })
+            .unwrap_or_default(),
         compose_child_position: false,
     };
     collect_parent_equations(&caption.sub_list, parent, path, depth, equations)

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -1,0 +1,319 @@
+//! Structural reporting for equations embedded in visual HWPX objects.
+
+use serde::Serialize;
+
+use crate::schema::section::{
+    HxContainer, HxCtrl, HxEquation, HxParagraph, HxPic, HxRect, HxRun, HxRunChildOrder, HxSubList,
+    HxTable, HxTablePos,
+};
+
+/// Versioned report of equations that styled Markdown intentionally leaves
+/// inside picture captions and grouped drawing text.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HwpxVisualEquationReport {
+    /// Sidecar schema version.
+    pub schema_version: u32,
+    /// Visual equations in stable document order.
+    pub equations: Vec<HwpxVisualEquation>,
+}
+
+impl Default for HwpxVisualEquationReport {
+    fn default() -> Self {
+        Self { schema_version: 1, equations: Vec::new() }
+    }
+}
+
+/// One equation occurrence embedded in a visual HWPX parent.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HwpxVisualEquation {
+    /// Equation wire ID, or a deterministic path-derived fallback.
+    pub id: String,
+    /// Visual domain that owns the equation.
+    pub domain: HwpxVisualEquationDomain,
+    /// Equation object's wire `@id`, when present.
+    pub equation_object_id: Option<String>,
+    /// Nearest picture or grouped-rectangle wire `@id`, when present.
+    pub parent_object_id: Option<String>,
+    /// Nearest picture or grouped-rectangle wire `@instid`, when present.
+    pub parent_instance_id: Option<String>,
+    /// Visual parent category.
+    pub parent_kind: HwpxVisualEquationParentKind,
+    /// Stable section/paragraph/run/type-index path to the visual parent.
+    pub parent_path: String,
+    /// Zero-based order across every visual equation in the document.
+    pub document_order: usize,
+    /// Zero-based equation occurrence order inside the visual parent.
+    pub parent_order: usize,
+    /// Equation z-order, falling back to the nearest visual parent when absent.
+    pub z_order: u32,
+    /// Equation position, falling back to the nearest visual parent when absent.
+    pub position: HwpxVisualEquationPosition,
+    /// Original HancomEQN source.
+    pub script: String,
+    /// Converted LaTeX, populated by a format consumer such as the CLI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latex: Option<String>,
+}
+
+/// Supported visual-equation domains.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HwpxVisualEquationDomain {
+    /// Equation found under `pic/caption` paragraph content.
+    PictureCaption,
+    /// Equation found under `container/rect/drawText` paragraph content.
+    GroupDrawText,
+}
+
+/// Supported visual parent categories.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HwpxVisualEquationParentKind {
+    /// Picture object.
+    Picture,
+    /// Group container, represented by its nearest text-bearing rectangle.
+    Container,
+}
+
+/// HWPX position offsets for a visual equation.
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+pub struct HwpxVisualEquationPosition {
+    /// Horizontal offset in HWP units.
+    pub horz_offset: i32,
+    /// Vertical offset in HWP units.
+    pub vert_offset: i32,
+}
+
+#[derive(Clone, Copy)]
+struct VisualParent<'a> {
+    domain: HwpxVisualEquationDomain,
+    kind: HwpxVisualEquationParentKind,
+    object_id: &'a str,
+    instance_id: &'a str,
+    z_order: u32,
+    position: Option<&'a HxTablePos>,
+}
+
+pub(crate) fn collect_section(
+    paragraphs: &[HxParagraph],
+    section_index: usize,
+) -> Vec<HwpxVisualEquation> {
+    let mut equations = Vec::new();
+    let root = format!("section[{section_index}]");
+    walk_visual_paragraphs(paragraphs, &root, &mut equations);
+    equations
+}
+
+fn walk_visual_paragraphs(
+    paragraphs: &[HxParagraph],
+    prefix: &str,
+    equations: &mut Vec<HwpxVisualEquation>,
+) {
+    for (paragraph_index, paragraph) in paragraphs.iter().enumerate() {
+        let paragraph_path = format!("{prefix}/paragraph[{paragraph_index}]");
+        for (run_index, run) in paragraph.runs.iter().enumerate() {
+            let run_path = format!("{paragraph_path}/run[{run_index}]");
+            walk_visual_run(run, &run_path, equations);
+        }
+    }
+}
+
+fn walk_visual_run(run: &HxRun, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+    if run.child_order.is_empty() {
+        walk_run_by_type(run, path, equations);
+        return;
+    }
+
+    for child in &run.child_order {
+        match *child {
+            HxRunChildOrder::Table(index) => {
+                walk_table(&run.tables[index], &format!("{path}/table[{index}]"), equations);
+            }
+            HxRunChildOrder::Picture(index) => {
+                collect_picture(
+                    &run.pictures[index],
+                    &format!("{path}/picture[{index}]"),
+                    equations,
+                );
+            }
+            HxRunChildOrder::Ctrl(index) => {
+                walk_ctrl(&run.ctrls[index], &format!("{path}/ctrl[{index}]"), equations);
+            }
+            HxRunChildOrder::Container(index) => {
+                collect_container(
+                    &run.containers[index],
+                    &format!("{path}/container[{index}]"),
+                    equations,
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+fn walk_run_by_type(run: &HxRun, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+    for (index, table) in run.tables.iter().enumerate() {
+        walk_table(table, &format!("{path}/table[{index}]"), equations);
+    }
+    for (index, picture) in run.pictures.iter().enumerate() {
+        collect_picture(picture, &format!("{path}/picture[{index}]"), equations);
+    }
+    for (index, ctrl) in run.ctrls.iter().enumerate() {
+        walk_ctrl(ctrl, &format!("{path}/ctrl[{index}]"), equations);
+    }
+    for (index, container) in run.containers.iter().enumerate() {
+        collect_container(container, &format!("{path}/container[{index}]"), equations);
+    }
+}
+
+fn walk_table(table: &HxTable, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+    for (row_index, row) in table.rows.iter().enumerate() {
+        for (cell_index, cell) in row.cells.iter().enumerate() {
+            if let Some(sub_list) = &cell.sub_list {
+                walk_visual_paragraphs(
+                    &sub_list.paragraphs,
+                    &format!("{path}/row[{row_index}]/cell[{cell_index}]"),
+                    equations,
+                );
+            }
+        }
+    }
+}
+
+fn walk_ctrl(ctrl: &HxCtrl, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+    if let Some(footnote) = &ctrl.foot_note {
+        walk_visual_paragraphs(
+            &footnote.sub_list.paragraphs,
+            &format!("{path}/footnote"),
+            equations,
+        );
+    }
+    if let Some(endnote) = &ctrl.end_note {
+        walk_visual_paragraphs(&endnote.sub_list.paragraphs, &format!("{path}/endnote"), equations);
+    }
+}
+
+fn collect_picture(pic: &HxPic, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+    let Some(caption) = &pic.caption else { return };
+    let parent = VisualParent {
+        domain: HwpxVisualEquationDomain::PictureCaption,
+        kind: HwpxVisualEquationParentKind::Picture,
+        object_id: &pic.id,
+        instance_id: &pic.instid,
+        z_order: pic.z_order,
+        position: pic.pos.as_ref(),
+    };
+    collect_parent_equations(&caption.sub_list, parent, path, equations);
+}
+
+fn collect_container(container: &HxContainer, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+    for (rect_index, rect) in container.rects.iter().enumerate() {
+        collect_group_rect(rect, &format!("{path}/rect[{rect_index}]"), equations);
+    }
+    for (container_index, nested) in container.containers.iter().enumerate() {
+        collect_container(nested, &format!("{path}/container[{container_index}]"), equations);
+    }
+}
+
+fn collect_group_rect(rect: &HxRect, path: &str, equations: &mut Vec<HwpxVisualEquation>) {
+    let Some(draw_text) = &rect.draw_text else { return };
+    let parent = VisualParent {
+        domain: HwpxVisualEquationDomain::GroupDrawText,
+        kind: HwpxVisualEquationParentKind::Container,
+        object_id: &rect.id,
+        instance_id: &rect.instid,
+        z_order: rect.z_order,
+        position: rect.pos.as_ref(),
+    };
+    collect_parent_equations(&draw_text.sub_list, parent, path, equations);
+}
+
+fn collect_parent_equations(
+    sub_list: &HxSubList,
+    parent: VisualParent<'_>,
+    parent_path: &str,
+    equations: &mut Vec<HwpxVisualEquation>,
+) {
+    let mut occurrences = Vec::new();
+    collect_equations_from_paragraphs(&sub_list.paragraphs, &mut occurrences);
+    for (parent_order, equation) in occurrences.into_iter().enumerate() {
+        let equation_object_id = nonempty(&equation.id);
+        let id = equation_object_id
+            .clone()
+            .unwrap_or_else(|| format!("{parent_path}/equation[{parent_order}]"));
+        let position =
+            equation.pos.as_ref().or(parent.position).map(position_from).unwrap_or_default();
+        let z_order = if equation.z_order == 0 { parent.z_order } else { equation.z_order };
+        equations.push(HwpxVisualEquation {
+            id,
+            domain: parent.domain,
+            equation_object_id,
+            parent_object_id: nonempty(parent.object_id),
+            parent_instance_id: nonempty(parent.instance_id),
+            parent_kind: parent.kind,
+            parent_path: parent_path.to_string(),
+            document_order: 0,
+            parent_order,
+            z_order,
+            position,
+            script: equation.script.as_ref().map(|script| script.text.clone()).unwrap_or_default(),
+            latex: None,
+        });
+    }
+}
+
+fn collect_equations_from_paragraphs<'a>(
+    paragraphs: &'a [HxParagraph],
+    equations: &mut Vec<&'a HxEquation>,
+) {
+    for paragraph in paragraphs {
+        for run in &paragraph.runs {
+            if run.child_order.is_empty() {
+                equations.extend(&run.equations);
+            } else {
+                for child in &run.child_order {
+                    match *child {
+                        HxRunChildOrder::Equation(index) => equations.push(&run.equations[index]),
+                        HxRunChildOrder::Table(index) => {
+                            collect_equations_from_table(&run.tables[index], equations);
+                        }
+                        HxRunChildOrder::Ctrl(index) => {
+                            collect_equations_from_ctrl(&run.ctrls[index], equations);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_equations_from_table<'a>(table: &'a HxTable, equations: &mut Vec<&'a HxEquation>) {
+    for row in &table.rows {
+        for cell in &row.cells {
+            if let Some(sub_list) = &cell.sub_list {
+                collect_equations_from_paragraphs(&sub_list.paragraphs, equations);
+            }
+        }
+    }
+}
+
+fn collect_equations_from_ctrl<'a>(ctrl: &'a HxCtrl, equations: &mut Vec<&'a HxEquation>) {
+    if let Some(footnote) = &ctrl.foot_note {
+        collect_equations_from_paragraphs(&footnote.sub_list.paragraphs, equations);
+    }
+    if let Some(endnote) = &ctrl.end_note {
+        collect_equations_from_paragraphs(&endnote.sub_list.paragraphs, equations);
+    }
+}
+
+fn nonempty(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn position_from(position: &HxTablePos) -> HwpxVisualEquationPosition {
+    HwpxVisualEquationPosition {
+        horz_offset: position.horz_offset,
+        vert_offset: position.vert_offset,
+    }
+}

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -375,7 +375,10 @@ fn collect_container(
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     ensure_depth(depth)?;
-    let container_position = container.pos.as_ref().map(position_from_table).or(inherited_position);
+    let container_position = add_optional_positions(
+        inherited_position,
+        container.pos.as_ref().map(position_from_table),
+    )?;
     if !container.child_order.is_empty() {
         for child in &container.child_order {
             match *child {
@@ -427,18 +430,18 @@ fn collect_group_rect(
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
     let Some(draw_text) = &rect.draw_text else { return Ok(()) };
+    let rect_position = rect
+        .offset
+        .as_ref()
+        .map(position_from_offset)
+        .or_else(|| rect.pos.as_ref().map(position_from_table));
     let parent = VisualParent {
         domain: HwpxVisualEquationDomain::GroupDrawText,
         kind: HwpxVisualEquationParentKind::Container,
         object_id: &rect.id,
         instance_id: &rect.instid,
         z_order: rect.z_order,
-        position: rect
-            .offset
-            .as_ref()
-            .map(position_from_offset)
-            .or_else(|| rect.pos.as_ref().map(position_from_table))
-            .or(container_position),
+        position: add_optional_positions(container_position, rect_position)?,
         raw_box_size: rect.org_sz.as_ref().map(size_from_original),
         scale: rect
             .rendering_info
@@ -715,4 +718,15 @@ fn add_positions(
         }
     })?;
     Ok(HwpxVisualEquationPosition { horz_offset, vert_offset })
+}
+
+fn add_optional_positions(
+    parent: Option<HwpxVisualEquationPosition>,
+    child: Option<HwpxVisualEquationPosition>,
+) -> HwpxResult<Option<HwpxVisualEquationPosition>> {
+    match (parent, child) {
+        (Some(parent), Some(child)) => add_positions(parent, child).map(Some),
+        (Some(position), None) | (None, Some(position)) => Ok(Some(position)),
+        (None, None) => Ok(None),
+    }
 }

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -471,18 +471,12 @@ fn collect_picture(
     let Some(ancestor) = ancestor else {
         return collect_parent_equations(&caption.sub_list, parent_base, path, depth, equations);
     };
-    let scale_horz = compose_scale(ancestor.scale.horz, child_scale.horz)?;
-    let scale_vert = compose_scale(ancestor.scale.vert, child_scale.vert)?;
-    let translation_horz = compose_translation(
-        ancestor.translation.horz,
-        ancestor.scale.horz,
-        child_translation.horz,
-    )?;
-    let translation_vert = compose_translation(
-        ancestor.translation.vert,
-        ancestor.scale.vert,
-        child_translation.vert,
-    )?;
+    let scale_horz = compose_scale(ancestor.scale.horz, child_scale.horz);
+    let scale_vert = compose_scale(ancestor.scale.vert, child_scale.vert);
+    let translation_horz =
+        compose_translation(ancestor.translation.horz, ancestor.scale.horz, child_translation.horz);
+    let translation_vert =
+        compose_translation(ancestor.translation.vert, ancestor.scale.vert, child_translation.vert);
     let parent = VisualParent {
         position: add_optional_positions(ancestor.position, child_position)?,
         scale: VisualScale { horz: &scale_horz, vert: &scale_vert },
@@ -710,18 +704,12 @@ fn collect_group_shape(
     let Some(ancestor) = ancestor else {
         return collect_parent_equations(&draw_text.sub_list, parent_base, path, depth, equations);
     };
-    let scale_horz = compose_scale(ancestor.scale.horz, child_scale.horz)?;
-    let scale_vert = compose_scale(ancestor.scale.vert, child_scale.vert)?;
-    let translation_horz = compose_translation(
-        ancestor.translation.horz,
-        ancestor.scale.horz,
-        child_translation.horz,
-    )?;
-    let translation_vert = compose_translation(
-        ancestor.translation.vert,
-        ancestor.scale.vert,
-        child_translation.vert,
-    )?;
+    let scale_horz = compose_scale(ancestor.scale.horz, child_scale.horz);
+    let scale_vert = compose_scale(ancestor.scale.vert, child_scale.vert);
+    let translation_horz =
+        compose_translation(ancestor.translation.horz, ancestor.scale.horz, child_translation.horz);
+    let translation_vert =
+        compose_translation(ancestor.translation.vert, ancestor.scale.vert, child_translation.vert);
     let parent = VisualParent {
         scale: VisualScale { horz: &scale_horz, vert: &scale_vert },
         translation: VisualTranslation { horz: &translation_horz, vert: &translation_vert },
@@ -974,18 +962,12 @@ fn collect_owned_shape_text(
                 vert: rendering.sca_matrix.e6.as_str(),
             })
             .unwrap_or_default();
-        let scale_horz = compose_scale(parent.scale.horz, child_scale.horz)?;
-        let scale_vert = compose_scale(parent.scale.vert, child_scale.vert)?;
-        let translation_horz = compose_translation(
-            parent.translation.horz,
-            parent.scale.horz,
-            child_translation.horz,
-        )?;
-        let translation_vert = compose_translation(
-            parent.translation.vert,
-            parent.scale.vert,
-            child_translation.vert,
-        )?;
+        let scale_horz = compose_scale(parent.scale.horz, child_scale.horz);
+        let scale_vert = compose_scale(parent.scale.vert, child_scale.vert);
+        let translation_horz =
+            compose_translation(parent.translation.horz, parent.scale.horz, child_translation.horz);
+        let translation_vert =
+            compose_translation(parent.translation.vert, parent.scale.vert, child_translation.vert);
         let nested_parent = VisualParent {
             position: add_optional_positions(parent.position, child_position)?,
             raw_box_size: original_size.map(size_from_original).or(parent.raw_box_size),
@@ -1294,29 +1276,45 @@ fn equation_position(
     }
 }
 
-fn compose_scale(parent: &str, child: &str) -> HwpxResult<String> {
-    let parent = parse_transform(parent)?;
-    let child = parse_transform(child)?;
-    Ok(format_transform(parent * child))
+fn compose_scale(parent: &str, child: &str) -> String {
+    let Some(parent_value) = finite_transform(parent) else {
+        return parent.to_string();
+    };
+    let Some(child_value) = finite_transform(child) else {
+        return child.to_string();
+    };
+    format_composed_transform(parent_value * child_value)
 }
 
 fn compose_translation(
     parent_translation: &str,
     parent_scale: &str,
     child_translation: &str,
-) -> HwpxResult<String> {
-    let parent_translation = parse_transform(parent_translation)?;
-    let parent_scale = parse_transform(parent_scale)?;
-    let child_translation = parse_transform(child_translation)?;
-    Ok(format_transform(parent_translation + parent_scale * child_translation))
+) -> String {
+    let Some(parent_translation_value) = finite_transform(parent_translation) else {
+        return parent_translation.to_string();
+    };
+    let Some(parent_scale_value) = finite_transform(parent_scale) else {
+        return parent_scale.to_string();
+    };
+    let Some(child_translation_value) = finite_transform(child_translation) else {
+        return child_translation.to_string();
+    };
+    format_composed_transform(
+        parent_translation_value + parent_scale_value * child_translation_value,
+    )
 }
 
-fn parse_transform(value: &str) -> HwpxResult<f64> {
-    value.parse::<f64>().ok().filter(|value| value.is_finite()).ok_or_else(|| {
-        HwpxError::InvalidStructure {
-            detail: format!("visual-equation transform is not finite: {value}"),
-        }
-    })
+fn finite_transform(value: &str) -> Option<f64> {
+    value.parse::<f64>().ok().filter(|value| value.is_finite())
+}
+
+fn format_composed_transform(value: f64) -> String {
+    if value.is_finite() {
+        format_transform(value)
+    } else {
+        "unprojectable".to_string()
+    }
 }
 
 fn format_transform(value: f64) -> String {

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -243,6 +243,24 @@ fn walk_visual_run(
                     equations,
                 )?;
             }
+            HxRunChildOrder::Rect(index) => walk_shape_text_visuals(
+                run.rects[index].draw_text.as_ref(),
+                &format!("{path}/rect[{index}]"),
+                depth,
+                equations,
+            )?,
+            HxRunChildOrder::Ellipse(index) => walk_shape_text_visuals(
+                run.ellipses[index].draw_text.as_ref(),
+                &format!("{path}/ellipse[{index}]"),
+                depth,
+                equations,
+            )?,
+            HxRunChildOrder::Polygon(index) => walk_shape_text_visuals(
+                run.polygons[index].draw_text.as_ref(),
+                &format!("{path}/polygon[{index}]"),
+                depth,
+                equations,
+            )?,
             _ => {}
         }
     }
@@ -273,7 +291,46 @@ fn walk_run_by_type(
             equations,
         )?;
     }
+    for (index, rect) in run.rects.iter().enumerate() {
+        walk_shape_text_visuals(
+            rect.draw_text.as_ref(),
+            &format!("{path}/rect[{index}]"),
+            depth,
+            equations,
+        )?;
+    }
+    for (index, ellipse) in run.ellipses.iter().enumerate() {
+        walk_shape_text_visuals(
+            ellipse.draw_text.as_ref(),
+            &format!("{path}/ellipse[{index}]"),
+            depth,
+            equations,
+        )?;
+    }
+    for (index, polygon) in run.polygons.iter().enumerate() {
+        walk_shape_text_visuals(
+            polygon.draw_text.as_ref(),
+            &format!("{path}/polygon[{index}]"),
+            depth,
+            equations,
+        )?;
+    }
     Ok(())
+}
+
+fn walk_shape_text_visuals(
+    draw_text: Option<&HxDrawText>,
+    path: &str,
+    depth: usize,
+    equations: &mut Vec<HwpxVisualEquation>,
+) -> HwpxResult<()> {
+    let Some(draw_text) = draw_text else { return Ok(()) };
+    walk_visual_paragraphs(
+        &draw_text.sub_list.paragraphs,
+        &format!("{path}/drawText"),
+        depth + 1,
+        equations,
+    )
 }
 
 fn walk_table(

--- a/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs
@@ -341,6 +341,14 @@ fn walk_table(
     depth: usize,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
+    if let Some(caption) = &table.caption {
+        walk_visual_paragraphs(
+            &caption.sub_list.paragraphs,
+            &format!("{path}/caption"),
+            depth + 1,
+            equations,
+        )?;
+    }
     for (row_index, row) in table.rows.iter().enumerate() {
         for (cell_index, cell) in row.cells.iter().enumerate() {
             if let Some(sub_list) = &cell.sub_list {
@@ -909,6 +917,17 @@ fn collect_owned_visual_table(
     parent_order: &mut usize,
     equations: &mut Vec<HwpxVisualEquation>,
 ) -> HwpxResult<()> {
+    if let Some(caption) = &table.caption {
+        collect_owned_visual_paragraphs(
+            &caption.sub_list.paragraphs,
+            parent,
+            parent_path,
+            &format!("{path}/caption"),
+            depth + 1,
+            parent_order,
+            equations,
+        )?;
+    }
     for (row_index, row) in table.rows.iter().enumerate() {
         for (cell_index, cell) in row.cells.iter().enumerate() {
             if let Some(sub_list) = &cell.sub_list {

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -932,6 +932,7 @@ fn build_runs(
             composes,
             containers: Vec::new(),
             textarts: Vec::new(),
+            child_order: Vec::new(),
         });
     }
 
@@ -961,6 +962,7 @@ fn build_runs(
                     connect_lines: Vec::new(),
                     containers: Vec::new(),
                     textarts: Vec::new(),
+                    child_order: Vec::new(),
                 },
             );
         }

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/equation.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/equation.rs
@@ -24,7 +24,7 @@ pub(super) fn encode_equation_to_hx(ctrl: &Control) -> HwpxResult<HxEquation> {
         // Wave 12p Step 4: cross-ref target id 가 있으면 사용,
         // 없으면 fresh fallback (한컴 native 와는 id 차이만 발생).
         id: inst_id.map(|n| n.to_string()).unwrap_or_else(generate_instid),
-        z_order: 0,
+        z_order: Some(0),
         numbering_type: "EQUATION".to_string(),
         text_wrap: "TOP_AND_BOTTOM".to_string(),
         text_flow: "BOTH_SIDES".to_string(),

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -83,6 +83,7 @@ pub use decoder::{
     HwpxDecoder, HwpxDocument, HwpxVisualEquation, HwpxVisualEquationDomain,
     HwpxVisualEquationGeometry, HwpxVisualEquationParentKind, HwpxVisualEquationPosition,
     HwpxVisualEquationReport, HwpxVisualEquationScale, HwpxVisualEquationSize,
+    HwpxVisualEquationTranslation,
 };
 pub use default_styles::{DefaultStyleEntry, HancomStyleSet};
 pub use diff::{

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -81,7 +81,8 @@ pub use cell_edit::{
 pub use decoder::package::{PackageEntryInfo, PackageReader};
 pub use decoder::{
     HwpxDecoder, HwpxDocument, HwpxVisualEquation, HwpxVisualEquationDomain,
-    HwpxVisualEquationParentKind, HwpxVisualEquationPosition, HwpxVisualEquationReport,
+    HwpxVisualEquationGeometry, HwpxVisualEquationParentKind, HwpxVisualEquationPosition,
+    HwpxVisualEquationReport, HwpxVisualEquationScale, HwpxVisualEquationSize,
 };
 pub use default_styles::{DefaultStyleEntry, HancomStyleSet};
 pub use diff::{

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -79,7 +79,10 @@ pub use cell_edit::{
     HwpxCellEditor, SetCellOutcome, SetCellResult,
 };
 pub use decoder::package::{PackageEntryInfo, PackageReader};
-pub use decoder::{HwpxDecoder, HwpxDocument};
+pub use decoder::{
+    HwpxDecoder, HwpxDocument, HwpxVisualEquation, HwpxVisualEquationDomain,
+    HwpxVisualEquationParentKind, HwpxVisualEquationPosition, HwpxVisualEquationReport,
+};
 pub use default_styles::{DefaultStyleEntry, HancomStyleSet};
 pub use diff::{
     CellTextChange, DocumentDiff, FieldChange, FieldChangeKind, HwpxDiffer, PackageDiff,

--- a/crates/hwpforge-smithy-hwpx/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/schema/section.rs
@@ -10,7 +10,9 @@
 use hwpforge_core::inline::{InlineSegment, InlineTabAttr, InlineText};
 use hwpforge_core::run::RunContent;
 use hwpforge_foundation::HwpUnit;
+use serde::de::{MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use super::deser_i32_or_u32;
 
@@ -87,7 +89,7 @@ pub struct HxParagraph {
 ///
 /// Phase 3 extracts text, tables, images, and secPr; everything else
 /// is silently skipped by serde (no `deny_unknown_fields`).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct HxRun {
     #[serde(rename = "@charPrIDRef", default)]
     pub char_pr_id_ref: u32,
@@ -240,6 +242,224 @@ pub struct HxRun {
     /// `Control::TextArt`.
     #[serde(rename(deserialize = "textart"), default, skip_serializing)]
     pub textarts: Vec<HxTextArt>,
+
+    /// Direct child order captured during decode.
+    #[serde(skip)]
+    pub child_order: Vec<HxRunChildOrder>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HxRunChildOrder {
+    Text(usize),
+    Table(usize),
+    Picture(usize),
+    Ctrl(usize),
+    Rect(usize),
+    Line(usize),
+    Ellipse(usize),
+    Polygon(usize),
+    Curve(usize),
+    ConnectLine(usize),
+    Equation(usize),
+    Switch(usize),
+    Dutmal(usize),
+    Compose(usize),
+    Container(usize),
+    TextArt(usize),
+}
+
+impl<'de> Deserialize<'de> for HxRun {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        enum Field {
+            CharPrIdRef,
+            SecPr,
+            Text,
+            Table,
+            Picture,
+            Ctrl,
+            Rect,
+            Line,
+            Ellipse,
+            Polygon,
+            Curve,
+            ConnectLine,
+            Equation,
+            Switch,
+            TitleMark,
+            Dutmal,
+            Compose,
+            Container,
+            TextArt,
+            Ignore,
+        }
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl Visitor<'_> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        formatter.write_str("an HWPX run attribute or child")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Ok(match value {
+                            "@charPrIDRef" => Field::CharPrIdRef,
+                            "secPr" => Field::SecPr,
+                            "t" => Field::Text,
+                            "tbl" => Field::Table,
+                            "pic" => Field::Picture,
+                            "ctrl" => Field::Ctrl,
+                            "rect" => Field::Rect,
+                            "line" => Field::Line,
+                            "ellipse" => Field::Ellipse,
+                            "polygon" => Field::Polygon,
+                            "curve" => Field::Curve,
+                            "connectLine" => Field::ConnectLine,
+                            "equation" => Field::Equation,
+                            "switch" => Field::Switch,
+                            "titleMark" => Field::TitleMark,
+                            "dutmal" => Field::Dutmal,
+                            "compose" => Field::Compose,
+                            "container" => Field::Container,
+                            "textart" => Field::TextArt,
+                            _ => Field::Ignore,
+                        })
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct HxRunVisitor;
+
+        impl<'de> Visitor<'de> for HxRunVisitor {
+            type Value = HxRun;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an hp:run element")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut run = HxRun {
+                    char_pr_id_ref: 0,
+                    sec_pr: None,
+                    texts: Vec::new(),
+                    tables: Vec::new(),
+                    pictures: Vec::new(),
+                    ctrls: Vec::new(),
+                    rects: Vec::new(),
+                    lines: Vec::new(),
+                    ellipses: Vec::new(),
+                    polygons: Vec::new(),
+                    curves: Vec::new(),
+                    connect_lines: Vec::new(),
+                    equations: Vec::new(),
+                    switches: Vec::new(),
+                    title_mark: None,
+                    dutmals: Vec::new(),
+                    composes: Vec::new(),
+                    containers: Vec::new(),
+                    textarts: Vec::new(),
+                    child_order: Vec::new(),
+                };
+
+                while let Some(field) = map.next_key()? {
+                    match field {
+                        Field::CharPrIdRef => run.char_pr_id_ref = map.next_value()?,
+                        Field::SecPr => run.sec_pr = Some(map.next_value()?),
+                        Field::Text => {
+                            run.child_order.push(HxRunChildOrder::Text(run.texts.len()));
+                            run.texts.push(map.next_value()?);
+                        }
+                        Field::Table => {
+                            run.child_order.push(HxRunChildOrder::Table(run.tables.len()));
+                            run.tables.push(map.next_value()?);
+                        }
+                        Field::Picture => {
+                            run.child_order.push(HxRunChildOrder::Picture(run.pictures.len()));
+                            run.pictures.push(map.next_value()?);
+                        }
+                        Field::Ctrl => {
+                            run.child_order.push(HxRunChildOrder::Ctrl(run.ctrls.len()));
+                            run.ctrls.push(map.next_value()?);
+                        }
+                        Field::Rect => {
+                            run.child_order.push(HxRunChildOrder::Rect(run.rects.len()));
+                            run.rects.push(map.next_value()?);
+                        }
+                        Field::Line => {
+                            run.child_order.push(HxRunChildOrder::Line(run.lines.len()));
+                            run.lines.push(map.next_value()?);
+                        }
+                        Field::Ellipse => {
+                            run.child_order.push(HxRunChildOrder::Ellipse(run.ellipses.len()));
+                            run.ellipses.push(map.next_value()?);
+                        }
+                        Field::Polygon => {
+                            run.child_order.push(HxRunChildOrder::Polygon(run.polygons.len()));
+                            run.polygons.push(map.next_value()?);
+                        }
+                        Field::Curve => {
+                            run.child_order.push(HxRunChildOrder::Curve(run.curves.len()));
+                            run.curves.push(map.next_value()?);
+                        }
+                        Field::ConnectLine => {
+                            run.child_order
+                                .push(HxRunChildOrder::ConnectLine(run.connect_lines.len()));
+                            run.connect_lines.push(map.next_value()?);
+                        }
+                        Field::Equation => {
+                            run.child_order.push(HxRunChildOrder::Equation(run.equations.len()));
+                            run.equations.push(map.next_value()?);
+                        }
+                        Field::Switch => {
+                            run.child_order.push(HxRunChildOrder::Switch(run.switches.len()));
+                            run.switches.push(map.next_value()?);
+                        }
+                        Field::TitleMark => run.title_mark = Some(map.next_value()?),
+                        Field::Dutmal => {
+                            run.child_order.push(HxRunChildOrder::Dutmal(run.dutmals.len()));
+                            run.dutmals.push(map.next_value()?);
+                        }
+                        Field::Compose => {
+                            run.child_order.push(HxRunChildOrder::Compose(run.composes.len()));
+                            run.composes.push(map.next_value()?);
+                        }
+                        Field::Container => {
+                            run.child_order.push(HxRunChildOrder::Container(run.containers.len()));
+                            run.containers.push(map.next_value()?);
+                        }
+                        Field::TextArt => {
+                            run.child_order.push(HxRunChildOrder::TextArt(run.textarts.len()));
+                            run.textarts.push(map.next_value()?);
+                        }
+                        Field::Ignore => {
+                            let _: serde::de::IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+                Ok(run)
+            }
+        }
+
+        deserializer.deserialize_map(HxRunVisitor)
+    }
 }
 
 /// `<hp:textart>` — TextArt (글맵시) decorative warped-text object.
@@ -1805,7 +2025,7 @@ impl Default for HxMatrix {
 }
 
 /// `<hp:renderingInfo>` — transformation matrices for rendering.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
 pub struct HxRenderingInfo {
     /// Translation matrix.
     #[serde(rename(serialize = "hc:transMatrix", deserialize = "transMatrix"))]
@@ -1816,6 +2036,30 @@ pub struct HxRenderingInfo {
     /// Rotation matrix.
     #[serde(rename(serialize = "hc:rotMatrix", deserialize = "rotMatrix"))]
     pub rot_matrix: HxMatrix,
+}
+
+impl<'de> Deserialize<'de> for HxRenderingInfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RenderingInfoElements {
+            #[serde(rename = "transMatrix", default)]
+            trans_matrices: Vec<HxMatrix>,
+            #[serde(rename = "scaMatrix", default)]
+            scale_matrices: Vec<HxMatrix>,
+            #[serde(rename = "rotMatrix", default)]
+            rotation_matrices: Vec<HxMatrix>,
+        }
+
+        let elements = RenderingInfoElements::deserialize(deserializer)?;
+        Ok(Self {
+            trans_matrix: elements.trans_matrices.into_iter().last().unwrap_or_default(),
+            sca_matrix: elements.scale_matrices.into_iter().last().unwrap_or_default(),
+            rot_matrix: elements.rotation_matrices.into_iter().last().unwrap_or_default(),
+        })
+    }
 }
 
 // Shape-common types (HxLineShape, HxWinBrush, HxFillBrush, HxShadow, HxShapeComment)
@@ -2078,6 +2322,26 @@ mod tests {
         let xml = r#"<hs:sec></hs:sec>"#;
         let sec = parse_section(xml);
         assert!(sec.paragraphs.is_empty());
+    }
+
+    #[test]
+    fn parse_rendering_info_with_repeated_scale_and_rotation_matrices() {
+        let xml = r#"
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1.07102" e2="0" e3="0" e4="0" e5="0.926194" e6="337"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>"#;
+
+        let rendering: HxRenderingInfo =
+            quick_xml::de::from_str(xml).expect("repeated matrices should decode");
+
+        assert_eq!(rendering.trans_matrix.e1, "1");
+        assert_eq!(rendering.sca_matrix.e1, "1.07102");
+        assert_eq!(rendering.sca_matrix.e5, "0.926194");
+        assert_eq!(rendering.rot_matrix.e1, "1");
     }
 
     #[test]

--- a/crates/hwpforge-smithy-hwpx/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/schema/section.rs
@@ -2081,9 +2081,10 @@ pub struct HxEquation {
     /// Element ID.
     #[serde(rename = "@id", default)]
     pub id: String,
-    /// Z-order for overlapping objects.
-    #[serde(rename = "@zOrder", default)]
-    pub z_order: u32,
+    /// Z-order for overlapping objects, preserving wire absence separately
+    /// from an explicit `zOrder="0"`.
+    #[serde(rename = "@zOrder", default, skip_serializing_if = "Option::is_none")]
+    pub z_order: Option<u32>,
     /// Numbering type: NONE, EQUATION, etc.
     #[serde(rename = "@numberingType", default)]
     pub numbering_type: String,

--- a/crates/hwpforge-smithy-hwpx/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/schema/section.rs
@@ -516,48 +516,187 @@ pub struct HxTextArtPr {
 /// nested `<hp:container>` children (Wave B). The shape-common block
 /// (offset/orgSz/…) is parsed for geometry; children reuse the per-shape
 /// decoders, and nested containers recurse through `decode_container`.
-#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct HxContainer {
     /// Group nesting level (`0` = outermost).
-    #[serde(rename = "@groupLevel", default)]
     pub group_level: u32,
     /// Instance identifier (mirrors HWP5 / Core `inst_id`).
-    #[serde(rename = "@instid", default)]
     pub instid: String,
 
     /// Group bounding-box original size (`<hp:orgSz>`).
-    #[serde(rename(deserialize = "orgSz"), default)]
     pub org_sz: Option<HxSizeAttr>,
     /// Group placement (`<hp:pos>`) — carries the anchor offsets.
-    #[serde(rename(deserialize = "pos"), default)]
     pub pos: Option<HxTablePos>,
     /// Group display size (`<hp:sz>`).
-    #[serde(rename(deserialize = "sz"), default)]
     pub sz: Option<HxTableSz>,
 
     // ── Children (flat shapes for Wave A) ──
     /// `<hp:rect>` children (textboxes / pure rects).
-    #[serde(rename(deserialize = "rect"), default)]
     pub rects: Vec<HxRect>,
     /// `<hp:line>` children.
-    #[serde(rename(deserialize = "line"), default)]
     pub lines: Vec<HxLine>,
     /// `<hp:ellipse>` children (ellipse / arc).
-    #[serde(rename(deserialize = "ellipse"), default)]
     pub ellipses: Vec<HxEllipse>,
     /// `<hp:polygon>` children.
-    #[serde(rename(deserialize = "polygon"), default)]
     pub polygons: Vec<HxPolygon>,
     /// `<hp:curve>` children.
-    #[serde(rename(deserialize = "curve"), default)]
     pub curves: Vec<HxCurve>,
     /// `<hp:connectLine>` children.
-    #[serde(rename(deserialize = "connectLine"), default)]
     pub connect_lines: Vec<HxConnectLine>,
     /// Nested `<hp:container>` children (group-in-group, Wave B). `Vec` is
     /// heap-indirected so the recursive type needs no explicit `Box`.
-    #[serde(rename(deserialize = "container"), default)]
     pub containers: Vec<HxContainer>,
+
+    /// Direct shape/container order captured during decode.
+    pub child_order: Vec<HxContainerChildOrder>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HxContainerChildOrder {
+    Rect(usize),
+    Line(usize),
+    Ellipse(usize),
+    Polygon(usize),
+    Curve(usize),
+    ConnectLine(usize),
+    Container(usize),
+}
+
+impl<'de> Deserialize<'de> for HxContainer {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        enum Field {
+            GroupLevel,
+            InstId,
+            OriginalSize,
+            Position,
+            Size,
+            Rect,
+            Line,
+            Ellipse,
+            Polygon,
+            Curve,
+            ConnectLine,
+            Container,
+            Ignore,
+        }
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl Visitor<'_> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        formatter.write_str("an HWPX container attribute or child")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Ok(match value {
+                            "@groupLevel" => Field::GroupLevel,
+                            "@instid" => Field::InstId,
+                            "orgSz" => Field::OriginalSize,
+                            "pos" => Field::Position,
+                            "sz" => Field::Size,
+                            "rect" => Field::Rect,
+                            "line" => Field::Line,
+                            "ellipse" => Field::Ellipse,
+                            "polygon" => Field::Polygon,
+                            "curve" => Field::Curve,
+                            "connectLine" => Field::ConnectLine,
+                            "container" => Field::Container,
+                            _ => Field::Ignore,
+                        })
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct HxContainerVisitor;
+
+        impl<'de> Visitor<'de> for HxContainerVisitor {
+            type Value = HxContainer;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an hp:container element")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut container = HxContainer::default();
+                while let Some(field) = map.next_key()? {
+                    match field {
+                        Field::GroupLevel => container.group_level = map.next_value()?,
+                        Field::InstId => container.instid = map.next_value()?,
+                        Field::OriginalSize => container.org_sz = Some(map.next_value()?),
+                        Field::Position => container.pos = Some(map.next_value()?),
+                        Field::Size => container.sz = Some(map.next_value()?),
+                        Field::Rect => {
+                            container
+                                .child_order
+                                .push(HxContainerChildOrder::Rect(container.rects.len()));
+                            container.rects.push(map.next_value()?);
+                        }
+                        Field::Line => {
+                            container
+                                .child_order
+                                .push(HxContainerChildOrder::Line(container.lines.len()));
+                            container.lines.push(map.next_value()?);
+                        }
+                        Field::Ellipse => {
+                            container
+                                .child_order
+                                .push(HxContainerChildOrder::Ellipse(container.ellipses.len()));
+                            container.ellipses.push(map.next_value()?);
+                        }
+                        Field::Polygon => {
+                            container
+                                .child_order
+                                .push(HxContainerChildOrder::Polygon(container.polygons.len()));
+                            container.polygons.push(map.next_value()?);
+                        }
+                        Field::Curve => {
+                            container
+                                .child_order
+                                .push(HxContainerChildOrder::Curve(container.curves.len()));
+                            container.curves.push(map.next_value()?);
+                        }
+                        Field::ConnectLine => {
+                            container.child_order.push(HxContainerChildOrder::ConnectLine(
+                                container.connect_lines.len(),
+                            ));
+                            container.connect_lines.push(map.next_value()?);
+                        }
+                        Field::Container => {
+                            container
+                                .child_order
+                                .push(HxContainerChildOrder::Container(container.containers.len()));
+                            container.containers.push(map.next_value()?);
+                        }
+                        Field::Ignore => {
+                            let _: serde::de::IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+                Ok(container)
+            }
+        }
+
+        deserializer.deserialize_map(HxContainerVisitor)
+    }
 }
 
 // ── Text ──────────────────────────────────────────────────────────

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -203,6 +203,52 @@ fn visual_equation_group_offset_and_picture_placement_are_preserved() {
 }
 
 #[test]
+fn visual_equation_group_position_adds_rect_placement_to_child_local_pos() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst">
+        <rect id="2010924737" instid="rect-zero-child" zOrder="41">
+          <offset x="0" y="11428"/>
+          <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="explicit-zero-child"><pos horzOffset="0" vertOffset="0"/><script>zero child</script></equation>
+          </run></p></subList></drawText>
+        </rect>
+        <rect id="rect-local-child" instid="rect-local-child-inst" zOrder="42">
+          <offset x="321" y="-654"/>
+          <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="local-child"><pos horzOffset="11" vertOffset="12"/><script>local child</script></equation>
+          </run></p></subList></drawText>
+        </rect>
+        <rect id="rect-unsigned-offset" instid="rect-unsigned-offset-inst" zOrder="43">
+          <offset x="4294966848" y="11428"/>
+          <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="unsigned-offset"><pos horzOffset="0" vertOffset="0"/><script>unsigned offset</script></equation>
+          </run></p></subList></drawText>
+        </rect>
+      </container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let positions: Vec<(&str, i32, i32)> = report
+        .equations
+        .iter()
+        .map(|equation| {
+            (equation.id.as_str(), equation.position.horz_offset, equation.position.vert_offset)
+        })
+        .collect();
+    assert_eq!(
+        positions,
+        vec![
+            ("explicit-zero-child", 0, 11428),
+            ("local-child", 332, -642),
+            ("unsigned-offset", -448, 11428),
+        ],
+        "group positions must combine rect placement with equation-local coordinates"
+    );
+}
+
+#[test]
 fn visual_equation_nesting_boundary_succeeds() {
     let section = nested_containers_section(32);
 

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -1,0 +1,99 @@
+use std::io::Write as _;
+
+use hwpforge_smithy_hwpx::{HwpxDecoder, HwpxVisualEquationDomain, HwpxVisualEquationParentKind};
+use zip::write::SimpleFileOptions;
+
+const HEADER_XML: &str = r##"<head version="1.4" secCnt="1">
+  <refList>
+    <fontfaces itemCnt="1"><fontface lang="HANGUL" fontCnt="1"><font id="0" face="함초롬돋움" type="TTF" isEmbedded="0"/></fontface></fontfaces>
+    <charProperties itemCnt="1"><charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE" borderFillIDRef="0"><fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/></charPr></charProperties>
+    <paraProperties itemCnt="1"><paraPr id="0"><align horizontal="LEFT" vertical="BASELINE"/><switch><default><lineSpacing type="PERCENT" value="160"/></default></switch></paraPr></paraProperties>
+  </refList>
+</head>"##;
+
+const SECTION_XML: &str = r#"<sec>
+  <p id="1" paraPrIDRef="0" styleIDRef="0">
+    <run charPrIDRef="0">
+      <equation id="ordinary-1" zOrder="99"><pos horzOffset="900" vertOffset="901"/><script>ordinary</script></equation>
+      <tbl id="ordinary-table" rowCnt="1" colCnt="1"><tr><tc><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="ordinary-table-eq"><script>ordinary table</script></equation></run></p></subList><cellAddr colAddr="0" rowAddr="0"/><cellSpan rowSpan="1" colSpan="1"/></tc></tr></tbl>
+      <rect id="textbox-1" instid="textbox-inst" zOrder="98"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="textbox-eq"><script>textbox</script></equation></run></p></subList></drawText></rect>
+      <ctrl><endNote instId="9007199254740993"><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <pic id="9007199254740995" instid="9007199254740996" zOrder="7">
+          <pos horzOffset="101" vertOffset="102"/>
+          <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <t>caption</t>
+            <equation id="9007199254740997" zOrder="31"><pos horzOffset="111" vertOffset="112"/><script>{a} over {b}</script></equation>
+          </run></p></subList></caption>
+        </pic>
+      </run></p></subList></endNote></ctrl>
+      <container id="group-1" instid="group-inst" zOrder="8">
+        <rect id="9007199254740999" instid="9007199254741000" zOrder="41">
+          <pos horzOffset="201" vertOffset="202"/>
+          <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation zOrder="42"><script>x ^{2}</script></equation>
+          </run></p></subList></drawText>
+        </rect>
+      </container>
+    </run>
+  </p>
+</sec>"#;
+
+fn visual_equations_fixture() -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let stored = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default();
+    writer.start_file("mimetype", stored).unwrap();
+    writer.write_all(b"application/hwp+zip").unwrap();
+    writer.start_file("Contents/header.xml", deflated).unwrap();
+    writer.write_all(HEADER_XML.as_bytes()).unwrap();
+    writer.start_file("Contents/section0.xml", deflated).unwrap();
+    writer.write_all(SECTION_XML.as_bytes()).unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+#[test]
+fn visual_equations_report_preserves_only_supported_visual_domains() {
+    let (_document, report) = HwpxDecoder::decode_with_report(&visual_equations_fixture()).unwrap();
+
+    assert_eq!(report.schema_version, 1);
+    assert_eq!(report.equations.len(), 2);
+
+    let picture = &report.equations[0];
+    assert_eq!(picture.domain, HwpxVisualEquationDomain::PictureCaption);
+    assert_eq!(picture.parent_kind, HwpxVisualEquationParentKind::Picture);
+    assert_eq!(picture.id, "9007199254740997");
+    assert_eq!(picture.equation_object_id.as_deref(), Some("9007199254740997"));
+    assert_eq!(picture.parent_object_id.as_deref(), Some("9007199254740995"));
+    assert_eq!(picture.parent_instance_id.as_deref(), Some("9007199254740996"));
+    assert_eq!(
+        picture.parent_path,
+        "section[0]/paragraph[0]/run[0]/ctrl[0]/endnote/paragraph[0]/run[0]/picture[0]"
+    );
+    assert_eq!(picture.document_order, 0);
+    assert_eq!(picture.parent_order, 0);
+    assert_eq!(picture.z_order, 31);
+    assert_eq!(picture.position.horz_offset, 111);
+    assert_eq!(picture.position.vert_offset, 112);
+    assert_eq!(picture.script, "{a} over {b}");
+    assert_eq!(picture.latex, None);
+
+    let grouped = &report.equations[1];
+    assert_eq!(grouped.domain, HwpxVisualEquationDomain::GroupDrawText);
+    assert_eq!(grouped.parent_kind, HwpxVisualEquationParentKind::Container);
+    assert_eq!(grouped.id, "section[0]/paragraph[0]/run[0]/container[0]/rect[0]/equation[0]");
+    assert_eq!(grouped.equation_object_id, None);
+    assert_eq!(grouped.parent_object_id.as_deref(), Some("9007199254740999"));
+    assert_eq!(grouped.parent_instance_id.as_deref(), Some("9007199254741000"));
+    assert_eq!(grouped.parent_path, "section[0]/paragraph[0]/run[0]/container[0]/rect[0]");
+    assert_eq!(grouped.document_order, 1);
+    assert_eq!(grouped.parent_order, 0);
+    assert_eq!(grouped.z_order, 42);
+    assert_eq!(grouped.position.horz_offset, 201);
+    assert_eq!(grouped.position.vert_offset, 202);
+    assert_eq!(grouped.script, "x ^{2}");
+    assert_eq!(grouped.latex, None);
+
+    let serialized = serde_json::to_value(report).unwrap();
+    assert_eq!(serialized["equations"][0]["equation_object_id"], "9007199254740997");
+    assert_eq!(serialized["equations"][1]["parent_instance_id"], "9007199254741000");
+}

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -103,7 +103,7 @@ fn nested_table_controls_section(levels: usize) -> String {
 fn visual_equations_report_preserves_only_supported_visual_domains() {
     let (_document, report) = HwpxDecoder::decode_with_report(&visual_equations_fixture()).unwrap();
 
-    assert_eq!(report.schema_version, 3);
+    assert_eq!(report.schema_version, 4);
     assert_eq!(report.equations.len(), 2);
 
     let picture = &report.equations[0];
@@ -129,7 +129,7 @@ fn visual_equations_report_preserves_only_supported_visual_domains() {
     assert_eq!(picture.geometry.scale.vert, "1");
     assert_eq!(picture.geometry.display_box_size, None);
     assert_eq!(picture.geometry.display_equation_size, None);
-    assert_eq!(picture.geometry.display_base_unit, None);
+    assert_eq!(picture.geometry.render_base_unit, None);
     assert_eq!(picture.script, "{a} over {b}");
     assert_eq!(picture.latex, None);
 
@@ -266,7 +266,7 @@ fn visual_equation_group_position_adds_rect_placement_to_child_local_pos() {
 }
 
 #[test]
-fn visual_equation_group_geometry_applies_wire_scale_without_losing_raw_sizes() {
+fn q524_group_geometry_keeps_render_base_unit_unscaled_while_scaling_display_sizes() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <container instid="group-inst"><rect id="rect-1" instid="rect-inst" zOrder="41">
         <offset x="18928" y="7966"/><orgSz width="8504" height="8504"/>
@@ -286,7 +286,7 @@ fn visual_equation_group_geometry_applies_wire_scale_without_losing_raw_sizes() 
     let (_document, report) =
         HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
 
-    assert_eq!(report.schema_version, 3);
+    assert_eq!(report.schema_version, 4);
     let geometry = &report.equations[0].geometry;
     assert_eq!(geometry.raw_box_size.unwrap().width, 8504);
     assert_eq!(geometry.raw_box_size.unwrap().height, 8504);
@@ -299,7 +299,7 @@ fn visual_equation_group_geometry_applies_wire_scale_without_losing_raw_sizes() 
     assert_eq!(geometry.display_box_size.unwrap().height, 2145);
     assert_eq!(geometry.display_equation_size.unwrap().width, 147);
     assert_eq!(geometry.display_equation_size.unwrap().height, 284);
-    assert_eq!(geometry.display_base_unit, Some(277));
+    assert_eq!(geometry.render_base_unit, Some(1100));
 
     let serialized = serde_json::to_value(report).unwrap();
     assert_eq!(
@@ -314,10 +314,15 @@ fn visual_equation_group_geometry_applies_wire_scale_without_losing_raw_sizes() 
         serialized["equations"][0]["display_position"],
         serde_json::json!({"horz_offset": 20309, "vert_offset": 8498})
     );
+    assert_eq!(serialized["equations"][0]["geometry"]["render_base_unit"], 1100);
+    assert!(
+        serialized["equations"][0]["geometry"].get("display_base_unit").is_none(),
+        "schema v4 must not expose the misleading scale-applied font base unit"
+    );
 }
 
 #[test]
-fn visual_equation_group_display_position_applies_final_scale_translation() {
+fn q448_group_position_uses_translation_but_render_base_unit_stays_raw() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <container id="2010952039" instid="937210216"><rect id="0" instid="937210219" zOrder="28100">
         <offset x="4294965625" y="343"/><orgSz width="2477" height="1883"/>
@@ -349,6 +354,32 @@ fn visual_equation_group_display_position_applies_final_scale_translation() {
         equation["display_position"],
         serde_json::json!({"horz_offset": 190, "vert_offset": 1022})
     );
+    assert_eq!(equation["geometry"]["scale"]["vert"], "0.831652");
+    assert_eq!(equation["geometry"]["display_equation_size"]["height"], 748);
+    assert_eq!(equation["geometry"]["render_base_unit"], 900);
+    assert!(equation["geometry"].get("display_base_unit").is_none());
+}
+
+#[test]
+fn visual_equation_render_base_unit_falls_back_to_raw_equation_height() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst"><rect id="rect-1" instid="rect-inst">
+        <orgSz width="2477" height="1883"/>
+        <renderingInfo><scaMatrix e1="0.478401" e2="0" e3="0" e4="0" e5="0.831652" e6="0"/></renderingInfo>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="height-fallback"><sz width="405" height="900"/><script>y</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+    let geometry = &report.equations[0].geometry;
+
+    assert_eq!(geometry.raw_base_unit, None);
+    assert_eq!(geometry.raw_equation_size.unwrap().height, 900);
+    assert_eq!(geometry.render_base_unit, Some(900));
+    assert_eq!(geometry.display_equation_size.unwrap().height, 748);
 }
 
 #[test]
@@ -380,7 +411,7 @@ fn visual_equation_display_position_overflow_fails_closed_without_losing_wire_tr
 }
 
 #[test]
-fn visual_equation_invalid_scale_preserves_provenance_and_uses_explicit_null_display_values() {
+fn visual_equation_invalid_scale_preserves_geometry_and_raw_render_base_unit() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <container instid="group-inst"><rect id="rect-1" instid="rect-inst">
         <orgSz width="8504" height="8504"/>
@@ -402,12 +433,13 @@ fn visual_equation_invalid_scale_preserves_provenance_and_uses_explicit_null_dis
     assert_eq!(geometry.scale.vert, "-1");
     assert_eq!(geometry.display_box_size, None);
     assert_eq!(geometry.display_equation_size, None);
-    assert_eq!(geometry.display_base_unit, None);
+    assert_eq!(geometry.render_base_unit, Some(1100));
 
     let serialized = serde_json::to_value(report).unwrap();
     assert!(serialized["equations"][0]["geometry"]["display_box_size"].is_null());
     assert!(serialized["equations"][0]["geometry"]["display_equation_size"].is_null());
-    assert!(serialized["equations"][0]["geometry"]["display_base_unit"].is_null());
+    assert_eq!(serialized["equations"][0]["geometry"]["render_base_unit"], 1100);
+    assert!(serialized["equations"][0]["geometry"].get("display_base_unit").is_none());
 }
 
 #[test]

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -39,6 +39,10 @@ const SECTION_XML: &str = r#"<sec>
 </sec>"#;
 
 fn visual_equations_fixture() -> Vec<u8> {
+    fixture_with_section(SECTION_XML)
+}
+
+fn fixture_with_section(section_xml: &str) -> Vec<u8> {
     let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
     let stored = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
     let deflated = SimpleFileOptions::default();
@@ -47,8 +51,52 @@ fn visual_equations_fixture() -> Vec<u8> {
     writer.start_file("Contents/header.xml", deflated).unwrap();
     writer.write_all(HEADER_XML.as_bytes()).unwrap();
     writer.start_file("Contents/section0.xml", deflated).unwrap();
-    writer.write_all(SECTION_XML.as_bytes()).unwrap();
+    writer.write_all(section_xml.as_bytes()).unwrap();
     writer.finish().unwrap().into_inner()
+}
+
+fn nested_containers_section(levels: usize) -> String {
+    let mut visual = concat!(
+        r#"<rect id="deep-rect" instid="deep-rect-inst" zOrder="17">"#,
+        r#"<offset x="701" y="702"/>"#,
+        r#"<drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">"#,
+        r#"<equation id="deep-equation"><script>deep</script></equation>"#,
+        r#"</run></p></subList></drawText></rect>"#,
+    )
+    .to_string();
+    for level in (0..levels).rev() {
+        visual = format!(
+            r#"<container groupLevel="{level}" instid="container-{level}">{visual}</container>"#
+        );
+    }
+    format!(
+        r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">{visual}</run></p></sec>"#
+    )
+}
+
+fn nested_table_controls_section(levels: usize) -> String {
+    let mut visual = concat!(
+        r#"<pic id="deep-picture" instid="deep-picture-inst" zOrder="19">"#,
+        r#"<pos horzOffset="801" vertOffset="802"/>"#,
+        r#"<caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">"#,
+        r#"<equation id="deep-caption-equation"><script>deep caption</script></equation>"#,
+        r#"</run></p></subList></caption></pic>"#,
+    )
+    .to_string();
+    for level in (0..levels).rev() {
+        visual = if level % 2 == 0 {
+            format!(
+                r#"<tbl id="table-{level}" rowCnt="1" colCnt="1"><tr><tc><subList><p paraPrIDRef="0"><run charPrIDRef="0">{visual}</run></p></subList><cellAddr colAddr="0" rowAddr="0"/><cellSpan rowSpan="1" colSpan="1"/></tc></tr></tbl>"#
+            )
+        } else {
+            format!(
+                r#"<ctrl><endNote instId="{level}"><subList><p paraPrIDRef="0"><run charPrIDRef="0">{visual}</run></p></subList></endNote></ctrl>"#
+            )
+        };
+    }
+    format!(
+        r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">{visual}</run></p></sec>"#
+    )
 }
 
 #[test]
@@ -96,4 +144,101 @@ fn visual_equations_report_preserves_only_supported_visual_domains() {
     let serialized = serde_json::to_value(report).unwrap();
     assert_eq!(serialized["equations"][0]["equation_object_id"], "9007199254740997");
     assert_eq!(serialized["equations"][1]["parent_instance_id"], "9007199254741000");
+}
+
+#[test]
+fn visual_equation_explicit_zero_z_order_does_not_inherit_parent() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst"><rect id="rect-1" instid="rect-inst" zOrder="41">
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="explicit-zero" zOrder="0"><script>zero</script></equation>
+          <equation id="absent-z-order"><script>absent</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    assert_eq!(report.equations.len(), 2);
+    assert_eq!(report.equations[0].id, "explicit-zero");
+    assert_eq!(
+        report.equations[0].z_order, 0,
+        "an explicit wire zOrder=0 must not inherit the parent z-order"
+    );
+    assert_eq!(report.equations[1].id, "absent-z-order");
+    assert_eq!(
+        report.equations[1].z_order, 41,
+        "only an absent equation zOrder may inherit the visual parent"
+    );
+}
+
+#[test]
+fn visual_equation_group_offset_and_picture_placement_are_preserved() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst"><rect id="rect-1" instid="rect-inst" zOrder="41">
+        <offset x="321" y="-654"/>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="group-offset"><script>group</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+      <pic id="picture-1" instid="picture-inst" zOrder="42">
+        <offset x="11" y="12"/><pos horzOffset="421" vertOffset="422"/>
+        <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="picture-placement"><script>picture</script></equation>
+        </run></p></subList></caption>
+      </pic>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    assert_eq!(report.equations.len(), 2);
+    assert_eq!(report.equations[0].id, "group-offset");
+    assert_eq!(report.equations[0].position.horz_offset, 321);
+    assert_eq!(report.equations[0].position.vert_offset, -654);
+    assert_eq!(report.equations[1].id, "picture-placement");
+    assert_eq!(report.equations[1].position.horz_offset, 421);
+    assert_eq!(report.equations[1].position.vert_offset, 422);
+}
+
+#[test]
+fn visual_equation_nesting_boundary_succeeds() {
+    let section = nested_containers_section(32);
+
+    let (_document, report) = HwpxDecoder::decode_with_report(&fixture_with_section(&section))
+        .expect("32 visual-container levels must remain within the decoder boundary");
+
+    assert_eq!(report.equations.len(), 1);
+    assert_eq!(report.equations[0].id, "deep-equation");
+}
+
+#[test]
+fn visual_equation_container_nesting_depth_exceeded_fails_closed() {
+    let section = nested_containers_section(33);
+
+    let result = HwpxDecoder::decode_with_report(&fixture_with_section(&section));
+
+    match result {
+        Ok(_) => panic!("33 visual-container levels must fail closed"),
+        Err(error) => assert!(
+            error.to_string().contains("visual-equation nesting depth 32 exceeds limit of 32"),
+            "unexpected error: {error}"
+        ),
+    }
+}
+
+#[test]
+fn visual_equation_table_control_nesting_depth_exceeded_fails_closed() {
+    let section = nested_table_controls_section(33);
+
+    let result = HwpxDecoder::decode_with_report(&fixture_with_section(&section));
+
+    match result {
+        Ok(_) => panic!("33 table/control levels must fail closed"),
+        Err(error) => assert!(
+            error.to_string().contains("visual-equation nesting depth 32 exceeds limit of 32"),
+            "unexpected error: {error}"
+        ),
+    }
 }

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -223,8 +223,17 @@ fn legacy_decode_ignores_visual_report_projection_overflow() {
     </run></p></sec>"#;
     let fixture = fixture_with_section(section);
 
+    let path =
+        std::env::temp_dir().join(format!("hwpforge-visual-overflow-{}.hwpx", std::process::id()));
+    std::fs::write(&path, &fixture).unwrap();
+    let legacy_file_result = HwpxDecoder::decode_file(&path);
+    let report_file_result = HwpxDecoder::decode_file_with_report(&path);
+    std::fs::remove_file(&path).unwrap();
+
     assert!(HwpxDecoder::decode(&fixture).is_ok());
     assert!(HwpxDecoder::decode_with_report(&fixture).is_err());
+    assert!(legacy_file_result.is_ok());
+    assert!(report_file_result.is_err());
 }
 
 #[test]
@@ -287,6 +296,7 @@ fn visual_equation_group_offset_and_picture_placement_are_preserved() {
 fn visual_equation_group_position_adds_rect_placement_to_child_local_pos() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <container instid="group-inst">
+        <pos horzOffset="100" vertOffset="200"/>
         <rect id="2010924737" instid="rect-zero-child" zOrder="41">
           <offset x="0" y="11428"/>
           <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
@@ -325,11 +335,11 @@ fn visual_equation_group_position_adds_rect_placement_to_child_local_pos() {
     assert_eq!(
         positions,
         vec![
-            ("explicit-zero-child", 0, 11428),
-            ("local-child", 332, -642),
-            ("unsigned-offset", -448, 11428),
+            ("explicit-zero-child", 100, 11628),
+            ("local-child", 432, -442),
+            ("unsigned-offset", -348, 11628),
         ],
-        "group positions must combine rect placement with equation-local coordinates"
+        "group positions must combine container, rect, and equation-local coordinates"
     );
 }
 

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -103,7 +103,7 @@ fn nested_table_controls_section(levels: usize) -> String {
 fn visual_equations_report_preserves_only_supported_visual_domains() {
     let (_document, report) = HwpxDecoder::decode_with_report(&visual_equations_fixture()).unwrap();
 
-    assert_eq!(report.schema_version, 2);
+    assert_eq!(report.schema_version, 3);
     assert_eq!(report.equations.len(), 2);
 
     let picture = &report.equations[0];
@@ -120,8 +120,8 @@ fn visual_equations_report_preserves_only_supported_visual_domains() {
     assert_eq!(picture.document_order, 0);
     assert_eq!(picture.parent_order, 0);
     assert_eq!(picture.z_order, 31);
-    assert_eq!(picture.position.horz_offset, 111);
-    assert_eq!(picture.position.vert_offset, 112);
+    assert_eq!(picture.raw_position.horz_offset, 111);
+    assert_eq!(picture.raw_position.vert_offset, 112);
     assert_eq!(picture.geometry.raw_box_size, None);
     assert_eq!(picture.geometry.raw_equation_size, None);
     assert_eq!(picture.geometry.raw_base_unit, None);
@@ -144,8 +144,8 @@ fn visual_equations_report_preserves_only_supported_visual_domains() {
     assert_eq!(grouped.document_order, 1);
     assert_eq!(grouped.parent_order, 0);
     assert_eq!(grouped.z_order, 42);
-    assert_eq!(grouped.position.horz_offset, 201);
-    assert_eq!(grouped.position.vert_offset, 202);
+    assert_eq!(grouped.raw_position.horz_offset, 201);
+    assert_eq!(grouped.raw_position.vert_offset, 202);
     assert_eq!(grouped.geometry.raw_box_size, None);
     assert_eq!(grouped.geometry.raw_equation_size, None);
     assert_eq!(grouped.geometry.display_box_size, None);
@@ -208,11 +208,11 @@ fn visual_equation_group_offset_and_picture_placement_are_preserved() {
 
     assert_eq!(report.equations.len(), 2);
     assert_eq!(report.equations[0].id, "group-offset");
-    assert_eq!(report.equations[0].position.horz_offset, 321);
-    assert_eq!(report.equations[0].position.vert_offset, -654);
+    assert_eq!(report.equations[0].raw_position.horz_offset, 321);
+    assert_eq!(report.equations[0].raw_position.vert_offset, -654);
     assert_eq!(report.equations[1].id, "picture-placement");
-    assert_eq!(report.equations[1].position.horz_offset, 421);
-    assert_eq!(report.equations[1].position.vert_offset, 422);
+    assert_eq!(report.equations[1].raw_position.horz_offset, 421);
+    assert_eq!(report.equations[1].raw_position.vert_offset, 422);
 }
 
 #[test]
@@ -247,7 +247,11 @@ fn visual_equation_group_position_adds_rect_placement_to_child_local_pos() {
         .equations
         .iter()
         .map(|equation| {
-            (equation.id.as_str(), equation.position.horz_offset, equation.position.vert_offset)
+            (
+                equation.id.as_str(),
+                equation.raw_position.horz_offset,
+                equation.raw_position.vert_offset,
+            )
         })
         .collect();
     assert_eq!(
@@ -282,7 +286,7 @@ fn visual_equation_group_geometry_applies_wire_scale_without_losing_raw_sizes() 
     let (_document, report) =
         HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
 
-    assert_eq!(report.schema_version, 2);
+    assert_eq!(report.schema_version, 3);
     let geometry = &report.equations[0].geometry;
     assert_eq!(geometry.raw_box_size.unwrap().width, 8504);
     assert_eq!(geometry.raw_box_size.unwrap().height, 8504);
@@ -296,6 +300,83 @@ fn visual_equation_group_geometry_applies_wire_scale_without_losing_raw_sizes() 
     assert_eq!(geometry.display_equation_size.unwrap().width, 147);
     assert_eq!(geometry.display_equation_size.unwrap().height, 284);
     assert_eq!(geometry.display_base_unit, Some(277));
+
+    let serialized = serde_json::to_value(report).unwrap();
+    assert_eq!(
+        serialized["equations"][0]["raw_position"],
+        serde_json::json!({"horz_offset": 18928, "vert_offset": 7966})
+    );
+    assert_eq!(
+        serialized["equations"][0]["translation"],
+        serde_json::json!({"horz": "1381.427002", "vert": "532.402954"})
+    );
+    assert_eq!(
+        serialized["equations"][0]["display_position"],
+        serde_json::json!({"horz_offset": 20309, "vert_offset": 8498})
+    );
+}
+
+#[test]
+fn visual_equation_group_display_position_applies_final_scale_translation() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container id="2010952039" instid="937210216"><rect id="0" instid="937210219" zOrder="28100">
+        <offset x="4294965625" y="343"/><orgSz width="2477" height="1883"/>
+        <renderingInfo>
+          <transMatrix e1="1" e2="0" e3="-1671" e4="0" e5="1" e6="343"/>
+          <scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <scaMatrix e1="0.478401" e2="0" e3="1861" e4="0" e5="0.831652" e6="679"/>
+          <rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </renderingInfo>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="2010952060" baseUnit="900"><sz width="405" height="900"/><pos horzOffset="0" vertOffset="0"/><script>y</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+    let serialized = serde_json::to_value(report).unwrap();
+    let equation = &serialized["equations"][0];
+
+    assert_eq!(equation["equation_object_id"], "2010952060");
+    assert_eq!(
+        equation["raw_position"],
+        serde_json::json!({"horz_offset": -1671, "vert_offset": 343})
+    );
+    assert_eq!(equation["translation"], serde_json::json!({"horz": "1861", "vert": "679"}));
+    assert_eq!(
+        equation["display_position"],
+        serde_json::json!({"horz_offset": 190, "vert_offset": 1022})
+    );
+}
+
+#[test]
+fn visual_equation_display_position_overflow_fails_closed_without_losing_wire_translation() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst"><rect id="rect-1" instid="rect-inst">
+        <offset x="2147483647" y="0"/><orgSz width="100" height="100"/>
+        <renderingInfo>
+          <transMatrix e1="1" e2="0" e3="2147483647" e4="0" e5="1" e6="0"/>
+          <scaMatrix e1="1" e2="0" e3="1" e4="0" e5="1" e6="0"/>
+        </renderingInfo>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="overflow" baseUnit="100"><sz width="100" height="100"/><script>x</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+    let serialized = serde_json::to_value(report).unwrap();
+    let equation = &serialized["equations"][0];
+
+    assert_eq!(
+        equation["raw_position"],
+        serde_json::json!({"horz_offset": 2147483647_i64, "vert_offset": 0})
+    );
+    assert_eq!(equation["translation"], serde_json::json!({"horz": "1", "vert": "0"}));
+    assert!(equation["display_position"].is_null());
 }
 
 #[test]

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -303,6 +303,87 @@ fn visual_equations_traverse_visuals_nested_in_top_level_shape_text() {
 }
 
 #[test]
+fn visual_equations_collect_text_bearing_ellipse_and_polygon_in_group() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst">
+        <ellipse id="group-ellipse" instid="group-ellipse-inst"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="ellipse-equation"><script>ellipse</script></equation>
+        </run></p></subList></drawText></ellipse>
+        <polygon id="group-polygon" instid="group-polygon-inst"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="polygon-equation"><script>polygon</script></equation>
+        </run></p></subList></drawText></polygon>
+      </container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let identities: Vec<(&str, Option<&str>)> = report
+        .equations
+        .iter()
+        .map(|equation| (equation.id.as_str(), equation.parent_object_id.as_deref()))
+        .collect();
+    assert_eq!(
+        identities,
+        vec![
+            ("ellipse-equation", Some("group-ellipse")),
+            ("polygon-equation", Some("group-polygon")),
+        ]
+    );
+    assert!(report
+        .equations
+        .iter()
+        .all(|equation| equation.domain == HwpxVisualEquationDomain::GroupDrawText));
+}
+
+#[test]
+fn visual_equations_preserve_nested_visual_parent_and_interleaved_order() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <pic id="outer-picture" instid="outer-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <equation id="outer-before"><script>before</script></equation>
+        <pic id="nested-picture" instid="nested-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="nested-picture-equation"><script>nested</script></equation>
+        </run></p></subList></caption></pic>
+        <equation id="outer-after"><script>after</script></equation>
+      </run></p></subList></caption></pic>
+      <container instid="outer-container"><rect id="outer-rect" instid="outer-rect-inst"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <equation id="group-before"><script>group before</script></equation>
+        <container instid="nested-container"><rect id="nested-rect" instid="nested-rect-inst"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="nested-group-equation"><script>nested group</script></equation>
+        </run></p></subList></drawText></rect></container>
+        <equation id="group-after"><script>group after</script></equation>
+      </run></p></subList></drawText></rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let identities: Vec<(&str, Option<&str>, usize, usize)> = report
+        .equations
+        .iter()
+        .map(|equation| {
+            (
+                equation.id.as_str(),
+                equation.parent_object_id.as_deref(),
+                equation.parent_order,
+                equation.document_order,
+            )
+        })
+        .collect();
+    assert_eq!(
+        identities,
+        vec![
+            ("outer-before", Some("outer-picture"), 0, 0),
+            ("nested-picture-equation", Some("nested-picture"), 0, 1),
+            ("outer-after", Some("outer-picture"), 1, 2),
+            ("group-before", Some("outer-rect"), 0, 3),
+            ("nested-group-equation", Some("nested-rect"), 0, 4),
+            ("group-after", Some("outer-rect"), 1, 5),
+        ]
+    );
+}
+
+#[test]
 fn visual_equations_report_traverses_header_and_footer_controls() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <ctrl><header id="header-1" applyPageType="BOTH"><subList><p paraPrIDRef="0"><run charPrIDRef="0">

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -99,6 +99,33 @@ fn nested_table_controls_section(levels: usize) -> String {
     )
 }
 
+fn nested_picture_captions_section(levels: usize) -> String {
+    let mut visual =
+        r#"<equation id="deep-picture-equation"><script>deep picture</script></equation>"#
+            .to_string();
+    for level in (0..levels).rev() {
+        visual = format!(
+            r#"<pic id="picture-{level}" instid="picture-inst-{level}"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">{visual}</run></p></subList></caption></pic>"#
+        );
+    }
+    format!(
+        r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">{visual}</run></p></sec>"#
+    )
+}
+
+fn nested_group_shape_text_section(levels: usize) -> String {
+    let mut visual =
+        r#"<equation id="deep-group-equation"><script>deep group</script></equation>"#.to_string();
+    for level in (0..levels).rev() {
+        visual = format!(
+            r#"<container instid="container-{level}"><rect id="rect-{level}" instid="rect-inst-{level}"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">{visual}</run></p></subList></drawText></rect></container>"#
+        );
+    }
+    format!(
+        r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">{visual}</run></p></sec>"#
+    )
+}
+
 #[test]
 fn visual_equations_report_preserves_only_supported_visual_domains() {
     let (_document, report) = HwpxDecoder::decode_with_report(&visual_equations_fixture()).unwrap();
@@ -660,6 +687,42 @@ fn visual_equations_report_traverses_header_and_footer_controls() {
 }
 
 #[test]
+fn visual_equations_report_traverses_memo_field_sublists() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <ctrl><fieldBegin type="MEMO" fieldid="1"><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <pic id="memo-picture" instid="memo-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="memo-picture-equation"><script>memo picture</script></equation>
+        </run></p></subList></caption></pic>
+      </run></p></subList></fieldBegin></ctrl>
+      <pic id="outer-picture" instid="outer-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <ctrl><fieldBegin type="MEMO" fieldid="2"><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <container instid="memo-container"><rect id="memo-rect" instid="memo-rect-inst"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="memo-group-equation"><script>memo group</script></equation>
+          </run></p></subList></drawText></rect></container>
+        </run></p></subList></fieldBegin></ctrl>
+      </run></p></subList></caption></pic>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let identities: Vec<(&str, Option<&str>)> = report
+        .equations
+        .iter()
+        .map(|equation| (equation.id.as_str(), equation.parent_object_id.as_deref()))
+        .collect();
+    assert_eq!(
+        identities,
+        vec![
+            ("memo-picture-equation", Some("memo-picture")),
+            ("memo-group-equation", Some("memo-rect")),
+        ]
+    );
+    assert!(report.equations[0].parent_path.contains("/fieldBegin/"));
+    assert!(report.equations[1].parent_path.contains("/fieldBegin/"));
+}
+
+#[test]
 fn legacy_decode_ignores_visual_report_projection_overflow() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <container instid="group-inst"><rect id="overflow-rect" instid="overflow-rect-inst">
@@ -1002,6 +1065,45 @@ fn visual_equation_table_control_nesting_depth_exceeded_fails_closed() {
 
     match result {
         Ok(_) => panic!("33 table/control levels must fail closed"),
+        Err(error) => assert!(
+            error.to_string().contains("visual-equation nesting depth 32 exceeds limit of 32"),
+            "unexpected error: {error}"
+        ),
+    }
+}
+
+#[test]
+fn visual_equation_nested_picture_caption_depth_is_enforced() {
+    let boundary = nested_picture_captions_section(32);
+    let (_document, report) = HwpxDecoder::decode_with_report(&fixture_with_section(&boundary))
+        .expect("32 nested picture captions must remain within the decoder boundary");
+    assert_eq!(report.equations.len(), 1);
+    assert_eq!(report.equations[0].id, "deep-picture-equation");
+
+    let exceeded = nested_picture_captions_section(33);
+    let result = HwpxDecoder::decode_with_report(&fixture_with_section(&exceeded));
+    match result {
+        Ok(_) => panic!("33 nested picture captions must fail closed"),
+        Err(error) => assert!(
+            error.to_string().contains("visual-equation nesting depth 32 exceeds limit of 32"),
+            "unexpected error: {error}"
+        ),
+    }
+}
+
+#[test]
+fn visual_equation_nested_group_shape_text_depth_is_enforced() {
+    let group_boundary = nested_group_shape_text_section(32);
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(&group_boundary))
+            .expect("32 nested group shape texts must remain within the decoder boundary");
+    assert_eq!(report.equations.len(), 1);
+    assert_eq!(report.equations[0].id, "deep-group-equation");
+
+    let group_exceeded = nested_group_shape_text_section(33);
+    let result = HwpxDecoder::decode_with_report(&fixture_with_section(&group_exceeded));
+    match result {
+        Ok(_) => panic!("33 nested group shape texts must fail closed"),
         Err(error) => assert!(
             error.to_string().contains("visual-equation nesting depth 32 exceeds limit of 32"),
             "unexpected error: {error}"

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -186,6 +186,68 @@ fn visual_equations_preserve_interleaved_nested_container_order() {
 }
 
 #[test]
+fn visual_equations_traverse_nested_shape_text_with_outer_visual_parent() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <pic id="outer-picture" instid="outer-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <rect id="nested-picture-rect"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="picture-rect-equation"><script>pr</script></equation></run></p></subList></drawText></rect>
+        <ellipse id="nested-picture-ellipse"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="picture-ellipse-equation"><script>pe</script></equation></run></p></subList></drawText></ellipse>
+        <polygon id="nested-picture-polygon"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="picture-polygon-equation"><script>pp</script></equation></run></p></subList></drawText></polygon>
+      </run></p></subList></caption></pic>
+      <container instid="group-inst"><rect id="outer-group-rect" instid="outer-group-rect-inst"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <rect id="nested-group-rect"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="group-rect-equation"><script>gr</script></equation></run></p></subList></drawText></rect>
+        <ellipse id="nested-group-ellipse"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="group-ellipse-equation"><script>ge</script></equation></run></p></subList></drawText></ellipse>
+        <polygon id="nested-group-polygon"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0"><equation id="group-polygon-equation"><script>gp</script></equation></run></p></subList></drawText></polygon>
+      </run></p></subList></drawText></rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let identities: Vec<(&str, Option<&str>, HwpxVisualEquationDomain)> = report
+        .equations
+        .iter()
+        .map(|equation| {
+            (equation.id.as_str(), equation.parent_object_id.as_deref(), equation.domain)
+        })
+        .collect();
+    assert_eq!(
+        identities,
+        vec![
+            (
+                "picture-rect-equation",
+                Some("outer-picture"),
+                HwpxVisualEquationDomain::PictureCaption,
+            ),
+            (
+                "picture-ellipse-equation",
+                Some("outer-picture"),
+                HwpxVisualEquationDomain::PictureCaption,
+            ),
+            (
+                "picture-polygon-equation",
+                Some("outer-picture"),
+                HwpxVisualEquationDomain::PictureCaption,
+            ),
+            (
+                "group-rect-equation",
+                Some("outer-group-rect"),
+                HwpxVisualEquationDomain::GroupDrawText,
+            ),
+            (
+                "group-ellipse-equation",
+                Some("outer-group-rect"),
+                HwpxVisualEquationDomain::GroupDrawText,
+            ),
+            (
+                "group-polygon-equation",
+                Some("outer-group-rect"),
+                HwpxVisualEquationDomain::GroupDrawText,
+            ),
+        ]
+    );
+}
+
+#[test]
 fn visual_equations_report_traverses_header_and_footer_controls() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <ctrl><header id="header-1" applyPageType="BOTH"><subList><p paraPrIDRef="0"><run charPrIDRef="0">

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -289,6 +289,40 @@ fn visual_equations_compose_nested_shape_placement_and_rendering() {
 }
 
 #[test]
+fn visual_equations_traverse_table_caption_before_cells_in_picture_caption() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <pic id="outer-picture" instid="outer-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <tbl id="nested-table" rowCnt="1" colCnt="1">
+          <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="table-caption-equation"><script>caption</script></equation>
+          </run></p></subList></caption>
+          <tr><tc><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="table-cell-equation"><script>cell</script></equation>
+          </run></p></subList><cellAddr colAddr="0" rowAddr="0"/><cellSpan rowSpan="1" colSpan="1"/></tc></tr>
+        </tbl>
+      </run></p></subList></caption></pic>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let identities: Vec<(&str, Option<&str>, usize)> = report
+        .equations
+        .iter()
+        .map(|equation| {
+            (equation.id.as_str(), equation.parent_object_id.as_deref(), equation.parent_order)
+        })
+        .collect();
+    assert_eq!(
+        identities,
+        vec![
+            ("table-caption-equation", Some("outer-picture"), 0),
+            ("table-cell-equation", Some("outer-picture"), 1),
+        ]
+    );
+}
+
+#[test]
 fn visual_equations_traverse_visuals_nested_in_top_level_shape_text() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <rect id="top-rect"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -1032,6 +1032,54 @@ fn visual_equation_invalid_scale_preserves_geometry_and_raw_render_base_unit() {
 }
 
 #[test]
+fn visual_equation_nested_invalid_transforms_preserve_raw_geometry() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <pic id="invalid-outer-picture" instid="invalid-outer-picture-inst">
+        <renderingInfo><scaMatrix e1="not-a-number" e2="0" e3="NaN" e4="0" e5="2" e6="3"/></renderingInfo>
+        <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <pic id="nested-picture" instid="nested-picture-inst">
+            <renderingInfo><scaMatrix e1="4" e2="0" e3="11" e4="0" e5="5" e6="13"/></renderingInfo>
+            <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+              <equation id="invalid-ancestor-equation" baseUnit="20"><sz width="10" height="20"/><script>picture</script></equation>
+            </run></p></subList></caption>
+          </pic>
+        </run></p></subList></caption>
+      </pic>
+      <container instid="valid-outer-container"><rect id="valid-outer-rect" instid="valid-outer-rect-inst">
+        <renderingInfo><scaMatrix e1="2" e2="0" e3="5" e4="0" e5="3" e6="7"/></renderingInfo>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <container instid="invalid-nested-container"><rect id="invalid-nested-rect" instid="invalid-nested-rect-inst">
+            <orgSz width="30" height="40"/>
+            <renderingInfo><scaMatrix e1="Infinity" e2="0" e3="not-a-number" e4="0" e5="5" e6="13"/></renderingInfo>
+            <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+              <equation id="invalid-child-equation" baseUnit="20"><sz width="10" height="20"/><script>group</script></equation>
+            </run></p></subList></drawText>
+          </rect></container>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let invalid_ancestor = &report.equations[0];
+    assert_eq!(invalid_ancestor.geometry.raw_equation_size.unwrap().width, 10);
+    assert_eq!(invalid_ancestor.geometry.render_base_unit, Some(20));
+    assert_eq!(invalid_ancestor.geometry.scale.horz, "not-a-number");
+    assert_eq!(invalid_ancestor.geometry.display_equation_size, None);
+    assert_eq!(invalid_ancestor.translation.horz, "NaN");
+    assert_eq!(invalid_ancestor.display_position, None);
+
+    let invalid_child = &report.equations[1];
+    assert_eq!(invalid_child.geometry.raw_box_size.unwrap().width, 30);
+    assert_eq!(invalid_child.geometry.render_base_unit, Some(20));
+    assert_eq!(invalid_child.geometry.scale.horz, "Infinity");
+    assert_eq!(invalid_child.geometry.display_box_size, None);
+    assert_eq!(invalid_child.translation.horz, "not-a-number");
+    assert_eq!(invalid_child.display_position, None);
+}
+
+#[test]
 fn visual_equation_nesting_boundary_succeeds() {
     let section = nested_containers_section(32);
 

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -103,7 +103,7 @@ fn nested_table_controls_section(levels: usize) -> String {
 fn visual_equations_report_preserves_only_supported_visual_domains() {
     let (_document, report) = HwpxDecoder::decode_with_report(&visual_equations_fixture()).unwrap();
 
-    assert_eq!(report.schema_version, 1);
+    assert_eq!(report.schema_version, 2);
     assert_eq!(report.equations.len(), 2);
 
     let picture = &report.equations[0];
@@ -122,6 +122,14 @@ fn visual_equations_report_preserves_only_supported_visual_domains() {
     assert_eq!(picture.z_order, 31);
     assert_eq!(picture.position.horz_offset, 111);
     assert_eq!(picture.position.vert_offset, 112);
+    assert_eq!(picture.geometry.raw_box_size, None);
+    assert_eq!(picture.geometry.raw_equation_size, None);
+    assert_eq!(picture.geometry.raw_base_unit, None);
+    assert_eq!(picture.geometry.scale.horz, "1");
+    assert_eq!(picture.geometry.scale.vert, "1");
+    assert_eq!(picture.geometry.display_box_size, None);
+    assert_eq!(picture.geometry.display_equation_size, None);
+    assert_eq!(picture.geometry.display_base_unit, None);
     assert_eq!(picture.script, "{a} over {b}");
     assert_eq!(picture.latex, None);
 
@@ -138,12 +146,17 @@ fn visual_equations_report_preserves_only_supported_visual_domains() {
     assert_eq!(grouped.z_order, 42);
     assert_eq!(grouped.position.horz_offset, 201);
     assert_eq!(grouped.position.vert_offset, 202);
+    assert_eq!(grouped.geometry.raw_box_size, None);
+    assert_eq!(grouped.geometry.raw_equation_size, None);
+    assert_eq!(grouped.geometry.display_box_size, None);
+    assert_eq!(grouped.geometry.display_equation_size, None);
     assert_eq!(grouped.script, "x ^{2}");
     assert_eq!(grouped.latex, None);
 
     let serialized = serde_json::to_value(report).unwrap();
     assert_eq!(serialized["equations"][0]["equation_object_id"], "9007199254740997");
     assert_eq!(serialized["equations"][1]["parent_instance_id"], "9007199254741000");
+    assert!(serialized["equations"][0]["geometry"]["display_box_size"].is_null());
 }
 
 #[test]
@@ -246,6 +259,74 @@ fn visual_equation_group_position_adds_rect_placement_to_child_local_pos() {
         ],
         "group positions must combine rect placement with equation-local coordinates"
     );
+}
+
+#[test]
+fn visual_equation_group_geometry_applies_wire_scale_without_losing_raw_sizes() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst"><rect id="rect-1" instid="rect-inst" zOrder="41">
+        <offset x="18928" y="7966"/><orgSz width="8504" height="8504"/>
+        <renderingInfo>
+          <transMatrix e1="1" e2="0" e3="18928" e4="0" e5="1" e6="7966"/>
+          <scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <scaMatrix e1="0.242542" e2="0" e3="1381.427002" e4="0" e5="0.252211" e6="532.402954"/>
+          <rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </renderingInfo>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="scaled-label" baseUnit="1100"><sz width="607" height="1125"/><pos horzOffset="0" vertOffset="0"/><script>rm B</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    assert_eq!(report.schema_version, 2);
+    let geometry = &report.equations[0].geometry;
+    assert_eq!(geometry.raw_box_size.unwrap().width, 8504);
+    assert_eq!(geometry.raw_box_size.unwrap().height, 8504);
+    assert_eq!(geometry.raw_equation_size.unwrap().width, 607);
+    assert_eq!(geometry.raw_equation_size.unwrap().height, 1125);
+    assert_eq!(geometry.raw_base_unit, Some(1100));
+    assert_eq!(geometry.scale.horz, "0.242542");
+    assert_eq!(geometry.scale.vert, "0.252211");
+    assert_eq!(geometry.display_box_size.unwrap().width, 2063);
+    assert_eq!(geometry.display_box_size.unwrap().height, 2145);
+    assert_eq!(geometry.display_equation_size.unwrap().width, 147);
+    assert_eq!(geometry.display_equation_size.unwrap().height, 284);
+    assert_eq!(geometry.display_base_unit, Some(277));
+}
+
+#[test]
+fn visual_equation_invalid_scale_preserves_provenance_and_uses_explicit_null_display_values() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst"><rect id="rect-1" instid="rect-inst">
+        <orgSz width="8504" height="8504"/>
+        <renderingInfo><scaMatrix e1="not-a-number" e2="0" e3="0" e4="0" e5="-1" e6="0"/></renderingInfo>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="invalid-scale" baseUnit="1100"><sz width="607" height="1125"/><script>rm B</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let geometry = &report.equations[0].geometry;
+    assert_eq!(geometry.raw_box_size.unwrap().width, 8504);
+    assert_eq!(geometry.raw_equation_size.unwrap().height, 1125);
+    assert_eq!(geometry.raw_base_unit, Some(1100));
+    assert_eq!(geometry.scale.horz, "not-a-number");
+    assert_eq!(geometry.scale.vert, "-1");
+    assert_eq!(geometry.display_box_size, None);
+    assert_eq!(geometry.display_equation_size, None);
+    assert_eq!(geometry.display_base_unit, None);
+
+    let serialized = serde_json::to_value(report).unwrap();
+    assert!(serialized["equations"][0]["geometry"]["display_box_size"].is_null());
+    assert!(serialized["equations"][0]["geometry"]["display_equation_size"].is_null());
+    assert!(serialized["equations"][0]["geometry"]["display_base_unit"].is_null());
 }
 
 #[test]

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -186,6 +186,48 @@ fn visual_equations_preserve_interleaved_nested_container_order() {
 }
 
 #[test]
+fn visual_equations_report_traverses_header_and_footer_controls() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <ctrl><header id="header-1" applyPageType="BOTH"><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <pic id="header-picture" instid="header-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="header-equation"><script>header</script></equation>
+        </run></p></subList></caption></pic>
+      </run></p></subList></header></ctrl>
+      <ctrl><footer id="footer-1" applyPageType="BOTH"><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <container instid="footer-container"><rect id="footer-rect" instid="footer-rect-inst">
+          <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="footer-equation"><script>footer</script></equation>
+          </run></p></subList></drawText>
+        </rect></container>
+      </run></p></subList></footer></ctrl>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let ids: Vec<&str> = report.equations.iter().map(|equation| equation.id.as_str()).collect();
+    assert_eq!(ids, vec!["header-equation", "footer-equation"]);
+    assert!(report.equations[0].parent_path.contains("/header/"));
+    assert!(report.equations[1].parent_path.contains("/footer/"));
+}
+
+#[test]
+fn legacy_decode_ignores_visual_report_projection_overflow() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst"><rect id="overflow-rect" instid="overflow-rect-inst">
+        <offset x="2147483647" y="0"/>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="overflow-equation"><pos horzOffset="1" vertOffset="0"/><script>x</script></equation>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+    let fixture = fixture_with_section(section);
+
+    assert!(HwpxDecoder::decode(&fixture).is_ok());
+    assert!(HwpxDecoder::decode_with_report(&fixture).is_err());
+}
+
+#[test]
 fn visual_equation_explicit_zero_z_order_does_not_inherit_parent() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <container instid="group-inst"><rect id="rect-1" instid="rect-inst" zOrder="41">

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -160,6 +160,32 @@ fn visual_equations_report_preserves_only_supported_visual_domains() {
 }
 
 #[test]
+fn visual_equations_preserve_interleaved_nested_container_order() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="outer">
+        <container instid="nested-first"><rect id="nested-rect" instid="nested-rect-inst">
+          <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="nested-equation"><script>nested first</script></equation>
+          </run></p></subList></drawText>
+        </rect></container>
+        <rect id="sibling-rect" instid="sibling-rect-inst">
+          <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+            <equation id="sibling-equation"><script>sibling second</script></equation>
+          </run></p></subList></drawText>
+        </rect>
+      </container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let ids: Vec<&str> = report.equations.iter().map(|equation| equation.id.as_str()).collect();
+    assert_eq!(ids, vec!["nested-equation", "sibling-equation"]);
+    assert_eq!(report.equations[0].document_order, 0);
+    assert_eq!(report.equations[1].document_order, 1);
+}
+
+#[test]
 fn visual_equation_explicit_zero_z_order_does_not_inherit_parent() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <container instid="group-inst"><rect id="rect-1" instid="rect-inst" zOrder="41">

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -248,6 +248,61 @@ fn visual_equations_traverse_nested_shape_text_with_outer_visual_parent() {
 }
 
 #[test]
+fn visual_equations_traverse_visuals_nested_in_top_level_shape_text() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <rect id="top-rect"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <equation id="ordinary-rect-equation"><script>excluded rect text</script></equation>
+        <pic id="rect-picture" instid="rect-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="rect-picture-equation"><script>rp</script></equation>
+        </run></p></subList></caption></pic>
+      </run></p></subList></drawText></rect>
+      <ellipse id="top-ellipse"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <equation id="ordinary-ellipse-equation"><script>excluded ellipse text</script></equation>
+        <container instid="ellipse-container"><rect id="ellipse-group-rect" instid="ellipse-group-rect-inst"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="ellipse-group-equation"><script>eg</script></equation>
+        </run></p></subList></drawText></rect></container>
+      </run></p></subList></drawText></ellipse>
+      <polygon id="top-polygon"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+        <equation id="ordinary-polygon-equation"><script>excluded polygon text</script></equation>
+        <pic id="polygon-picture" instid="polygon-picture-inst"><caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="polygon-picture-equation"><script>pp</script></equation>
+        </run></p></subList></caption></pic>
+      </run></p></subList></drawText></polygon>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let identities: Vec<(&str, Option<&str>, HwpxVisualEquationDomain)> = report
+        .equations
+        .iter()
+        .map(|equation| {
+            (equation.id.as_str(), equation.parent_object_id.as_deref(), equation.domain)
+        })
+        .collect();
+    assert_eq!(
+        identities,
+        vec![
+            (
+                "rect-picture-equation",
+                Some("rect-picture"),
+                HwpxVisualEquationDomain::PictureCaption,
+            ),
+            (
+                "ellipse-group-equation",
+                Some("ellipse-group-rect"),
+                HwpxVisualEquationDomain::GroupDrawText,
+            ),
+            (
+                "polygon-picture-equation",
+                Some("polygon-picture"),
+                HwpxVisualEquationDomain::PictureCaption,
+            ),
+        ]
+    );
+}
+
+#[test]
 fn visual_equations_report_traverses_header_and_footer_controls() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <ctrl><header id="header-1" applyPageType="BOTH"><subList><p paraPrIDRef="0"><run charPrIDRef="0">

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -488,6 +488,152 @@ fn visual_equations_preserve_nested_visual_parent_and_interleaved_order() {
 }
 
 #[test]
+fn visual_equations_compose_ancestor_transform_into_nearer_nested_visual_parents() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <pic id="outer-picture" instid="outer-picture-inst">
+        <pos horzOffset="100" vertOffset="200"/>
+        <renderingInfo><scaMatrix e1="2" e2="0" e3="5" e4="0" e5="3" e6="7"/></renderingInfo>
+        <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <pic id="nested-picture" instid="nested-picture-inst">
+            <pos horzOffset="10" vertOffset="20"/>
+            <renderingInfo><scaMatrix e1="4" e2="0" e3="11" e4="0" e5="5" e6="13"/></renderingInfo>
+            <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+              <equation id="nested-picture-equation"><sz width="10" height="20"/><pos horzOffset="1" vertOffset="2"/><script>picture</script></equation>
+            </run></p></subList></caption>
+          </pic>
+          <container instid="nested-container"><pos horzOffset="30" vertOffset="40"/>
+            <rect id="nested-rect" instid="nested-rect-inst">
+              <offset x="4" y="5"/>
+              <orgSz width="30" height="40"/>
+              <renderingInfo><scaMatrix e1="6" e2="0" e3="17" e4="0" e5="7" e6="19"/></renderingInfo>
+              <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+                <equation id="nested-container-equation"><sz width="10" height="20"/><pos horzOffset="1" vertOffset="2"/><script>container</script></equation>
+              </run></p></subList></drawText>
+            </rect>
+          </container>
+        </run></p></subList></caption>
+      </pic>
+      <container instid="outer-container"><rect id="outer-rect" instid="outer-rect-inst">
+        <pos horzOffset="1000" vertOffset="2000"/>
+        <renderingInfo><scaMatrix e1="2" e2="0" e3="5" e4="0" e5="3" e6="7"/></renderingInfo>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <pic id="group-nested-picture" instid="group-nested-picture-inst">
+            <pos horzOffset="10" vertOffset="20"/>
+            <renderingInfo><scaMatrix e1="4" e2="0" e3="11" e4="0" e5="5" e6="13"/></renderingInfo>
+            <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+              <equation id="group-nested-picture-equation"><sz width="10" height="20"/><pos horzOffset="1" vertOffset="2"/><script>group picture</script></equation>
+            </run></p></subList></caption>
+          </pic>
+          <container instid="group-nested-container"><pos horzOffset="30" vertOffset="40"/>
+            <rect id="group-nested-rect" instid="group-nested-rect-inst">
+              <offset x="4" y="5"/>
+              <orgSz width="30" height="40"/>
+              <renderingInfo><scaMatrix e1="6" e2="0" e3="17" e4="0" e5="7" e6="19"/></renderingInfo>
+              <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+                <equation id="group-nested-container-equation"><sz width="10" height="20"/><pos horzOffset="1" vertOffset="2"/><script>group container</script></equation>
+              </run></p></subList></drawText>
+            </rect>
+          </container>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let nested_picture = &report.equations[0];
+    assert_eq!(nested_picture.parent_object_id.as_deref(), Some("nested-picture"));
+    assert_eq!(
+        (nested_picture.raw_position.horz_offset, nested_picture.raw_position.vert_offset,),
+        (111, 222)
+    );
+    assert_eq!(
+        (nested_picture.translation.horz.as_str(), nested_picture.translation.vert.as_str(),),
+        ("27", "46")
+    );
+    assert_eq!(
+        nested_picture
+            .display_position
+            .map(|position| { (position.horz_offset, position.vert_offset) }),
+        Some((138, 268))
+    );
+    assert_eq!(
+        (nested_picture.geometry.scale.horz.as_str(), nested_picture.geometry.scale.vert.as_str(),),
+        ("8", "15")
+    );
+
+    let nested_container = &report.equations[1];
+    assert_eq!(nested_container.parent_object_id.as_deref(), Some("nested-rect"));
+    assert_eq!(
+        (nested_container.raw_position.horz_offset, nested_container.raw_position.vert_offset,),
+        (135, 247)
+    );
+    assert_eq!(
+        (nested_container.translation.horz.as_str(), nested_container.translation.vert.as_str(),),
+        ("39", "64")
+    );
+    assert_eq!(
+        nested_container
+            .display_position
+            .map(|position| { (position.horz_offset, position.vert_offset) }),
+        Some((174, 311))
+    );
+    assert_eq!(
+        (
+            nested_container.geometry.scale.horz.as_str(),
+            nested_container.geometry.scale.vert.as_str(),
+        ),
+        ("12", "21")
+    );
+
+    let group_nested_picture = &report.equations[2];
+    assert_eq!(group_nested_picture.parent_object_id.as_deref(), Some("group-nested-picture"));
+    assert_eq!(
+        (
+            group_nested_picture.raw_position.horz_offset,
+            group_nested_picture.raw_position.vert_offset,
+        ),
+        (1011, 2022)
+    );
+    assert_eq!(
+        group_nested_picture
+            .display_position
+            .map(|position| { (position.horz_offset, position.vert_offset) }),
+        Some((1038, 2068))
+    );
+    assert_eq!(
+        (
+            group_nested_picture.geometry.scale.horz.as_str(),
+            group_nested_picture.geometry.scale.vert.as_str(),
+        ),
+        ("8", "15")
+    );
+
+    let group_nested_container = &report.equations[3];
+    assert_eq!(group_nested_container.parent_object_id.as_deref(), Some("group-nested-rect"));
+    assert_eq!(
+        (
+            group_nested_container.raw_position.horz_offset,
+            group_nested_container.raw_position.vert_offset,
+        ),
+        (1035, 2047)
+    );
+    assert_eq!(
+        group_nested_container
+            .display_position
+            .map(|position| { (position.horz_offset, position.vert_offset) }),
+        Some((1074, 2111))
+    );
+    assert_eq!(
+        (
+            group_nested_container.geometry.scale.horz.as_str(),
+            group_nested_container.geometry.scale.vert.as_str(),
+        ),
+        ("12", "21")
+    );
+}
+
+#[test]
 fn visual_equations_report_traverses_header_and_footer_controls() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <ctrl><header id="header-1" applyPageType="BOTH"><subList><p paraPrIDRef="0"><run charPrIDRef="0">

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -160,6 +160,35 @@ fn visual_equations_report_preserves_only_supported_visual_domains() {
 }
 
 #[test]
+fn visual_equations_apply_picture_rendering_to_caption_equations() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <pic id="scaled-picture" instid="scaled-picture-inst">
+        <renderingInfo><scaMatrix e1="2" e2="0" e3="5" e4="0" e5="3" e6="7"/></renderingInfo>
+        <caption><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <equation id="caption-equation"><sz width="10" height="20"/><pos horzOffset="1" vertOffset="2"/><script>caption</script></equation>
+        </run></p></subList></caption>
+      </pic>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let equation = &report.equations[0];
+    assert_eq!(
+        (equation.translation.horz.as_str(), equation.translation.vert.as_str()),
+        ("5", "7")
+    );
+    assert_eq!(
+        (equation.geometry.scale.horz.as_str(), equation.geometry.scale.vert.as_str()),
+        ("2", "3")
+    );
+    let display_position = equation.display_position.unwrap();
+    assert_eq!((display_position.horz_offset, display_position.vert_offset), (6, 9));
+    let display_size = equation.geometry.display_equation_size.unwrap();
+    assert_eq!((display_size.width, display_size.height), (20, 60));
+}
+
+#[test]
 fn visual_equations_preserve_interleaved_nested_container_order() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <container instid="outer">

--- a/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/visual_equations.rs
@@ -248,6 +248,47 @@ fn visual_equations_traverse_nested_shape_text_with_outer_visual_parent() {
 }
 
 #[test]
+fn visual_equations_compose_nested_shape_placement_and_rendering() {
+    let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
+      <container instid="group-inst"><rect id="outer-rect" instid="outer-rect-inst">
+        <pos horzOffset="100" vertOffset="200"/>
+        <orgSz width="50" height="60"/>
+        <renderingInfo><scaMatrix e1="2" e2="0" e3="5" e4="0" e5="3" e6="7"/></renderingInfo>
+        <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+          <ellipse id="nested-ellipse">
+            <offset x="10" y="20"/>
+            <orgSz width="30" height="40"/>
+            <renderingInfo><scaMatrix e1="4" e2="0" e3="11" e4="0" e5="5" e6="13"/></renderingInfo>
+            <drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">
+              <equation id="nested-equation"><sz width="10" height="20"/><pos horzOffset="1" vertOffset="2"/><script>nested</script></equation>
+            </run></p></subList></drawText>
+          </ellipse>
+        </run></p></subList></drawText>
+      </rect></container>
+    </run></p></sec>"#;
+
+    let (_document, report) =
+        HwpxDecoder::decode_with_report(&fixture_with_section(section)).unwrap();
+
+    let equation = &report.equations[0];
+    assert_eq!(equation.parent_object_id.as_deref(), Some("outer-rect"));
+    assert_eq!((equation.raw_position.horz_offset, equation.raw_position.vert_offset), (111, 222));
+    assert_eq!(
+        (equation.translation.horz.as_str(), equation.translation.vert.as_str()),
+        ("27", "46")
+    );
+    let display = equation.display_position.unwrap();
+    assert_eq!((display.horz_offset, display.vert_offset), (138, 268));
+    assert_eq!(
+        (equation.geometry.scale.horz.as_str(), equation.geometry.scale.vert.as_str()),
+        ("8", "15")
+    );
+    assert_eq!(equation.geometry.raw_box_size.unwrap().width, 30);
+    assert_eq!(equation.geometry.display_box_size.unwrap().width, 240);
+    assert_eq!(equation.geometry.display_equation_size.unwrap().height, 300);
+}
+
+#[test]
 fn visual_equations_traverse_visuals_nested_in_top_level_shape_text() {
     let section = r#"<sec><p id="1" paraPrIDRef="0" styleIDRef="0"><run charPrIDRef="0">
       <rect id="top-rect"><drawText><subList><p paraPrIDRef="0"><run charPrIDRef="0">

--- a/crates/hwpforge-smithy-md/src/encoder/styled.rs
+++ b/crates/hwpforge-smithy-md/src/encoder/styled.rs
@@ -51,17 +51,29 @@ impl FootnoteCollector {
         Self { footnotes: Vec::new(), endnotes: Vec::new() }
     }
 
-    /// Adds a footnote body and returns the inline marker `[^N]`.
-    fn add_footnote(&mut self, body: &str) -> String {
+    /// Reserves a footnote number before recursively encoding its body.
+    fn reserve_footnote(&mut self) -> usize {
         let n = self.footnotes.len() + 1;
-        self.footnotes.push(body.to_string());
+        self.footnotes.push(String::new());
+        n
+    }
+
+    /// Fills a reserved footnote body and returns the inline marker `[^N]`.
+    fn complete_footnote(&mut self, n: usize, body: &str) -> String {
+        self.footnotes[n - 1] = body.to_string();
         format!("[^{n}]")
     }
 
-    /// Adds an endnote body and returns the inline marker `[^eN]`.
-    fn add_endnote(&mut self, body: &str) -> String {
+    /// Reserves an endnote number before recursively encoding its body.
+    fn reserve_endnote(&mut self) -> usize {
         let n = self.endnotes.len() + 1;
-        self.endnotes.push(body.to_string());
+        self.endnotes.push(String::new());
+        n
+    }
+
+    /// Fills a reserved endnote body and returns the inline marker `[^eN]`.
+    fn complete_endnote(&mut self, n: usize, body: &str) -> String {
+        self.endnotes[n - 1] = body.to_string();
         format!("[^e{n}]")
     }
 
@@ -371,12 +383,14 @@ fn encode_control_styled(
             }
         }
         Control::Footnote { paragraphs, .. } => {
+            let number = footnotes.reserve_footnote();
             let body = encode_nested_paragraphs(paragraphs, styles, images, footnotes);
-            footnotes.add_footnote(body.trim())
+            footnotes.complete_footnote(number, body.trim())
         }
         Control::Endnote { paragraphs, .. } => {
+            let number = footnotes.reserve_endnote();
             let body = encode_nested_paragraphs(paragraphs, styles, images, footnotes);
-            footnotes.add_endnote(body.trim())
+            footnotes.complete_endnote(number, body.trim())
         }
         Control::TextBox { paragraphs, .. } => {
             let body = encode_nested_paragraphs(paragraphs, styles, images, footnotes);
@@ -1654,6 +1668,64 @@ mod tests {
 
         let output = encode_styled(&doc, &styles);
         assert_eq!(output.markdown, "[^e1]\n\n[^e1]: end body");
+    }
+
+    #[test]
+    fn nested_footnote_numbers_follow_visible_reference_order() {
+        let inner_body = Paragraph::with_runs(
+            vec![Run::text("inner", CharShapeIndex::new(0))],
+            ParaShapeIndex::new(0),
+        );
+        let outer_body = Paragraph::with_runs(
+            vec![
+                Run::text("outer ", CharShapeIndex::new(0)),
+                Run::control(
+                    Control::Footnote { inst_id: None, paragraphs: vec![inner_body] },
+                    CharShapeIndex::new(0),
+                ),
+            ],
+            ParaShapeIndex::new(0),
+        );
+        let doc = validated_document(vec![Paragraph::with_runs(
+            vec![Run::control(
+                Control::Footnote { inst_id: None, paragraphs: vec![outer_body] },
+                CharShapeIndex::new(0),
+            )],
+            ParaShapeIndex::new(0),
+        )]);
+
+        let output = encode_styled(&doc, &MockStyles::new());
+
+        assert_eq!(output.markdown, "[^1]\n\n[^1]: outer [^2]\n[^2]: inner");
+    }
+
+    #[test]
+    fn nested_endnote_numbers_follow_visible_reference_order() {
+        let inner_body = Paragraph::with_runs(
+            vec![Run::text("inner", CharShapeIndex::new(0))],
+            ParaShapeIndex::new(0),
+        );
+        let outer_body = Paragraph::with_runs(
+            vec![
+                Run::text("outer ", CharShapeIndex::new(0)),
+                Run::control(
+                    Control::Endnote { inst_id: None, paragraphs: vec![inner_body] },
+                    CharShapeIndex::new(0),
+                ),
+            ],
+            ParaShapeIndex::new(0),
+        );
+        let doc = validated_document(vec![Paragraph::with_runs(
+            vec![Run::control(
+                Control::Endnote { inst_id: None, paragraphs: vec![outer_body] },
+                CharShapeIndex::new(0),
+            )],
+            ParaShapeIndex::new(0),
+        )]);
+
+        let output = encode_styled(&doc, &MockStyles::new());
+
+        assert_eq!(output.markdown, "[^e1]\n\n[^e1]: outer [^e2]\n[^e2]: inner");
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/encoder/styled.rs
+++ b/crates/hwpforge-smithy-md/src/encoder/styled.rs
@@ -437,7 +437,11 @@ fn encode_control_styled(
             String::new()
         }
         Control::Memo { content, .. } => {
-            let body = encode_nested_paragraphs(content, styles, images, footnotes);
+            // Memo content is hidden inside an HTML comment. Keep note
+            // registrations local as well, otherwise an invisible memo
+            // reference leaks its body into document-level definitions.
+            let mut memo_footnotes = FootnoteCollector::new();
+            let body = encode_nested_paragraphs(content, styles, images, &mut memo_footnotes);
             let trimmed = body.trim();
             if trimmed.is_empty() {
                 String::new()
@@ -2483,6 +2487,56 @@ mod tests {
             output.markdown
         );
         assert!(output.markdown.contains("memo note"));
+    }
+
+    #[test]
+    fn control_memo_discards_nested_footnote_definitions() {
+        use hwpforge_core::control::MemoMetadata;
+        let hidden_footnote = Paragraph::with_runs(
+            vec![Run::control(
+                Control::Footnote {
+                    inst_id: None,
+                    paragraphs: vec![Paragraph::with_runs(
+                        vec![Run::text("secret memo footnote", CharShapeIndex::new(0))],
+                        ParaShapeIndex::new(0),
+                    )],
+                },
+                CharShapeIndex::new(0),
+            )],
+            ParaShapeIndex::new(0),
+        );
+        let visible_footnote = Paragraph::with_runs(
+            vec![Run::control(
+                Control::Footnote {
+                    inst_id: None,
+                    paragraphs: vec![Paragraph::with_runs(
+                        vec![Run::text("visible footnote", CharShapeIndex::new(0))],
+                        ParaShapeIndex::new(0),
+                    )],
+                },
+                CharShapeIndex::new(0),
+            )],
+            ParaShapeIndex::new(0),
+        );
+        let doc = validated_document(vec![
+            Paragraph::with_runs(
+                vec![Run::control(
+                    Control::Memo {
+                        content: vec![hidden_footnote],
+                        anchor_runs: vec![],
+                        metadata: MemoMetadata::default(),
+                    },
+                    CharShapeIndex::new(0),
+                )],
+                ParaShapeIndex::new(0),
+            ),
+            visible_footnote,
+        ]);
+
+        let output = encode_styled(&doc, &MockStyles::new());
+        assert!(!output.markdown.contains("secret memo footnote"));
+        assert!(output.markdown.contains("[^1]: visible footnote"));
+        assert!(!output.markdown.contains("[^2]:"));
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/encoder/styled.rs
+++ b/crates/hwpforge-smithy-md/src/encoder/styled.rs
@@ -349,7 +349,7 @@ fn paragraph_text_styled(
 fn encode_control_styled(
     control: &Control,
     styles: &dyn StyleLookup,
-    _images: &mut HashMap<String, Vec<u8>>,
+    images: &mut HashMap<String, Vec<u8>>,
     footnotes: &mut FootnoteCollector,
 ) -> String {
     match control {
@@ -371,38 +371,22 @@ fn encode_control_styled(
             }
         }
         Control::Footnote { paragraphs, .. } => {
-            let body = paragraphs
-                .iter()
-                .map(|p| extract_paragraph_text(p, styles))
-                .collect::<Vec<_>>()
-                .join(" ");
+            let body = encode_nested_paragraphs(paragraphs, styles, images, footnotes);
             footnotes.add_footnote(body.trim())
         }
         Control::Endnote { paragraphs, .. } => {
-            let body = paragraphs
-                .iter()
-                .map(|p| extract_paragraph_text(p, styles))
-                .collect::<Vec<_>>()
-                .join(" ");
+            let body = encode_nested_paragraphs(paragraphs, styles, images, footnotes);
             footnotes.add_endnote(body.trim())
         }
         Control::TextBox { paragraphs, .. } => {
-            let body = paragraphs
-                .iter()
-                .map(|p| extract_paragraph_text(p, styles))
-                .collect::<Vec<_>>()
-                .join(" ");
+            let body = encode_nested_paragraphs(paragraphs, styles, images, footnotes);
             body.trim().to_string()
         }
         Control::Equation { script, .. } => eqn_to_latex(script),
         Control::Chart { .. } => "<!-- chart -->".to_string(),
         Control::Line { .. } => String::new(),
         Control::Ellipse { paragraphs, .. } | Control::Polygon { paragraphs, .. } => {
-            let body = paragraphs
-                .iter()
-                .map(|p| extract_paragraph_text(p, styles))
-                .collect::<Vec<_>>()
-                .join(" ");
+            let body = encode_nested_paragraphs(paragraphs, styles, images, footnotes);
             if body.trim().is_empty() {
                 String::new()
             } else {
@@ -439,11 +423,7 @@ fn encode_control_styled(
             String::new()
         }
         Control::Memo { content, .. } => {
-            let body = content
-                .iter()
-                .map(|p| extract_paragraph_text(p, styles))
-                .collect::<Vec<_>>()
-                .join(" ");
+            let body = encode_nested_paragraphs(content, styles, images, footnotes);
             let trimmed = body.trim();
             if trimmed.is_empty() {
                 String::new()
@@ -468,17 +448,24 @@ fn encode_control_styled(
     }
 }
 
-/// Recursively extracts plain text from a paragraph using style-aware formatting.
-///
-/// Note: Uses a local `FootnoteCollector`, so footnotes nested inside control
-/// bodies (e.g. footnote inside a TextBox) will not propagate to the document-level
-/// collector. This is acceptable because HWP rarely nests footnotes inside shapes,
-/// and threading the collector through all recursive paths would require significant
-/// refactoring for marginal benefit.
-fn extract_paragraph_text(paragraph: &Paragraph, styles: &dyn StyleLookup) -> String {
-    let mut dummy = FootnoteCollector::new();
-    let (text, _images) = paragraph_text_styled(paragraph, styles, &mut dummy);
-    text
+/// Encodes paragraphs nested in controls while retaining their extracted images
+/// and any nested footnote/endnote definitions in the document-level collectors.
+fn encode_nested_paragraphs(
+    paragraphs: &[Paragraph],
+    styles: &dyn StyleLookup,
+    images: &mut HashMap<String, Vec<u8>>,
+    footnotes: &mut FootnoteCollector,
+) -> String {
+    paragraphs
+        .iter()
+        .map(|paragraph| {
+            let (markdown, paragraph_images) =
+                encode_paragraph_styled(paragraph, styles, footnotes);
+            images.extend(paragraph_images);
+            markdown
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 // ---------------------------------------------------------------------------
@@ -1668,6 +1655,36 @@ mod tests {
 
         let output = encode_styled(&doc, &styles);
         assert_eq!(output.markdown, "[^e1]\n\n[^e1]: end body");
+    }
+
+    #[test]
+    fn control_endnote_extracts_nested_images() {
+        let mut styles = MockStyles::new();
+        styles.image_data.insert("BinData/graph.png".to_string(), vec![0x89, 0x50, 0x4E]);
+        let graph = Image::new(
+            "BinData/graph.png",
+            HwpUnit::from_mm(40.0).unwrap(),
+            HwpUnit::from_mm(30.0).unwrap(),
+            ImageFormat::Png,
+        );
+        let endnote_body = Paragraph::with_runs(
+            vec![
+                Run::text("solution", CharShapeIndex::new(0)),
+                Run::image(graph, CharShapeIndex::new(0)),
+            ],
+            ParaShapeIndex::new(0),
+        );
+        let doc = validated_document(vec![Paragraph::with_runs(
+            vec![Run::control(
+                Control::Endnote { inst_id: None, paragraphs: vec![endnote_body] },
+                CharShapeIndex::new(0),
+            )],
+            ParaShapeIndex::new(0),
+        )]);
+
+        let output = encode_styled(&doc, &styles);
+        assert_eq!(output.markdown, "[^e1]\n\n[^e1]: solution ![graph](images/graph.png)");
+        assert_eq!(output.images.get("images/graph.png"), Some(&vec![0x89, 0x50, 0x4E]));
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/encoder/styled.rs
+++ b/crates/hwpforge-smithy-md/src/encoder/styled.rs
@@ -459,8 +459,7 @@ fn encode_nested_paragraphs(
     paragraphs
         .iter()
         .map(|paragraph| {
-            let (markdown, paragraph_images) =
-                encode_paragraph_styled(paragraph, styles, footnotes);
+            let (markdown, paragraph_images) = paragraph_text_styled(paragraph, styles, footnotes);
             images.extend(paragraph_images);
             markdown
         })
@@ -1713,6 +1712,51 @@ mod tests {
 
         let output = encode_styled(&doc, &styles);
         assert_eq!(output.markdown, "box content");
+    }
+
+    #[test]
+    fn nested_control_paragraph_styles_remain_inline() {
+        let textbox_body = Paragraph::with_runs(
+            vec![Run::text("box heading", CharShapeIndex::new(0))],
+            ParaShapeIndex::new(1),
+        );
+        let footnote_body = Paragraph::with_runs(
+            vec![Run::text("note item", CharShapeIndex::new(0))],
+            ParaShapeIndex::new(2),
+        );
+        let doc = validated_document(vec![Paragraph::with_runs(
+            vec![
+                Run::control(
+                    Control::TextBox {
+                        paragraphs: vec![textbox_body],
+                        width: HwpUnit::from_mm(80.0).unwrap(),
+                        height: HwpUnit::from_mm(40.0).unwrap(),
+                        horz_offset: 0,
+                        vert_offset: 0,
+                        caption: None,
+                        style: None,
+                        text_vertical_align: hwpforge_foundation::VerticalAlign::Top,
+                    },
+                    CharShapeIndex::new(0),
+                ),
+                Run::text(" ", CharShapeIndex::new(0)),
+                Run::control(
+                    Control::Footnote { inst_id: None, paragraphs: vec![footnote_body] },
+                    CharShapeIndex::new(0),
+                ),
+            ],
+            ParaShapeIndex::new(0),
+        )]);
+        let mut styles = MockStyles::new();
+        styles.heading_paras.insert(1, 1);
+        styles.list_para_types.insert(2, "bullet");
+        styles.list_para_levels.insert(2, 0);
+
+        let output = encode_styled(&doc, &styles);
+
+        assert_eq!(output.markdown, "box heading [^1]\n\n[^1]: note item");
+        assert!(!output.markdown.contains("# box heading"));
+        assert!(!output.markdown.contains("[^1]: - note item"));
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/encoder/styled.rs
+++ b/crates/hwpforge-smithy-md/src/encoder/styled.rs
@@ -441,7 +441,9 @@ fn encode_control_styled(
             // registrations local as well, otherwise an invisible memo
             // reference leaks its body into document-level definitions.
             let mut memo_footnotes = FootnoteCollector::new();
-            let body = encode_nested_paragraphs(content, styles, images, &mut memo_footnotes);
+            let mut memo_images = HashMap::new();
+            let body =
+                encode_nested_paragraphs(content, styles, &mut memo_images, &mut memo_footnotes);
             let trimmed = body.trim();
             if trimmed.is_empty() {
                 String::new()
@@ -2537,6 +2539,39 @@ mod tests {
         assert!(!output.markdown.contains("secret memo footnote"));
         assert!(output.markdown.contains("[^1]: visible footnote"));
         assert!(!output.markdown.contains("[^2]:"));
+    }
+
+    #[test]
+    fn control_memo_discards_nested_image_artifacts() {
+        use hwpforge_core::control::MemoMetadata;
+
+        let mut styles = MockStyles::new();
+        styles.image_data.insert("BinData/secret.png".to_string(), vec![0x89, 0x50, 0x4E]);
+        let image = Image::new(
+            "BinData/secret.png",
+            HwpUnit::from_mm(40.0).unwrap(),
+            HwpUnit::from_mm(30.0).unwrap(),
+            ImageFormat::Png,
+        );
+        let memo_body = Paragraph::with_runs(
+            vec![Run::image(image, CharShapeIndex::new(0))],
+            ParaShapeIndex::new(0),
+        );
+        let doc = validated_document(vec![Paragraph::with_runs(
+            vec![Run::control(
+                Control::Memo {
+                    content: vec![memo_body],
+                    anchor_runs: vec![],
+                    metadata: MemoMetadata::default(),
+                },
+                CharShapeIndex::new(0),
+            )],
+            ParaShapeIndex::new(0),
+        )]);
+
+        let output = encode_styled(&doc, &styles);
+        assert!(output.markdown.contains("![secret](images/secret.png)"));
+        assert!(output.images.is_empty(), "memo images must remain local to the memo body");
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/eqn/lexer.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/lexer.rs
@@ -185,10 +185,6 @@ const UPPERCASE_COMMANDS: &[(&str, &str)] = &[
     ("SIM", "sim"),
 ];
 
-/// Lowercase commands observed attached directly to their operand.
-const ATTACHED_COMMAND_PREFIXES: &[&str] =
-    &["sqrt", "bold", "cdots", "over", "bar", "box", "rm", "it"];
-
 fn push_identifier_tokens(word: &str, tokens: &mut Vec<Token>) {
     if word.is_empty() {
         return;
@@ -223,14 +219,6 @@ fn push_identifier_tokens(word: &str, tokens: &mut Vec<Token>) {
         }
         tokens.push(Token::Keyword(canonical.to_string()));
         push_identifier_tokens(&word[index + source.len()..], tokens);
-        return;
-    }
-
-    if let Some(prefix) = ATTACHED_COMMAND_PREFIXES.iter().find(|prefix| {
-        word.strip_prefix(**prefix).is_some_and(|suffix| suffix.chars().count() == 1)
-    }) {
-        tokens.push(Token::Keyword((*prefix).to_string()));
-        push_identifier_tokens(&word[prefix.len()..], tokens);
         return;
     }
 
@@ -452,19 +440,23 @@ mod tests {
     #[test]
     fn ordinary_lowercase_identifiers_do_not_match_command_prefixes() {
         assert_eq!(
-            tokenize("item+barometer"),
+            tokenize("item+barometer+bars+its"),
             vec![
                 Token::Text("item".into()),
                 Token::Text("+".into()),
                 Token::Text("barometer".into()),
+                Token::Text("+".into()),
+                Token::Text("bars".into()),
+                Token::Text("+".into()),
+                Token::Text("its".into()),
             ]
         );
     }
 
     #[test]
-    fn tokenize_attached_root_accent_fraction_and_style_commands() {
+    fn tokenize_root_accent_fraction_and_style_commands_at_boundaries() {
         assert_eq!(
-            tokenize("sqrta+barz+3 overk+rmO+itf"),
+            tokenize("sqrt a+bar z+3 over k+rm O+it f"),
             vec![
                 Token::Keyword("sqrt".into()),
                 Token::Text("a".into()),
@@ -481,6 +473,20 @@ mod tests {
                 Token::Text("+".into()),
                 Token::Keyword("it".into()),
                 Token::Text("f".into()),
+            ]
+        );
+        assert_eq!(
+            tokenize("sqrta+barz+overk+rmO+itf"),
+            vec![
+                Token::Text("sqrta".into()),
+                Token::Text("+".into()),
+                Token::Text("barz".into()),
+                Token::Text("+".into()),
+                Token::Text("overk".into()),
+                Token::Text("+".into()),
+                Token::Text("rmO".into()),
+                Token::Text("+".into()),
+                Token::Text("itf".into()),
             ]
         );
     }

--- a/crates/hwpforge-smithy-md/src/eqn/lexer.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/lexer.rs
@@ -226,10 +226,9 @@ fn push_identifier_tokens(word: &str, tokens: &mut Vec<Token>) {
         return;
     }
 
-    if let Some(prefix) = ATTACHED_COMMAND_PREFIXES
-        .iter()
-        .find(|prefix| word.len() > prefix.len() && word.starts_with(**prefix))
-    {
+    if let Some(prefix) = ATTACHED_COMMAND_PREFIXES.iter().find(|prefix| {
+        word.strip_prefix(**prefix).is_some_and(|suffix| suffix.chars().count() == 1)
+    }) {
         tokens.push(Token::Keyword((*prefix).to_string()));
         push_identifier_tokens(&word[prefix.len()..], tokens);
         return;
@@ -448,6 +447,18 @@ mod tests {
     #[test]
     fn ordinary_uppercase_identifiers_do_not_match_command_substrings() {
         assert_eq!(tokenize("SIMPLE"), vec![Token::Text("SIMPLE".into())]);
+    }
+
+    #[test]
+    fn ordinary_lowercase_identifiers_do_not_match_command_prefixes() {
+        assert_eq!(
+            tokenize("item+barometer"),
+            vec![
+                Token::Text("item".into()),
+                Token::Text("+".into()),
+                Token::Text("barometer".into()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/eqn/lexer.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/lexer.rs
@@ -282,6 +282,38 @@ pub(crate) fn tokenize(input: &str) -> Vec<Token> {
                 tokens.push(Token::Keyword("!=".to_string()));
                 i += 2;
             }
+            '\\' => {
+                if i + 1 >= chars.len() {
+                    tokens.push(Token::Text("\\".to_string()));
+                    i += 1;
+                    continue;
+                }
+
+                if chars[i + 1].is_ascii_alphabetic() {
+                    let mut command_end = i + 1;
+                    while command_end < chars.len() && chars[command_end].is_ascii_alphabetic() {
+                        command_end += 1;
+                    }
+                    if command_end == i + 2 {
+                        // HancomEQN uses `\A`-style escapes for literal Latin
+                        // labels. Skip only the escape marker and let the
+                        // ordinary identifier path consume the operand.
+                        i += 1;
+                    } else {
+                        // Preserve multi-letter LaTeX commands as one token so
+                        // known Hancom keywords do not add a second backslash.
+                        tokens.push(Token::Text(chars[i..command_end].iter().collect()));
+                        i = command_end;
+                    }
+                    continue;
+                }
+
+                // Keep symbolic LaTeX escapes (`\{`, `\_`, `\\`, and so on)
+                // together so their second character is not parsed as
+                // HancomEQN structure.
+                tokens.push(Token::Text(chars[i..=i + 1].iter().collect()));
+                i += 2;
+            }
             // Identifier or keyword
             c if c.is_alphabetic() => {
                 let start = i;

--- a/crates/hwpforge-smithy-md/src/eqn/lexer.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/lexer.rs
@@ -170,8 +170,10 @@ fn is_keyword(s: &str) -> bool {
 
 /// Uppercase commands commonly emitted by Hancom equation editors.
 ///
-/// HancomEQN permits commands to be attached to adjacent identifiers
-/// (`PLEFT`, `THEREFOREk`) rather than separated by whitespace.
+/// HancomEQN permits commands to be attached to following operands when a
+/// case transition provides a boundary (`THEREFOREk`). A preceding operand
+/// requires a real token boundary (`P LEFT`) so ordinary identifiers remain
+/// indivisible.
 const UPPERCASE_COMMANDS: &[(&str, &str)] = &[
     ("THEREFORE", "therefore"),
     ("BECAUSE", "because"),
@@ -198,27 +200,15 @@ fn push_identifier_tokens(word: &str, tokens: &mut Vec<Token>) {
         return;
     }
 
-    let uppercase_match = UPPERCASE_COMMANDS.iter().find_map(|(source, canonical)| {
+    let attached_operand = UPPERCASE_COMMANDS.iter().find_map(|(source, canonical)| {
         let attached_operand = word
             .strip_prefix(source)
             .filter(|suffix| suffix.chars().next().is_some_and(|next| !next.is_ascii_uppercase()));
-        if attached_operand.is_some() {
-            return Some((0, *source, *canonical));
-        }
-
-        let attached_command = word.strip_suffix(source).filter(|prefix| {
-            let mut characters = prefix.chars();
-            characters.next().is_some_and(|first| first.is_ascii_alphabetic())
-                && characters.next().is_none()
-        });
-        attached_command.map(|prefix| (prefix.len(), *source, *canonical))
+        attached_operand.map(|_| (*source, *canonical))
     });
-    if let Some((index, source, canonical)) = uppercase_match {
-        if index > 0 {
-            push_identifier_tokens(&word[..index], tokens);
-        }
+    if let Some((source, canonical)) = attached_operand {
         tokens.push(Token::Keyword(canonical.to_string()));
-        push_identifier_tokens(&word[index + source.len()..], tokens);
+        push_identifier_tokens(&word[source.len()..], tokens);
         return;
     }
 
@@ -411,7 +401,7 @@ mod tests {
     #[test]
     fn tokenize_uppercase_and_attached_hancom_commands() {
         assert_eq!(
-            tokenize("PLEFT(x RIGHT),~THEREFOREk LEQ 1 TIMES 2 CDOTS"),
+            tokenize("P LEFT(x RIGHT),~THEREFOREk LEQ 1 TIMES 2 CDOTS"),
             vec![
                 Token::Text("P".into()),
                 Token::Keyword("left".into()),
@@ -434,7 +424,16 @@ mod tests {
 
     #[test]
     fn ordinary_uppercase_identifiers_do_not_match_command_substrings() {
-        assert_eq!(tokenize("SIMPLE"), vec![Token::Text("SIMPLE".into())]);
+        assert_eq!(
+            tokenize("SIMPLE+BRIGHT+CLEFT"),
+            vec![
+                Token::Text("SIMPLE".into()),
+                Token::Text("+".into()),
+                Token::Text("BRIGHT".into()),
+                Token::Text("+".into()),
+                Token::Text("CLEFT".into()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/eqn/lexer.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/lexer.rs
@@ -34,6 +34,11 @@ static KEYWORDS: &[&str] = &[
     "right",
     "matrix",
     "cases",
+    // Hancom font/style switches
+    "rm",
+    "it",
+    "bold",
+    "box",
     // Accents
     "vec",
     "hat",
@@ -58,6 +63,12 @@ static KEYWORDS: &[&str] = &[
     "leq",
     "geq",
     "neq",
+    "le",
+    "ge",
+    "ne",
+    "lt",
+    "gt",
+    "sim",
     // Arrows
     "rightarrow",
     "leftarrow",
@@ -157,6 +168,67 @@ fn is_keyword(s: &str) -> bool {
     KEYWORDS.contains(&s)
 }
 
+/// Uppercase commands commonly emitted by Hancom equation editors.
+///
+/// HancomEQN permits commands to be attached to adjacent identifiers
+/// (`PLEFT`, `THEREFOREk`) rather than separated by whitespace.
+const UPPERCASE_COMMANDS: &[(&str, &str)] = &[
+    ("THEREFORE", "therefore"),
+    ("BECAUSE", "because"),
+    ("TIMES", "times"),
+    ("CDOTS", "cdots"),
+    ("RIGHT", "right"),
+    ("LEFT", "left"),
+    ("LEQ", "leq"),
+    ("GEQ", "geq"),
+    ("NEQ", "neq"),
+    ("SIM", "sim"),
+];
+
+/// Lowercase commands observed attached directly to their operand.
+const ATTACHED_COMMAND_PREFIXES: &[&str] =
+    &["sqrt", "bold", "cdots", "over", "bar", "box", "rm", "it"];
+
+fn push_identifier_tokens(word: &str, tokens: &mut Vec<Token>) {
+    if word.is_empty() {
+        return;
+    }
+    if is_keyword(word) {
+        tokens.push(Token::Keyword(word.to_string()));
+        return;
+    }
+    if let Some((_, canonical)) = UPPERCASE_COMMANDS.iter().find(|(source, _)| word == *source) {
+        tokens.push(Token::Keyword((*canonical).to_string()));
+        return;
+    }
+
+    let uppercase_match = UPPERCASE_COMMANDS
+        .iter()
+        .filter_map(|(source, canonical)| {
+            word.find(source).map(|index| (index, *source, *canonical))
+        })
+        .min_by_key(|(index, _, _)| *index);
+    if let Some((index, source, canonical)) = uppercase_match {
+        if index > 0 {
+            push_identifier_tokens(&word[..index], tokens);
+        }
+        tokens.push(Token::Keyword(canonical.to_string()));
+        push_identifier_tokens(&word[index + source.len()..], tokens);
+        return;
+    }
+
+    if let Some(prefix) = ATTACHED_COMMAND_PREFIXES
+        .iter()
+        .find(|prefix| word.len() > prefix.len() && word.starts_with(**prefix))
+    {
+        tokens.push(Token::Keyword((*prefix).to_string()));
+        push_identifier_tokens(&word[prefix.len()..], tokens);
+        return;
+    }
+
+    tokens.push(Token::Text(word.to_string()));
+}
+
 /// Tokenizes a HancomEQN script into a flat token stream.
 pub(crate) fn tokenize(input: &str) -> Vec<Token> {
     let mut tokens = Vec::new();
@@ -165,8 +237,9 @@ pub(crate) fn tokenize(input: &str) -> Vec<Token> {
 
     while i < chars.len() {
         match chars[i] {
-            // Skip plain whitespace — preserve one space as Text(" ")
-            ' ' | '\t' | '\n' | '\r' => {
+            // Hancom uses backticks as visual spacing markers. LaTeX spacing is
+            // reconstructed by the parser, so they must not leak into output.
+            ' ' | '\t' | '\n' | '\r' | '`' => {
                 i += 1;
             }
             '{' => {
@@ -216,11 +289,7 @@ pub(crate) fn tokenize(input: &str) -> Vec<Token> {
                     i += 1;
                 }
                 let word: String = chars[start..i].iter().collect();
-                if is_keyword(&word) {
-                    tokens.push(Token::Keyword(word));
-                } else {
-                    tokens.push(Token::Text(word));
-                }
+                push_identifier_tokens(&word, &mut tokens);
             }
             // Numbers
             c if c.is_ascii_digit() => {
@@ -299,6 +368,62 @@ mod tests {
                 Token::Hash,
                 Token::Hash,
                 Token::Text("c".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenize_hancom_spacing_markers_as_whitespace() {
+        assert_eq!(
+            tokenize("a,````b`"),
+            vec![Token::Text("a".into()), Token::Text(",".into()), Token::Text("b".into()),]
+        );
+    }
+
+    #[test]
+    fn tokenize_uppercase_and_attached_hancom_commands() {
+        assert_eq!(
+            tokenize("PLEFT(x RIGHT),~THEREFOREk LEQ 1 TIMES 2 CDOTS"),
+            vec![
+                Token::Text("P".into()),
+                Token::Keyword("left".into()),
+                Token::Text("(".into()),
+                Token::Text("x".into()),
+                Token::Keyword("right".into()),
+                Token::Text(")".into()),
+                Token::Text(",".into()),
+                Token::Text("~".into()),
+                Token::Keyword("therefore".into()),
+                Token::Text("k".into()),
+                Token::Keyword("leq".into()),
+                Token::Text("1".into()),
+                Token::Keyword("times".into()),
+                Token::Text("2".into()),
+                Token::Keyword("cdots".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenize_attached_root_accent_fraction_and_style_commands() {
+        assert_eq!(
+            tokenize("sqrta+barz+3 overk+rmO+itf"),
+            vec![
+                Token::Keyword("sqrt".into()),
+                Token::Text("a".into()),
+                Token::Text("+".into()),
+                Token::Keyword("bar".into()),
+                Token::Text("z".into()),
+                Token::Text("+".into()),
+                Token::Text("3".into()),
+                Token::Keyword("over".into()),
+                Token::Text("k".into()),
+                Token::Text("+".into()),
+                Token::Keyword("rm".into()),
+                Token::Text("O".into()),
+                Token::Text("+".into()),
+                Token::Keyword("it".into()),
+                Token::Text("f".into()),
             ]
         );
     }

--- a/crates/hwpforge-smithy-md/src/eqn/lexer.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/lexer.rs
@@ -202,12 +202,21 @@ fn push_identifier_tokens(word: &str, tokens: &mut Vec<Token>) {
         return;
     }
 
-    let uppercase_match = UPPERCASE_COMMANDS
-        .iter()
-        .filter_map(|(source, canonical)| {
-            word.find(source).map(|index| (index, *source, *canonical))
-        })
-        .min_by_key(|(index, _, _)| *index);
+    let uppercase_match = UPPERCASE_COMMANDS.iter().find_map(|(source, canonical)| {
+        let attached_operand = word
+            .strip_prefix(source)
+            .filter(|suffix| suffix.chars().next().is_some_and(|next| !next.is_ascii_uppercase()));
+        if attached_operand.is_some() {
+            return Some((0, *source, *canonical));
+        }
+
+        let attached_command = word.strip_suffix(source).filter(|prefix| {
+            let mut characters = prefix.chars();
+            characters.next().is_some_and(|first| first.is_ascii_alphabetic())
+                && characters.next().is_none()
+        });
+        attached_command.map(|prefix| (prefix.len(), *source, *canonical))
+    });
     if let Some((index, source, canonical)) = uppercase_match {
         if index > 0 {
             push_identifier_tokens(&word[..index], tokens);
@@ -434,6 +443,11 @@ mod tests {
                 Token::Keyword("cdots".into()),
             ]
         );
+    }
+
+    #[test]
+    fn ordinary_uppercase_identifiers_do_not_match_command_substrings() {
+        assert_eq!(tokenize("SIMPLE"), vec![Token::Text("SIMPLE".into())]);
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/eqn/parser.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/parser.rs
@@ -662,7 +662,7 @@ mod tests {
     #[test]
     fn native_hancom_uppercase_commands_and_spacing() {
         assert_eq!(
-            eqn_to_latex("LEFT(1+i RIGHT)+PLEFT(x RIGHT),~THEREFOREk LEQ 1 TIMES 2 CDOTS`"),
+            eqn_to_latex("LEFT(1+i RIGHT)+P LEFT(x RIGHT),~THEREFOREk LEQ 1 TIMES 2 CDOTS`"),
             "$\\left(1+i\\right)+P\\left(x\\right),~\\therefore k\\le 1\\times 2\\cdots$"
         );
     }
@@ -679,6 +679,11 @@ mod tests {
     #[test]
     fn ordinary_lowercase_identifiers_remain_plain_text() {
         assert_eq!(eqn_to_latex("item+barometer+bars+its"), "$item+barometer+bars+its$");
+    }
+
+    #[test]
+    fn ordinary_uppercase_identifiers_remain_plain_text() {
+        assert_eq!(eqn_to_latex("BRIGHT+CLEFT"), "$BRIGHT+CLEFT$");
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/eqn/parser.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/parser.rs
@@ -668,16 +668,17 @@ mod tests {
     }
 
     #[test]
-    fn attached_root_accent_fraction_and_style_commands() {
+    fn root_accent_fraction_and_style_commands_at_boundaries() {
         assert_eq!(
-            eqn_to_latex("sqrta+barz+3 overk+rmO+itf"),
+            eqn_to_latex("sqrt a+bar z+3 over k+rm O+it f"),
             "$\\sqrt{a}+\\overline{z}+\\frac{3}{k}+O+f$"
         );
+        assert_eq!(eqn_to_latex("sqrta+barz+overk+rmO+itf"), "$sqrta+barz+overk+rmO+itf$");
     }
 
     #[test]
     fn ordinary_lowercase_identifiers_remain_plain_text() {
-        assert_eq!(eqn_to_latex("item+barometer"), "$item+barometer$");
+        assert_eq!(eqn_to_latex("item+barometer+bars+its"), "$item+barometer+bars+its$");
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/eqn/parser.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/parser.rs
@@ -686,4 +686,18 @@ mod tests {
              \\times{\\overline{{SD}}}^{2}=\\frac{35}{4}$"
         );
     }
+
+    #[test]
+    fn native_hancom_single_letter_escapes_are_plain_latin_labels() {
+        assert_eq!(eqn_to_latex(r"\B+\D+\A+\C"), "$B+D+A+C$");
+    }
+
+    #[test]
+    fn latex_commands_and_non_letter_backslash_syntax_are_preserved() {
+        assert_eq!(
+            eqn_to_latex(r"\alpha+\sqrt{x}+\operatorname{rank}"),
+            r"$\alpha+\sqrt{x}+\operatorname{rank}$"
+        );
+        assert_eq!(eqn_to_latex(r"\{x\}_1+\%+\_+\\"), r"$\{x\}_{1}+\%+\_+\\$");
+    }
 }

--- a/crates/hwpforge-smithy-md/src/eqn/parser.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/parser.rs
@@ -25,6 +25,12 @@ fn keyword_to_latex(kw: &str) -> &str {
         "leq" => r"\le",
         "geq" => r"\ge",
         "neq" => r"\ne",
+        "le" => r"\le",
+        "ge" => r"\ge",
+        "ne" => r"\ne",
+        "lt" => "<",
+        "gt" => ">",
+        "sim" => r"\sim",
         "therefore" => r"\therefore",
         "because" => r"\because",
         // Arrows
@@ -402,6 +408,16 @@ impl<'a> Parser<'a> {
                         };
                         format!("{}{{{}}}", cmd, arg)
                     }
+                    "rm" | "it" => {
+                        self.advance();
+                        String::new()
+                    }
+                    "bold" | "box" => {
+                        self.advance();
+                        let arg = self.parse_group();
+                        let cmd = if kw == "bold" { r"\mathbf" } else { r"\boxed" };
+                        format!("{}{{{}}}", cmd, arg)
+                    }
                     "left" => {
                         self.advance();
                         // next token should be a delimiter character
@@ -641,5 +657,33 @@ mod tests {
     fn prime_and_mod() {
         assert_eq!(eqn_to_latex("f prime"), "$f'$");
         assert_eq!(eqn_to_latex("a mod b"), "$a\\bmod b$");
+    }
+
+    #[test]
+    fn native_hancom_uppercase_commands_and_spacing() {
+        assert_eq!(
+            eqn_to_latex("LEFT(1+i RIGHT)+PLEFT(x RIGHT),~THEREFOREk LEQ 1 TIMES 2 CDOTS`"),
+            "$\\left(1+i\\right)+P\\left(x\\right),~\\therefore k\\le 1\\times 2\\cdots$"
+        );
+    }
+
+    #[test]
+    fn attached_root_accent_fraction_and_style_commands() {
+        assert_eq!(
+            eqn_to_latex("sqrta+barz+3 overk+rmO+itf"),
+            "$\\sqrt{a}+\\overline{z}+\\frac{3}{k}+O+f$"
+        );
+    }
+
+    #[test]
+    fn font_switch_at_group_end_does_not_consume_closing_brace() {
+        assert_eq!(
+            eqn_to_latex(
+                "left({ bar{rm{AB}it}}+{ bar{rm{BF}it}} right) \
+                 times { bar{rm{SD}it}}^{2}={35} over {4}"
+            ),
+            "$\\left({\\overline{{AB}}}+{\\overline{{BF}}}\\right)\
+             \\times{\\overline{{SD}}}^{2}=\\frac{35}{4}$"
+        );
     }
 }

--- a/crates/hwpforge-smithy-md/src/eqn/parser.rs
+++ b/crates/hwpforge-smithy-md/src/eqn/parser.rs
@@ -676,6 +676,11 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_lowercase_identifiers_remain_plain_text() {
+        assert_eq!(eqn_to_latex("item+barometer"), "$item+barometer$");
+    }
+
+    #[test]
     fn font_switch_at_group_end_does_not_consume_closing_brace() {
         assert_eq!(
             eqn_to_latex(

--- a/crates/hwpforge-smithy-md/src/lib.rs
+++ b/crates/hwpforge-smithy-md/src/lib.rs
@@ -38,3 +38,12 @@ pub use decoder::{MdDecoder, MdDocument};
 pub use encoder::{MdEncoder, MdOutput, MdWarning};
 pub use error::{MdError, MdErrorCode, MdResult};
 pub use frontmatter::Frontmatter;
+
+/// Converts a HancomEQN equation script into a LaTeX math expression.
+///
+/// This wrapper lets format consumers enrich structural HWPX reports without
+/// coupling the HWPX codec to the Markdown crate.
+#[must_use]
+pub fn hancom_eqn_to_latex(script: &str) -> String {
+    eqn::eqn_to_latex(script)
+}

--- a/crates/hwpforge-smithy-md/tests/visual_equations.rs
+++ b/crates/hwpforge-smithy-md/tests/visual_equations.rs
@@ -1,0 +1,7 @@
+use hwpforge_smithy_md::hancom_eqn_to_latex;
+
+#[test]
+fn visual_equations_convert_hancom_source_to_exact_latex() {
+    assert_eq!(hancom_eqn_to_latex("{a} over {b}"), r"$\frac{a}{b}$");
+    assert_eq!(hancom_eqn_to_latex("x ^{2}"), "$x^{2}$");
+}

--- a/docs/superpowers/plans/2026-08-03-visual-equation-render-base-unit-v4.md
+++ b/docs/superpowers/plans/2026-08-03-visual-equation-render-base-unit-v4.md
@@ -1,0 +1,62 @@
+# Visual Equation Render Base Unit V4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 시각 수식 sidecar v4가 부모 도형의 `scaMatrix.e5`를 수식 글꼴 크기에 중복 적용하지 않고 원본 `baseUnit`을 canonical 렌더 기준으로 제공하게 한다.
+
+**Architecture:** `HwpxVisualEquationGeometry`는 raw/display geometry와 scale을 그대로 유지하되 `display_base_unit`을 제거하고 `render_base_unit`을 추가한다. `render_base_unit`은 양수인 equation `baseUnit`을 우선하고, 없거나 0이면 양수인 raw equation height를 사용한다.
+
+**Tech Stack:** Rust 2021, serde/serde_json, Cargo workspace integration tests
+
+## Global Constraints
+
+- sidecar `schema_version`은 4이다.
+- raw/display geometry, raw/display position, scale, translation은 유지한다.
+- `display_base_unit`은 직렬화 결과에서 제거한다.
+- `render_base_unit`은 raw `baseUnit`, 없으면 raw equation height와 같다.
+- 실제 Q524와 Q448 wire 값을 회귀 fixture로 검증한다.
+
+---
+
+### Task 1: Schema v4 RED contract
+
+**Files:**
+- Modify: `crates/hwpforge-smithy-hwpx/tests/visual_equations.rs`
+- Modify: `crates/hwpforge-bindings-cli/tests/cli_integration.rs`
+
+**Interfaces:**
+- Consumes: `HwpxDecoder::decode_with_report`, CLI `to-md --json`
+- Produces: schema v4와 `render_base_unit` 공개 JSON 계약을 고정하는 테스트
+
+- [x] **Step 1: 실제 Q524 fixture가 `render_base_unit=1100`이고 `display_base_unit`이 없음을 요구한다.**
+- [x] **Step 2: 실제 Q448 fixture가 e5와 무관하게 `render_base_unit=900`임을 요구한다.**
+- [x] **Step 3: baseUnit이 없을 때 raw equation height fallback을 요구한다.**
+- [x] **Step 4: targeted Cargo tests를 실행해 schema v3/display_base_unit 때문에 예상대로 실패하는지 확인한다.**
+
+### Task 2: Minimal schema v4 implementation
+
+**Files:**
+- Modify: `crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs`
+
+**Interfaces:**
+- Consumes: `HxEquation.base_unit`, `HxEquation.sz.height`
+- Produces: `HwpxVisualEquationGeometry.render_base_unit: Option<u32>`
+
+- [x] **Step 1: schema version 상수를 4로 올린다.**
+- [x] **Step 2: `display_base_unit`과 scale helper를 제거한다.**
+- [x] **Step 3: raw baseUnit 우선, raw equation height fallback으로 `render_base_unit`을 계산한다.**
+- [x] **Step 4: targeted tests가 통과하는지 확인한다.**
+
+### Task 3: Corpus and workspace verification
+
+**Files:**
+- Verify only: actual M1-02 projection and generated visual-equations JSON
+
+**Interfaces:**
+- Consumes: HwpForge CLI `to-md`, 실제 Q448/Q524 HWPX projection
+- Produces: actual corpus `render_base_unit` assertions and workspace verification evidence
+
+- [x] **Step 1: `cargo fmt --check`와 `cargo clippy --workspace --all-targets --all-features -- -D warnings`를 실행한다.**
+- [x] **Step 2: `cargo test --workspace`를 실행한다.**
+- [x] **Step 3: actual corpus sidecar에서 Q448=900, Q524=1100, schema=4, `display_base_unit` 부재를 검증한다.**
+- [x] **Step 4: diff를 기능 범위로 검토하고 한국어 Conventional Commit으로 커밋한다.**

--- a/docs/superpowers/plans/2026-08-03-visual-equation-render-base-unit-v4.md
+++ b/docs/superpowers/plans/2026-08-03-visual-equation-render-base-unit-v4.md
@@ -21,10 +21,12 @@
 ### Task 1: Schema v4 RED contract
 
 **Files:**
+
 - Modify: `crates/hwpforge-smithy-hwpx/tests/visual_equations.rs`
 - Modify: `crates/hwpforge-bindings-cli/tests/cli_integration.rs`
 
 **Interfaces:**
+
 - Consumes: `HwpxDecoder::decode_with_report`, CLI `to-md --json`
 - Produces: schema v4와 `render_base_unit` 공개 JSON 계약을 고정하는 테스트
 
@@ -36,9 +38,11 @@
 ### Task 2: Minimal schema v4 implementation
 
 **Files:**
+
 - Modify: `crates/hwpforge-smithy-hwpx/src/decoder/visual_equations.rs`
 
 **Interfaces:**
+
 - Consumes: `HxEquation.base_unit`, `HxEquation.sz.height`
 - Produces: `HwpxVisualEquationGeometry.render_base_unit: Option<u32>`
 
@@ -50,9 +54,11 @@
 ### Task 3: Corpus and workspace verification
 
 **Files:**
+
 - Verify only: actual M1-02 projection and generated visual-equations JSON
 
 **Interfaces:**
+
 - Consumes: HwpForge CLI `to-md`, 실제 Q448/Q524 HWPX projection
 - Produces: actual corpus `render_base_unit` assertions and workspace verification evidence
 


### PR DESCRIPTION
## What

- 반복 rendering matrix와 mixed inline order를 손실 없이 보존합니다.
- caption/group 및 그 내부 rect/ellipse/polygon의 drawText 수식에 ID, 순서, 기하, transform을 포함한 visual-equations sidecar를 추가합니다.
- 최상위 rect/ellipse/polygon의 drawText에 중첩된 picture/container도 순회하되 일반 텍스트박스의 직접 수식은 제외합니다.
- group 내부 ellipse/polygon을 GroupDrawText 부모로 수집하고 공통 geometry를 기록합니다.
- caption/group shape text 안의 중첩 시각 객체는 최근접 부모와 원본 문서 순서를 보존합니다.
- 중첩 text-bearing 도형의 위치·scale·translation을 바깥 시각 부모 변환과 합성합니다.
- 가까운 중첩 picture/container로 부모가 바뀌어도 조상 위치·scale·translation을 새 시각 부모에 합성합니다.
- picture caption 수식에 picture의 final `scaMatrix` scale·translation을 적용합니다.
- MEMO `fieldBegin/subList`의 caption/group 수식을 일반·소유 visual walker 양쪽에서 수집합니다.
- 중첩 picture caption과 group drawText 진입마다 depth를 증가시켜 32단계 제한을 적용합니다.
- 숫자가 아니거나 유한하지 않은 중첩 `scaMatrix`는 원본 문자열을 보존하고 표시용 기하만 계산 불가로 처리합니다.
- 이질적인 text/equation/picture/table/control/shape 자식도 `child_order`에 따라 원본 run 순서를 보존합니다.
- memo 내부 각주/미주 정의와 이미지 산출물은 문서 전역 출력에서 격리합니다.
- 소문자 HancomEQN 명령은 식별자 경계에서만 인식해 `bars`, `its` 같은 일반 식별자를 보존합니다.
- 대문자 suffix 명령도 실제 토큰 경계에서만 인식해 `BRIGHT`, `CLEFT` 같은 일반 식별자를 보존합니다.
- 시각 부모 내부의 nested table은 caption 수식을 cell보다 먼저 순회합니다.
- schema v4에 `render_base_unit`을 추가하고 `baseUnit`이 없는 경우 height 기반 fallback을 기록합니다.
- styled 모드만 visual report decode를 사용하고 lossy/lossless는 legacy decode 경로를 유지합니다.
- non-styled 변환은 같은 출력 경로의 이전 visual-equations sidecar를 제거합니다.
- 중첩 각주와 미주는 바깥 참조 번호를 먼저 예약해 가시 순서를 보존합니다.
- HancomEQN 변환과 실제 문서 회귀 fixture를 보강합니다.

## Why

GeniTeacher 대형 수학Ⅰ HWPX의 그래프에는 본문 prose에 없는 수식 라벨이 drawing container와 caption 내부에 존재합니다. 또한 상위 `scaMatrix`를 glyph 크기에 중복 적용하지 않도록 원본 렌더 기준 단위와 transform을 분리해 보존해야 합니다.

## How it was tested

- `make ci`
- `cargo nextest`: 3,083 passed, 3 skipped
- workspace clippy: all targets/all features, warnings denied
- `cargo test -p hwpforge-smithy-hwpx --doc`: 11 passed
- `cargo test -p hwpforge-smithy-md --doc`: 1 ignored
- 실제 Q448/Q524 fixture와 visual-equation schema 회귀 테스트
- group 좌표 overflow의 styled/legacy decode 모드 분리 회귀 테스트
- nested 및 top-level rect/ellipse/polygon drawText의 visual parent 순회 회귀 테스트
- group 내부 ellipse/polygon 부모 및 중첩 시각 객체의 최근접 부모·문서 순서 회귀 테스트
- 중첩 도형 변환 합성, picture caption transform, memo 내부 각주·이미지 격리, 소문자 및 대문자 suffix 명령 경계 회귀 테스트
- picture caption과 group drawText 아래 중첩 picture/container의 조상 transform 합성 회귀 테스트
- MEMO field subList 시각 수식 및 중첩 picture/group 32단계 depth 경계 회귀 테스트
- 중첩 조상/자식의 비정상·비유한 변환에서도 raw 기하 보존 및 display geometry null 회귀 테스트
- text-equation-picture-text 혼합 run과 self-closing bookmark 원본 순서 회귀 테스트
- nested table caption/cell의 시각 부모 및 문서 순서 회귀 테스트
- non-styled 변환의 stale sidecar 제거 회귀 테스트
- 중첩 각주와 미주의 가시 참조 순서 회귀 테스트
- `git diff --check`
- 운영/네트워크 업로드 없음

## Checklist

- [x] `make ci`
- [x] 관련 테스트와 회귀 fixture 추가
- [x] 공개 JSON schema를 문서화
- [x] dprint/markdownlint로 문서 변경 검증
- [x] 의도적인 MSRV 하향 없음
- [x] Conventional Commits 사용

## Impact

- [ ] Breaking API change
- [x] New public API
- [x] Format roundtrip affected
- [ ] MSRV
- [ ] Performance
- [x] Dependency