### PR TITLE
ci: Dependabot major 분리 + release-plz 워크플로 액션 SHA 핀

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,15 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
+      # major 는 그룹에서 제외한다. 그룹에 major 가 섞이면 파괴적 bump 하나가
+      # 실패할 때 같은 PR 에 묶인 나머지 cargo 업데이트까지 전부 정체된다
+      # (rmcp 2.0 -> 3.1 이 PR #120 에서 실제로 그랬음).
       rust-workspace:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -53,21 +53,21 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
         run: rustup show
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Run release-plz release
         id: release_plz
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release
         env:
@@ -87,20 +87,20 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
         run: rustup show
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Run release-plz release-pr
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release-pr
         env:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -29,6 +29,7 @@
     "**/temp/**",
     ".omc/**",
     ".serena/**",
+    "**/.baram/**",
     ".github/PULL_REQUEST_TEMPLATE.md",
     "**/CHANGELOG.md",
     "examples/hwpx2md/**",

--- a/dprint.json
+++ b/dprint.json
@@ -19,6 +19,7 @@
     "**/.git/**",
     "**/.docs/**",
     "**/.omc/**",
+    "**/.baram/**",
     "**/temp/**",
     "**/examples/hwp5_review/**",
     "**/*.hwpx",


### PR DESCRIPTION
GitHub 설정 감사에서 나온 항목 중 **파일 변경이 필요한 두 건**을 처리한다.
설정 API 로 끝나는 나머지(secret scanning·룰셋·브랜치 자동삭제·머지 브랜치 28개 정리)는
이미 레포에 직접 반영했으므로 이 PR 범위 밖이다.

## 1. Dependabot cargo 그룹에서 major 분리

`groups.rust-workspace.patterns: ["*"]` 만 있으면 major 까지 한 PR 에 묶인다.
그래서 파괴적 bump 하나가 실패하면 **나머지 cargo 업데이트 전부가 그 뒤에 정체**된다.

실제로 발생 중이었다 — PR #120 (rmcp 2.0 → 3.1) 이 clippy 실패로 막혀 있고,
그 뒤에 다른 cargo 업데이트가 따로 올라오지 못하고 있다.

```
error[E0271]: expected `Result<ReadResourceResponse, ErrorData>`,
              found `Result<ReadResourceResult, ErrorData>`
error[E0063]: missing fields `cache_scope`, `result_type` and `ttl_ms`
              in initializer of `rmcp::model::ListPromptsResult`
```

`update-types: [minor, patch]` 로 그룹을 좁혀 major 를 개별 PR 로 분리한다.

**"major 가 누락되는 것 아닌가"를 문서로 확인했다** — Dependabot options reference,
`groups`: *"Any outdated dependencies that do not match a rule are updated in
individual pull requests."* major 는 계속 들어오되 그룹을 막지 않는다.

rmcp 3.1 마이그레이션 자체는 별도 슬라이스로 다룬다 (이 PR 범위 아님).

## 2. `release-plz.yml` 액션 6곳 SHA 핀

두 publish 워크플로의 보안 수준이 역전돼 있었다.

| 워크플로 | 보유 시크릿 | 핀 상태 (before) |
| --- | --- | --- |
| `npm-publish.yml` | `NPM_TOKEN` | 전량 SHA 핀 |
| `release-plz.yml` | **`APP_PRIVATE_KEY` + `CARGO_REGISTRY_TOKEN`** | 전량 mutable 태그 |

권한이 더 센 쪽이 덜 보호돼 있었고, 서드파티 `release-plz/action` 도 mutable 태그였다.

| 액션 | before | after |
| --- | --- | --- |
| `actions/checkout` | `@v7` | `@3d3c42e5` (v7.0.1) |
| `actions/create-github-app-token` | `@v3` | `@bcd2ba49` (v3.2.0) |
| `release-plz/action` | `@v0.5` | `@2eb1d8bc` (v0.5.131) |

`v0.5` == `v0.5.131` == `2eb1d8bc` 임을 API 로 확인했으므로 **동작 변화는 없다**
(annotated tag 는 commit SHA 로 역참조). Dependabot 이 SHA 핀도 추적하므로 이후
업데이트는 계속 들어온다.

레포 전역 `sha_pinning_required` 는 켜지 않았다 — ci/pages/security 의 미핀 액션
9곳이 한꺼번에 깨진다. 별도로 판단할 사안.

## 부수 수정 — 커밋·푸시를 막고 있던 블로커

`examples/.baram/`(baram 도구 스냅샷 캐시, 추적 파일 0개)의 미포맷 마크다운이
**두 게이트를 동시에** 막고 있었다.

| 단계 | 도구 | 증상 |
| --- | --- | --- |
| pre-commit | `dprint check` (`pass_filenames: false` → 레포 전체 스캔) | 커밋 거부 |
| pre-push | `make ci` → `lint-md` → `markdownlint-cli2 "**/*.md"` | 푸시 거부 |

이미 같은 성격의 도구 상태 디렉터리(`.omc/`·`.serena/`·`.docs/`·
`examples/hwp5_review/`)가 두 설정의 제외 목록에 있으므로 동일하게 처리했다.

git 추적 여부는 건드리지 않았다. `.markdownlint-cli2.jsonc` 는 `gitignore: true`
라 `.gitignore` 로도 풀리지만 dprint 는 자체 excludes 만 보므로 어차피 설정 제외가
필요하고, 스냅샷을 `git status` 에서 감출지는 도구 소유자가 정할 문제다.

## 검증

- `make lint-md` exit 0 — dprint check + markdownlint 73파일 0 issues
- actionlint 1.7.7 (CI 와 동일한 `rhysd/actionlint:1.7.7` 이미지) 통과
- Rust 코드 무변경 — 릴리스 트리거 없음 (`ci:`/`chore:` 는 release-plz 대상 아님)
