### PR TITLE
ci: npm publish 러너를 Node 24 로 올려 trusted publishing(OIDC) 활성화 준비

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -135,8 +135,32 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22"
+          # Node 24 (LTS Krypton) bundles npm >= 11.13. Trusted publishing (OIDC)
+          # requires npm >= 11.5.1 / Node >= 22.14.0, and Node 22 is pinned to
+          # npm 10.9.8 — too old. Bumping the runtime is preferred over
+          # `npm i -g npm` because the global self-update is flaky on Windows.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Report npm CLI (trusted publishing readiness)
+        run: |
+          node -v
+          npm -v
+          # Below npm 11.5.1 the CLI silently falls back to NODE_AUTH_TOKEN.
+          # That looks like a successful publish while OIDC never engaged, so
+          # surface it explicitly instead of letting it pass unnoticed.
+          if ! node -e '
+            const need = [11, 5, 1];
+            const got = process.argv[1].split(".").map(Number);
+            for (let i = 0; i < 3; i++) {
+              if ((got[i] || 0) > need[i]) process.exit(0);
+              if ((got[i] || 0) < need[i]) process.exit(1);
+            }
+          ' "$(npm -v)"; then
+            echo "::warning::npm $(npm -v) < 11.5.1 — trusted publishing (OIDC) unavailable, falling back to NODE_AUTH_TOKEN"
+          else
+            echo "npm $(npm -v) supports trusted publishing (OIDC)"
+          fi
 
       - name: Publish platform package (skip if already published)
         working-directory: npm/packages/mcp-${{ matrix.npm-suffix }}
@@ -222,8 +246,26 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22"
+          # See the platform job above — Node 24 for npm >= 11.5.1 (OIDC).
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Report npm CLI (trusted publishing readiness)
+        run: |
+          node -v
+          npm -v
+          if ! node -e '
+            const need = [11, 5, 1];
+            const got = process.argv[1].split(".").map(Number);
+            for (let i = 0; i < 3; i++) {
+              if ((got[i] || 0) > need[i]) process.exit(0);
+              if ((got[i] || 0) < need[i]) process.exit(1);
+            }
+          ' "$(npm -v)"; then
+            echo "::warning::npm $(npm -v) < 11.5.1 — trusted publishing (OIDC) unavailable, falling back to NODE_AUTH_TOKEN"
+          else
+            echo "npm $(npm -v) supports trusted publishing (OIDC)"
+          fi
 
       - name: Publish base package (skip if already published)
         working-directory: npm/packages/mcp


### PR DESCRIPTION
npm trusted publishing(OIDC) 전환의 **1단계**. 워크플로가 전제 조건을 만족하도록 러너를
올린다. 이 PR 자체는 배포 동작을 바꾸지 않는다 — 토큰 인증 그대로 유지된다.

## 왜

이 레포는 npm 장기 토큰 때문에 반복해서 릴리스가 깨졌다.

- `v0.6.0`~`v0.10.0` **publish 5연속 실패** — granular 토큰 90일 만료
- 진단이 늦은 이유: npm 이 **인증 실패를 `E404` 로 위장**한다 ("패키지 없음"처럼 보임)
- 재발급 후에도 `E403` — "Bypass 2FA" 옵션 필수
- 현 토큰 **~2026-10-11 재만료** 예정

trusted publishing 은 워크플로 자체를 OIDC 로 신원 증명하므로 저장되는 비밀이 없다.
만료도, 갱신도, 유출 시 재사용도 없다.

## 전제 조건 실측

요구치는 **npm ≥ 11.5.1 / Node ≥ 22.14.0**.

`v0.11.7` publish 실행 로그(run `30164996705`)를 열어보니 6개 잡 전부:

```
node: v22.23.1     ← 충족
npm:  10.9.8       ← 미달
```

`nodejs.org/dist` 대조:

| Node | 번들 npm | OIDC |
| --- | --- | --- |
| v22.23.x (현재) | 10.9.8 | ✗ |
| v24.16 ~ v24.19 (LTS Krypton) | 11.13.0 ~ 11.17.0 | ✓ |

v22 계열은 npm 10.9.8 에 고정이라 **런타임을 올리는 것 말고 방법이 없다.**

## 무엇을

`node-version: "22"` → `"24"` (2곳) + npm 버전 리포트 스텝 2개.

`npm i -g npm@latest` 대신 런타임을 올린 이유는 **전역 자기 갱신이 Windows 러너에서
불안정**하기 때문이다. publish 잡은 미리 빌드된 Rust 바이너리를 포장·업로드만 하므로
Node 런타임 변경의 회귀 표면이 없다.

리포트 스텝을 넣은 이유: npm 이 11.5.1 미만이면 **조용히 `NODE_AUTH_TOKEN` 으로
폴백**한다. 성공한 배포처럼 보이는데 OIDC 는 동작하지 않은 상태라 알아챌 방법이 없다.
지금은 경고로 두고, 토큰 제거 후(3단계) 하드 실패로 승격한다.

## `NODE_AUTH_TOKEN` 은 의도적으로 남긴다

npm CLI 는 **OIDC 를 토큰보다 우선** 사용한다. 따라서 사용자가 npmjs.com 에서
publisher 를 등록하는 순간 워크플로 수정 없이 OIDC 로 전환되고, 토큰은 폴백으로만
남는다. 공식 문서 권장 순서와 일치한다:

> 1. Set up trusted publishers first and verify functionality
> 2. Then restrict token access
> 3. Finally, revoke existing automation tokens

즉 **전환이 릴리스를 깨뜨릴 수 없는 구조**다. 토큰 제거는 OIDC 배포가 실증된 뒤 별도 PR.

## 다음 단계 (이 PR 머지 후)

**2단계 — npmjs.com 등록 6개** (사용자 작업). 각 패키지 → Settings → Trusted Publisher:

| 필드 | 값 |
| --- | --- |
| Provider | GitHub Actions |
| Organization or user | `ai-screams` |
| Repository | `HwpForge` |
| Workflow filename | `npm-publish.yml` |
| Environment | *(비워둠 — 이 잡들은 GitHub Environment 미사용)* |

대상 패키지 6개 (`npm/packages/*/package.json` 실측):

```
@hwpforge/mcp
@hwpforge/mcp-darwin-arm64
@hwpforge/mcp-darwin-x64
@hwpforge/mcp-linux-arm64
@hwpforge/mcp-linux-x64
@hwpforge/mcp-win32-x64
```

하나라도 빠지면 **그 패키지만** 실패한다.

**3단계 — 다음 릴리스에서 실증** → 확인되면 `NODE_AUTH_TOKEN` 2곳 제거 + `NPM_TOKEN`
시크릿 삭제 + 리포트 스텝을 하드 실패로 승격.

## ⚠️ 주의

trusted publisher 설정은 **워크플로 파일명 `npm-publish.yml` 을 신원의 일부로** 묶는다.
나중에 이 파일을 rename 하면 배포가 조용히 깨진다 — 등록 설정도 같이 고쳐야 한다.

## 검증

- actionlint 1.7.7 (CI 와 동일한 `rhysd/actionlint:1.7.7` 이미지) 통과
- 버전 비교 로직 경계값 로컬 확인 — `11.5.0` 미달 / `11.5.1` 통과
- `NODE_AUTH_TOKEN` 2곳 유지 확인 (grep)
- Rust 무변경 — 릴리스 트리거 없음
