### PR TITLE
feat(core)!: 줄 조판 캐시 LayoutCache 승격 (PDF Export 에픽 W1)

### DIFF
--- a/crates/hwpforge-convert/src/lib.rs
+++ b/crates/hwpforge-convert/src/lib.rs
@@ -18,7 +18,7 @@ use hwpforge_foundation::{HeadingType, ParaShapeIndex};
 use hwpforge_smithy_hwp5::schema::header::{Hwp5RawStyle, Hwp5RawTabDef, Hwp5TabDefSlot};
 use hwpforge_smithy_hwp5::style_store::Hwp5StyleStore;
 use hwpforge_smithy_hwp5::{decode_hwp5_to_core, Hwp5Error, Hwp5Result, Hwp5Warning};
-use hwpforge_smithy_hwpx::{HwpxEncoder, HwpxStyleStore};
+use hwpforge_smithy_hwpx::{EncodeOptions, HwpxEncoder, HwpxStyleStore};
 
 use crate::style_store_border_fill::{push_hwp5_border_fills, push_required_border_fills};
 use crate::style_store_convert::{
@@ -81,6 +81,41 @@ pub fn hwp5_to_hwpx(
 /// Returns [`Hwp5Error`] if the bytes cannot be decoded, the document fails
 /// validation, or HWPX encoding fails.
 pub fn hwp5_to_hwpx_bytes(bytes: &[u8]) -> Hwp5Result<(Vec<u8>, Vec<Hwp5Warning>)> {
+    hwp5_to_hwpx_bytes_with_options(bytes, ConvertOptions::default())
+}
+
+/// 변환 동작 옵션. [`Default`] 는 현행 변환 동작 그대로다.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct ConvertOptions {
+    /// `true` 면 HWP5 조판 캐시(`PARA_LINE_SEG`)를 HWPX
+    /// `<hp:linesegarray>` 로 carry 한다. 기본 `false`.
+    ///
+    /// ⚠️ **PDF 재생/비교 파이프라인 전용** (같은 조건 비교의 성립 요건).
+    /// 과거 무조건 carry 는 한컴에서 다중행 텍스트 겹침을 일으켜 제거됐다
+    /// (`layout_hint_patch` 는 표 높이만 재생) — 이 opt-in 산출물은 한컴
+    /// 재개봉 용도가 아니다.
+    pub carry_layout_cache: bool,
+}
+
+impl ConvertOptions {
+    /// 조판 캐시 carry 여부를 설정한다 (기본 `false`).
+    #[must_use]
+    pub fn with_carry_layout_cache(mut self, carry: bool) -> Self {
+        self.carry_layout_cache = carry;
+        self
+    }
+}
+
+/// [`hwp5_to_hwpx_bytes`] 에 동작 옵션([`ConvertOptions`])을 더한 변형.
+///
+/// # Errors
+///
+/// [`hwp5_to_hwpx_bytes`] 와 동일.
+pub fn hwp5_to_hwpx_bytes_with_options(
+    bytes: &[u8],
+    options: ConvertOptions,
+) -> Hwp5Result<(Vec<u8>, Vec<Hwp5Warning>)> {
     let decoded = decode_hwp5_to_core(bytes)?;
     let (hwpx_style_store, style_warnings) = hwp5_style_store_to_hwpx(&decoded.style_store);
     // Warning order: decode-phase warnings (intermediate + projection +
@@ -93,8 +128,15 @@ pub fn hwp5_to_hwpx_bytes(bytes: &[u8]) -> Hwp5Result<(Vec<u8>, Vec<Hwp5Warning>
     warnings.extend(style_warnings);
 
     let validated = decoded.document.validate().map_err(Hwp5Error::Core)?;
-    let hwpx_bytes = HwpxEncoder::encode(&validated, &hwpx_style_store, &decoded.image_store)
-        .map_err(|e| Hwp5Error::Cfb { detail: format!("HWPX encoding failed: {e}") })?;
+    let encode_options =
+        EncodeOptions::default().with_emit_layout_cache(options.carry_layout_cache);
+    let hwpx_bytes = HwpxEncoder::encode_with_options(
+        &validated,
+        &hwpx_style_store,
+        &decoded.image_store,
+        encode_options,
+    )
+    .map_err(|e| Hwp5Error::Cfb { detail: format!("HWPX encoding failed: {e}") })?;
     let hwpx_bytes =
         layout_hint_patch::patch_hwpx_layout_hints(&hwpx_bytes, &decoded.layout_hints)?;
 

--- a/crates/hwpforge-convert/src/tests.rs
+++ b/crates/hwpforge-convert/src/tests.rs
@@ -3844,3 +3844,47 @@ fn hwp5_to_hwpx_carries_column_separator_line() {
     );
     let _ = std::fs::remove_file(&out);
 }
+
+// ── W1d: HWP5 조판 캐시 opt-in carry ────────────────────────────────
+
+/// 기본 변환은 linesegarray 를 방출하지 않고(기존 불변), opt-in 은
+/// HWP5 LINE_SEG 를 `<hp:linesegarray>` 로 carry 하며 재디코드 시
+/// Core 캐시로 승격돼야 한다.
+#[test]
+fn carry_layout_cache_optin_emits_and_roundtrips() {
+    let path = fixture_path("hwp5/hwp5_00.hwp");
+    if !path.exists() {
+        return; // fixture-optional (suite 관례)
+    }
+    let bytes = std::fs::read(&path).expect("fixture read");
+
+    let (default_out, _) = hwp5_to_hwpx_bytes(&bytes).expect("default convert");
+    let default_xml = {
+        let mut pkg = PackageReader::new(&default_out).expect("package");
+        pkg.read_section_xml(0).expect("section xml")
+    };
+    assert!(
+        !default_xml.contains("linesegarray"),
+        "기본 변환은 캐시를 방출하지 않는다 (기존 불변)"
+    );
+
+    let options = crate::ConvertOptions::default().with_carry_layout_cache(true);
+    let (optin_out, _) =
+        crate::hwp5_to_hwpx_bytes_with_options(&bytes, options).expect("opt-in convert");
+    let optin_xml = {
+        let mut pkg = PackageReader::new(&optin_out).expect("package");
+        pkg.read_section_xml(0).expect("section xml")
+    };
+    assert!(optin_xml.contains("<hp:linesegarray>"), "opt-in 은 HWP5 LINE_SEG 를 carry 한다");
+
+    // 재디코드 → Core 캐시 승격 확인 (PDF 재생 소비 경로 성립)
+    let decoded = HwpxDecoder::decode(&optin_out).expect("decode opt-in output");
+    let mut cached = 0usize;
+    let mut doc = decoded.document;
+    doc.for_each_paragraph_mut(|p| {
+        if p.layout_cache.as_ref().is_some_and(|c| !c.is_empty()) {
+            cached += 1;
+        }
+    });
+    assert!(cached > 0, "재디코드된 산출물에 승격된 캐시가 있어야 한다");
+}

--- a/crates/hwpforge-core/src/caption.rs
+++ b/crates/hwpforge-core/src/caption.rs
@@ -101,6 +101,14 @@ impl Caption {
     /// assert!(cap.width.is_none());
     /// assert_eq!(cap.paragraphs.len(), 1);
     /// ```
+    /// 캡션 문단 전부를 재귀 방문한다 (문단 안 중첩 포함).
+    pub(crate) fn walk_paragraphs_mut(&mut self, f: &mut dyn FnMut(&mut Paragraph)) {
+        for p in &mut self.paragraphs {
+            p.walk_paragraphs_mut(f);
+        }
+    }
+
+    /// Creates a caption with the given paragraphs and side.
     pub fn new(paragraphs: Vec<Paragraph>, side: CaptionSide) -> Self {
         Self {
             side,

--- a/crates/hwpforge-core/src/control/mod.rs
+++ b/crates/hwpforge-core/src/control/mod.rs
@@ -58,7 +58,7 @@ use crate::run::Run;
 /// ```
 /// use hwpforge_core::control::Control;
 /// use hwpforge_core::paragraph::Paragraph;
-/// use hwpforge_foundation::{HwpUnit, ParaShapeIndex};
+/// use hwpforge_foundation::{HwpUnit, ParaShapeIndex, VerticalAlign};
 ///
 /// let text_box = Control::TextBox {
 ///     paragraphs: vec![Paragraph::new(ParaShapeIndex::new(0))],
@@ -68,6 +68,7 @@ use crate::run::Run;
 ///     vert_offset: 0,
 ///     caption: None,
 ///     style: None,
+///     text_vertical_align: VerticalAlign::Top,
 /// };
 /// assert!(text_box.is_text_box());
 /// assert!(!text_box.is_hyperlink());
@@ -694,6 +695,76 @@ pub enum Control {
 }
 
 impl Control {
+    /// 이 컨트롤 안에 중첩된 모든 문단을 재귀 방문한다
+    /// (글상자/도형 본문·캡션·각주/미주·메모 본문+앵커 run·묶음 자식 포함).
+    ///
+    /// 새 variant 가 문단을 담게 되면 이 match 가 컴파일 에러로 강제한다
+    /// (와일드카드 없음 — 순회 완전성 보장).
+    pub(crate) fn walk_paragraphs_mut(
+        &mut self,
+        f: &mut dyn FnMut(&mut crate::paragraph::Paragraph),
+    ) {
+        fn walk_vec(
+            paragraphs: &mut [crate::paragraph::Paragraph],
+            f: &mut dyn FnMut(&mut crate::paragraph::Paragraph),
+        ) {
+            for p in paragraphs {
+                p.walk_paragraphs_mut(f);
+            }
+        }
+        fn walk_caption(
+            caption: &mut Option<Caption>,
+            f: &mut dyn FnMut(&mut crate::paragraph::Paragraph),
+        ) {
+            if let Some(c) = caption {
+                c.walk_paragraphs_mut(f);
+            }
+        }
+        match self {
+            Self::TextBox { paragraphs, caption, .. }
+            | Self::Ellipse { paragraphs, caption, .. }
+            | Self::Polygon { paragraphs, caption, .. } => {
+                walk_vec(paragraphs, f);
+                walk_caption(caption, f);
+            }
+            Self::Footnote { paragraphs, .. } | Self::Endnote { paragraphs, .. } => {
+                walk_vec(paragraphs, f);
+            }
+            Self::Line { caption, .. }
+            | Self::Rect { caption, .. }
+            | Self::Arc { caption, .. }
+            | Self::Curve { caption, .. }
+            | Self::ConnectLine { caption, .. } => walk_caption(caption, f),
+            Self::Group { children, .. } => {
+                for child in children {
+                    child.walk_paragraphs_mut(f);
+                }
+            }
+            Self::Memo { content, anchor_runs, .. } => {
+                walk_vec(content, f);
+                for run in anchor_runs {
+                    run.walk_paragraphs_mut(f);
+                }
+            }
+            Self::Hyperlink { .. }
+            | Self::EmbeddedChart { .. }
+            | Self::Equation { .. }
+            | Self::Chart { .. }
+            | Self::Dutmal { .. }
+            | Self::Compose { .. }
+            | Self::TextArt { .. }
+            | Self::Bookmark { .. }
+            | Self::CrossRef { .. }
+            | Self::Field { .. }
+            | Self::IndexMark { .. }
+            | Self::UnknownSummary { .. }
+            | Self::DateCodeField { .. }
+            | Self::PathField { .. }
+            | Self::InlinePageNumber { .. }
+            | Self::Unknown { .. } => {}
+        }
+    }
+
     /// Returns the stable snake_case name of this control's kind.
     ///
     /// Read/diff projections use this to label embedded content without

--- a/crates/hwpforge-core/src/document.rs
+++ b/crates/hwpforge-core/src/document.rs
@@ -60,6 +60,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::CoreResult;
 use crate::metadata::Metadata;
+use crate::paragraph::Paragraph;
 use crate::section::Section;
 use crate::validate::validate_sections;
 
@@ -179,6 +180,64 @@ impl Document<Draft> {
     /// ```
     pub fn with_metadata(metadata: Metadata) -> Self {
         Self { sections: Vec::new(), metadata, _state: PhantomData }
+    }
+
+    /// 문서의 모든 문단(전 섹션 본문·머리말·꼬리말·바탕쪽 + 표 셀·캡션·
+    /// 글상자·각주/미주·메모 등 중첩 문단 전부)을 문서 순서로 방문한다.
+    ///
+    /// 캐시 정규화([`Self::strip_layout_caches`]) 등 전 문단 일괄 변환의
+    /// 진입점이다. `Draft` 전용 — `Validated` 는 typestate 상 불변이므로
+    /// 비교가 필요하면 검증 전 사본에서 수행한다.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hwpforge_core::document::Document;
+    /// use hwpforge_core::page::PageSettings;
+    /// use hwpforge_core::paragraph::Paragraph;
+    /// use hwpforge_core::section::Section;
+    /// use hwpforge_foundation::ParaShapeIndex;
+    ///
+    /// let mut doc = Document::new();
+    /// doc.add_section(Section::with_paragraphs(
+    ///     vec![Paragraph::new(ParaShapeIndex::new(0))],
+    ///     PageSettings::a4(),
+    /// ));
+    /// let mut count = 0;
+    /// doc.for_each_paragraph_mut(|_| count += 1);
+    /// assert_eq!(count, 1);
+    /// ```
+    pub fn for_each_paragraph_mut<F: FnMut(&mut Paragraph)>(&mut self, mut f: F) {
+        for section in &mut self.sections {
+            section.walk_paragraphs_mut(&mut f);
+        }
+    }
+
+    /// 모든 문단의 줄 조판 캐시([`Paragraph::layout_cache`])를 제거한다.
+    ///
+    /// 문서 동등성 비교(admission/golden)의 정규화 단계: 네이티브 입력은
+    /// 캐시를 보유하고 우리 재인코드 산출물은 미보유가 정상이므로, 비교
+    /// 전 양쪽 사본에서 이 함수를 호출해 캐시 차이를 제거한다.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hwpforge_core::document::Document;
+    /// use hwpforge_core::layout::LayoutCache;
+    /// use hwpforge_core::page::PageSettings;
+    /// use hwpforge_core::paragraph::Paragraph;
+    /// use hwpforge_core::section::Section;
+    /// use hwpforge_foundation::ParaShapeIndex;
+    ///
+    /// let mut para = Paragraph::new(ParaShapeIndex::new(0));
+    /// para.layout_cache = Some(LayoutCache::default());
+    /// let mut doc = Document::new();
+    /// doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+    /// doc.strip_layout_caches();
+    /// assert!(doc.sections()[0].paragraphs[0].layout_cache.is_none());
+    /// ```
+    pub fn strip_layout_caches(&mut self) {
+        self.for_each_paragraph_mut(|p| p.layout_cache = None);
     }
 
     /// Appends a section to the draft document.

--- a/crates/hwpforge-core/src/layout.rs
+++ b/crates/hwpforge-core/src/layout.rs
@@ -1,0 +1,326 @@
+//! Line layout cache (줄 조판 캐시) — Hancom 이 문서에 저장하는 조판 결과.
+//!
+//! HWPX 의 `<hp:linesegarray>`/`<hp:lineseg>` 와 HWP5 의 `PARA_LINE_SEG`
+//! (36바이트 레코드) 가 같은 의미의 캐시를 나른다. 이 모듈은 그 캐시를
+//! 공유 모델로 승격한 **decode-only** 표현이다:
+//!
+//! - 디코더(HWPX/HWP5)는 wire 의 캐시를 [`LayoutCache`] 로 승격한다.
+//! - 인코더는 기본적으로 캐시를 **방출하지 않는다** (opt-in 전용).
+//!   기존 byte-splice 보존(`layout_carry`)·제거(`strip_line_segs`) 불변식은
+//!   그대로 유지된다.
+//! - 문서 동등성 비교(admission/golden)는 캐시를 정규화(제거)한 사본으로
+//!   수행한다 — [`crate::document::Document::strip_layout_caches`] 참조.
+//!
+//! 필드 이름·타입은 wire 를 그대로 미러링한다 (발명 금지 — KS X 6101
+//! `lineseg` 속성명 기준).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// 한 줄의 조판 결과 (HWPX `<hp:lineseg>` 1개 / HWP5 LINE_SEG 36바이트 1개).
+///
+/// 모든 좌표·크기 단위는 HWPUNIT (1pt = 100). `vertpos` 는 본문 흐름
+/// 기준 상대값이며 쪽 단위로 리셋된다 (표 셀 안에서는 셀 상대값).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct LineSeg {
+    /// 줄 시작 텍스트 위치 (문단 텍스트의 UTF-16 코드유닛 오프셋).
+    pub textpos: u32,
+    /// 줄 세로 위치 (컨테이너 상대, 쪽/셀 단위 리셋).
+    pub vertpos: i32,
+    /// 줄 전체 높이.
+    pub vertsize: i32,
+    /// 텍스트 부분 높이.
+    pub textheight: i32,
+    /// 줄 상단에서 베이스라인까지 거리.
+    pub baseline: i32,
+    /// 줄 간격 (다음 줄과의 간격).
+    pub spacing: i32,
+    /// 컬럼 기준 가로 시작 위치.
+    pub horzpos: i32,
+    /// 줄 가로 폭 (컬럼 폭).
+    pub horzsize: i32,
+    /// 줄 플래그 비트필드 (wire 그대로 보존 — 해석하지 않음).
+    pub flags: u32,
+}
+
+/// 문단 하나의 줄 조판 캐시 (HWPX `<hp:linesegarray>` 전체).
+///
+/// [`crate::paragraph::Paragraph::layout_cache`] 로 부착된다.
+/// `lines` 는 wire 순서(첫 줄부터)를 그대로 보존한다.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct LayoutCache {
+    /// 줄 세그먼트 목록 (wire 순서).
+    pub lines: Vec<LineSeg>,
+}
+
+impl LayoutCache {
+    /// 주어진 줄 세그먼트들로 캐시를 만든다.
+    pub fn new(lines: Vec<LineSeg>) -> Self {
+        Self { lines }
+    }
+
+    /// 줄 수를 반환한다.
+    pub fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// 줄이 하나도 없으면 `true`.
+    pub fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(textpos: u32, vertpos: i32) -> LineSeg {
+        LineSeg {
+            textpos,
+            vertpos,
+            vertsize: 1000,
+            textheight: 1000,
+            baseline: 850,
+            spacing: 600,
+            horzpos: 0,
+            horzsize: 48188,
+            flags: 0x0060_0000,
+        }
+    }
+
+    #[test]
+    fn lineseg_boundary_values_roundtrip_serde() {
+        let s = LineSeg {
+            textpos: u32::MAX,
+            vertpos: i32::MIN,
+            vertsize: i32::MAX,
+            textheight: 0,
+            baseline: -1,
+            spacing: i32::MIN,
+            horzpos: i32::MAX,
+            horzsize: 0,
+            flags: u32::MAX,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: LineSeg = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, back);
+    }
+
+    #[test]
+    fn layout_cache_default_is_empty() {
+        let c = LayoutCache::default();
+        assert!(c.is_empty());
+        assert_eq!(c.line_count(), 0);
+    }
+
+    #[test]
+    fn layout_cache_preserves_wire_order() {
+        let c = LayoutCache::new(vec![seg(0, 0), seg(70, 1600), seg(122, 3200)]);
+        assert_eq!(c.line_count(), 3);
+        assert_eq!(c.lines[1].textpos, 70);
+        assert_eq!(c.lines[2].vertpos, 3200);
+    }
+
+    #[test]
+    fn layout_cache_eq_is_structural() {
+        let a = LayoutCache::new(vec![seg(0, 0)]);
+        let b = LayoutCache::new(vec![seg(0, 0)]);
+        let c = LayoutCache::new(vec![seg(0, 16)]);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn paragraph_json_without_cache_field_deserializes() {
+        // 구버전 to-json 산출물(layout_cache 필드 없음) 하위호환
+        let old_json = r#"{"runs":[],"para_shape_id":0}"#;
+        let p: crate::paragraph::Paragraph = serde_json::from_str(old_json).unwrap();
+        assert!(p.layout_cache.is_none());
+    }
+
+    #[test]
+    fn paragraph_json_omits_cache_when_none() {
+        let p = crate::paragraph::Paragraph::new(hwpforge_foundation::ParaShapeIndex::new(0));
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(!json.contains("layout_cache"), "None 캐시는 직렬화 생략: {json}");
+        let mut cached = p.clone();
+        cached.layout_cache = Some(LayoutCache::new(vec![seg(0, 0)]));
+        let json2 = serde_json::to_string(&cached).unwrap();
+        assert!(json2.contains("layout_cache"));
+        let back: crate::paragraph::Paragraph = serde_json::from_str(&json2).unwrap();
+        assert_eq!(cached, back);
+    }
+
+    // -----------------------------------------------------------------------
+    // 순회/정규화 완전성: 모든 문단 컨테이너를 한 문서에 담아 검증한다.
+    // -----------------------------------------------------------------------
+
+    mod traversal {
+        use super::*;
+        use crate::caption::{Caption, CaptionSide};
+        use crate::control::Control;
+        use crate::document::Document;
+        use crate::page::PageSettings;
+        use crate::paragraph::Paragraph;
+        use crate::run::Run;
+        use crate::section::{HeaderFooter, MasterPage, Section};
+        use crate::table::{Table, TableCell, TableRow};
+        use hwpforge_foundation::{ApplyPageType, CharShapeIndex, HwpUnit, ParaShapeIndex};
+
+        /// 캐시가 박힌 문단 (텍스트로 방문 추적).
+        fn cached_para(text: &str) -> Paragraph {
+            let mut p = Paragraph::with_runs(
+                vec![Run::text(text, CharShapeIndex::new(0))],
+                ParaShapeIndex::new(0),
+            );
+            p.layout_cache = Some(LayoutCache::new(vec![seg(0, 0)]));
+            p
+        }
+
+        fn one_cell_table(cell_para: Paragraph) -> Table {
+            Table::new(vec![TableRow::new(vec![TableCell::new(
+                vec![cell_para],
+                HwpUnit::from_pt(100.0).unwrap(),
+            )])])
+        }
+
+        /// 모든 문단 컨테이너를 담은 문서: 본문·표 셀(중첩 표 포함)·표 캡션·
+        /// 머리말·꼬리말·바탕쪽·글상자(+캡션)·묶음(재귀)·메모(본문+앵커 run)·
+        /// 각주·타원 본문.
+        fn document_with_all_containers() -> (Document<crate::document::Draft>, usize) {
+            let mut expected = 0usize;
+
+            // 본문 + 중첩 표(셀 문단 안에 또 표) + 표 캡션
+            let inner = one_cell_table(cached_para("inner-cell"));
+            let mut mid_cell = cached_para("mid-cell");
+            mid_cell.add_run(Run::table(inner, CharShapeIndex::new(0)));
+            let outer = one_cell_table(mid_cell)
+                .with_caption(Caption::new(vec![cached_para("tbl-caption")], CaptionSide::Bottom));
+            let mut host = cached_para("tbl-host");
+            host.add_run(Run::table(outer, CharShapeIndex::new(0)));
+            expected += 4; // host + mid-cell + inner-cell + caption
+
+            // 글상자(+캡션) — 캡션은 variant 필드라 직접 부착
+            let mut textbox = Control::text_box(
+                vec![cached_para("textbox-body")],
+                HwpUnit::from_pt(100.0).unwrap(),
+                HwpUnit::from_pt(50.0).unwrap(),
+            );
+            if let Control::TextBox { caption, .. } = &mut textbox {
+                *caption =
+                    Some(Caption::new(vec![cached_para("textbox-caption")], CaptionSide::Top));
+            }
+            let mut tb_host = cached_para("textbox-host");
+            tb_host.add_run(Run::control(textbox, CharShapeIndex::new(0)));
+            expected += 3; // host + body + caption
+
+            // 묶음(재귀) — 자식 글상자
+            let child = Control::text_box(
+                vec![cached_para("group-child-body")],
+                HwpUnit::from_pt(10.0).unwrap(),
+                HwpUnit::from_pt(10.0).unwrap(),
+            );
+            let group = Control::Group {
+                children: vec![child],
+                width: HwpUnit::from_pt(10.0).unwrap(),
+                height: HwpUnit::from_pt(10.0).unwrap(),
+                horz_offset: 0,
+                vert_offset: 0,
+                inst_id: None,
+            };
+            let mut group_host = cached_para("group-host");
+            group_host.add_run(Run::control(group, CharShapeIndex::new(0)));
+            expected += 2; // host + child body
+
+            // 메모: 본문 + 앵커 run 속 표 셀
+            let memo = Control::memo_with_anchor(
+                vec![cached_para("memo-body")],
+                vec![Run::table(
+                    one_cell_table(cached_para("memo-anchor-cell")),
+                    CharShapeIndex::new(0),
+                )],
+            );
+            let mut memo_host = cached_para("memo-host");
+            memo_host.add_run(Run::control(memo, CharShapeIndex::new(0)));
+            expected += 3; // host + body + anchor cell
+
+            // 각주 + 타원 본문 (한 문단에 함께)
+            let mut note_host = cached_para("note-host");
+            note_host.add_run(Run::control(
+                Control::footnote(vec![cached_para("footnote-body")]),
+                CharShapeIndex::new(0),
+            ));
+            note_host.add_run(Run::control(
+                Control::ellipse_with_text(
+                    HwpUnit::from_pt(20.0).unwrap(),
+                    HwpUnit::from_pt(20.0).unwrap(),
+                    vec![cached_para("ellipse-body")],
+                ),
+                CharShapeIndex::new(0),
+            ));
+            expected += 3; // host + footnote + ellipse
+
+            let mut section = Section::with_paragraphs(
+                vec![host, tb_host, group_host, memo_host, note_host],
+                PageSettings::a4(),
+            );
+            section.headers.push(HeaderFooter::all_pages(vec![cached_para("header")]));
+            section.footers.push(HeaderFooter::all_pages(vec![cached_para("footer")]));
+            section.master_pages =
+                Some(vec![MasterPage::new(ApplyPageType::Both, vec![cached_para("master")])]);
+            expected += 3; // header + footer + master
+
+            let mut doc = Document::new();
+            doc.add_section(section);
+            (doc, expected)
+        }
+
+        #[test]
+        fn for_each_paragraph_mut_visits_every_container() {
+            let (mut doc, expected) = document_with_all_containers();
+            let mut visited = Vec::new();
+            doc.for_each_paragraph_mut(|p| visited.push(p.text_content()));
+            assert_eq!(visited.len(), expected, "visited: {visited:?}");
+            // 대표 중첩 지점들이 실제로 방문됐는지
+            for needle in [
+                "inner-cell",
+                "tbl-caption",
+                "textbox-caption",
+                "group-child-body",
+                "memo-anchor-cell",
+                "footnote-body",
+                "master",
+            ] {
+                assert!(visited.iter().any(|t| t == needle), "missing {needle}: {visited:?}");
+            }
+        }
+
+        #[test]
+        fn strip_layout_caches_clears_every_container() {
+            let (mut doc, expected) = document_with_all_containers();
+            doc.strip_layout_caches();
+            let mut remaining = 0;
+            let mut total = 0;
+            doc.for_each_paragraph_mut(|p| {
+                total += 1;
+                if p.layout_cache.is_some() {
+                    remaining += 1;
+                }
+            });
+            assert_eq!(total, expected);
+            assert_eq!(remaining, 0);
+        }
+
+        #[test]
+        fn cache_difference_breaks_eq_until_stripped() {
+            let (doc_a, _) = document_with_all_containers();
+            let (mut doc_b, _) = document_with_all_containers();
+            assert_eq!(doc_a, doc_b);
+            doc_b.strip_layout_caches();
+            assert_ne!(doc_a, doc_b, "derived eq must still see cache differences");
+            let mut doc_a2 = doc_a.clone();
+            doc_a2.strip_layout_caches();
+            assert_eq!(doc_a2, doc_b, "normalized copies must compare equal");
+        }
+    }
+}

--- a/crates/hwpforge-core/src/lib.rs
+++ b/crates/hwpforge-core/src/lib.rs
@@ -88,6 +88,7 @@ pub mod document;
 pub mod error;
 pub mod image;
 pub mod inline;
+pub mod layout;
 pub mod metadata;
 pub mod numbering;
 pub mod object_id;

--- a/crates/hwpforge-core/src/metadata.rs
+++ b/crates/hwpforge-core/src/metadata.rs
@@ -13,11 +13,9 @@
 //! ```
 //! use hwpforge_core::Metadata;
 //!
-//! let meta = Metadata {
-//!     title: Some("Quarterly Report".to_string()),
-//!     author: Some("Kim".to_string()),
-//!     ..Metadata::default()
-//! };
+//! let meta = Metadata::new()
+//!     .with_title("Quarterly Report")
+//!     .with_author("Kim");
 //! assert_eq!(meta.title.as_deref(), Some("Quarterly Report"));
 //! assert!(meta.subject.is_none());
 //! ```

--- a/crates/hwpforge-core/src/paragraph.rs
+++ b/crates/hwpforge-core/src/paragraph.rs
@@ -72,6 +72,15 @@ pub struct Paragraph {
     /// `None` means 바탕글 (style 0, the default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub style_id: Option<StyleIndex>,
+    /// Hancom 이 저장한 줄 조판 캐시 (decode-only 승격).
+    ///
+    /// HWPX `<hp:linesegarray>` / HWP5 `PARA_LINE_SEG` 에서 디코더가
+    /// 채운다. `None` = 캐시 없음 (우리 순수 생성물의 정상 상태).
+    /// 인코더는 기본적으로 이 필드를 방출하지 않는다 (opt-in 전용).
+    /// 문서 동등성 비교(admission/golden)는 이 필드를 정규화한 사본으로
+    /// 수행한다 — [`crate::document::Document::strip_layout_caches`] 참조.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layout_cache: Option<crate::layout::LayoutCache>,
 }
 
 impl Paragraph {
@@ -94,6 +103,7 @@ impl Paragraph {
             page_break: false,
             heading_level: None,
             style_id: None,
+            layout_cache: None,
         }
     }
 
@@ -120,6 +130,25 @@ impl Paragraph {
             page_break: false,
             heading_level: None,
             style_id: None,
+            layout_cache: None,
+        }
+    }
+
+    /// 이 문단 자신과 안에 중첩된 모든 문단(표 셀·캡션·글상자·각주/미주·
+    /// 메모 등)을 문서 순서로 방문한다.
+    ///
+    /// 자신을 먼저 방문한 뒤 run 내용물로 재귀한다. 캐시 정규화 등
+    /// 전 문단 일괄 변환의 기반 유틸 —
+    /// [`crate::document::Document::for_each_paragraph_mut`] 참조.
+    pub fn for_each_paragraph_mut<F: FnMut(&mut Paragraph)>(&mut self, mut f: F) {
+        self.walk_paragraphs_mut(&mut f);
+    }
+
+    /// [`Self::for_each_paragraph_mut`] 의 내부 재귀 본체 (dyn 으로 단형화 제한).
+    pub(crate) fn walk_paragraphs_mut(&mut self, f: &mut dyn FnMut(&mut Paragraph)) {
+        f(self);
+        for run in &mut self.runs {
+            run.walk_paragraphs_mut(f);
         }
     }
 

--- a/crates/hwpforge-core/src/run.rs
+++ b/crates/hwpforge-core/src/run.rs
@@ -59,6 +59,18 @@ pub struct Run {
 }
 
 impl Run {
+    /// 이 run 안에 중첩된 모든 문단을 재귀 방문한다 (표 셀·캡션·컨트롤 포함).
+    pub(crate) fn walk_paragraphs_mut(
+        &mut self,
+        f: &mut dyn FnMut(&mut crate::paragraph::Paragraph),
+    ) {
+        match &mut self.content {
+            RunContent::Table(table) => table.walk_paragraphs_mut(f),
+            RunContent::Control(control) => control.walk_paragraphs_mut(f),
+            RunContent::Text(_) | RunContent::InlineText(_) | RunContent::Image(_) => {}
+        }
+    }
+
     /// Creates a text run.
     ///
     /// This is the most common constructor. Most runs in a typical

--- a/crates/hwpforge-core/src/section.rs
+++ b/crates/hwpforge-core/src/section.rs
@@ -494,6 +494,31 @@ pub struct Section {
 }
 
 impl Section {
+    /// 이 섹션의 모든 문단(본문·머리말·꼬리말·바탕쪽 + 각 문단의 중첩)을
+    /// 문서 순서로 방문한다.
+    pub fn for_each_paragraph_mut<F: FnMut(&mut Paragraph)>(&mut self, mut f: F) {
+        self.walk_paragraphs_mut(&mut f);
+    }
+
+    /// [`Self::for_each_paragraph_mut`] 의 내부 재귀 본체.
+    pub(crate) fn walk_paragraphs_mut(&mut self, f: &mut dyn FnMut(&mut Paragraph)) {
+        for p in &mut self.paragraphs {
+            p.walk_paragraphs_mut(f);
+        }
+        for hf in self.headers.iter_mut().chain(self.footers.iter_mut()) {
+            for p in &mut hf.paragraphs {
+                p.walk_paragraphs_mut(f);
+            }
+        }
+        if let Some(master_pages) = &mut self.master_pages {
+            for mp in master_pages {
+                for p in &mut mp.paragraphs {
+                    p.walk_paragraphs_mut(f);
+                }
+            }
+        }
+    }
+
     /// Creates an empty section with the given page settings.
     ///
     /// # Examples

--- a/crates/hwpforge-core/src/table/mod.rs
+++ b/crates/hwpforge-core/src/table/mod.rs
@@ -163,6 +163,23 @@ impl Table {
         }
     }
 
+    /// 표의 모든 셀 문단과 캡션 문단을 재귀 방문한다 (중첩 표 포함).
+    pub(crate) fn walk_paragraphs_mut(
+        &mut self,
+        f: &mut dyn FnMut(&mut crate::paragraph::Paragraph),
+    ) {
+        for row in &mut self.rows {
+            for cell in &mut row.cells {
+                for p in &mut cell.paragraphs {
+                    p.walk_paragraphs_mut(f);
+                }
+            }
+        }
+        if let Some(caption) = &mut self.caption {
+            caption.walk_paragraphs_mut(f);
+        }
+    }
+
     /// Sets an explicit table width.
     #[must_use]
     pub fn with_width(mut self, width: HwpUnit) -> Self {

--- a/crates/hwpforge-smithy-hwp5/src/projection/mod.rs
+++ b/crates/hwpforge-smithy-hwp5/src/projection/mod.rs
@@ -787,7 +787,37 @@ fn project_paragraph_with_images_flat(
     if hwp_para.style_id > 0 {
         paragraph = paragraph.with_style(StyleIndex::new(hwp_para.style_id as usize));
     }
+    paragraph.layout_cache = promote_line_segments(&hwp_para.line_segments);
     paragraph
+}
+
+/// HWP5 `PARA_LINE_SEG` 레코드(36바이트×N)를 Core 조판 캐시로 승격한다
+/// (decode-only — 인코더 방출은 convert opt-in 전용).
+///
+/// 필드 대응은 이름만 다르고 wire 의미는 HWPX `<hp:lineseg>` 와 동일하다.
+/// 세그먼트가 없으면 `None` (HWP5 네이티브 문단은 항상 1개 이상 보유 —
+/// 없음 = 캐시 부재 의미).
+fn promote_line_segments(
+    segs: &[crate::schema::section::Hwp5ParaLineSeg],
+) -> Option<hwpforge_core::layout::LayoutCache> {
+    if segs.is_empty() {
+        return None;
+    }
+    Some(hwpforge_core::layout::LayoutCache::new(
+        segs.iter()
+            .map(|s| hwpforge_core::layout::LineSeg {
+                textpos: s.text_start_position,
+                vertpos: s.vertical_position,
+                vertsize: s.line_height,
+                textheight: s.text_height,
+                baseline: s.baseline_distance,
+                spacing: s.line_spacing,
+                horzpos: s.column_start_position,
+                horzsize: s.segment_width,
+                flags: s.tag,
+            })
+            .collect(),
+    ))
 }
 
 fn project_paragraph_with_images_structural(
@@ -925,6 +955,7 @@ fn project_paragraph_with_images_structural(
     if hwp_para.style_id > 0 {
         paragraph = paragraph.with_style(StyleIndex::new(hwp_para.style_id as usize));
     }
+    paragraph.layout_cache = promote_line_segments(&hwp_para.line_segments);
 
     ProjectedParagraph { paragraph }
 }
@@ -3176,6 +3207,48 @@ mod tests {
             line_segments: Vec::new(),
             controls: vec![],
         }
+    }
+
+    #[test]
+    fn line_segments_promote_to_layout_cache() {
+        use crate::schema::section::Hwp5ParaLineSeg;
+        let segs = vec![
+            Hwp5ParaLineSeg {
+                text_start_position: 0,
+                vertical_position: 0,
+                line_height: 1000,
+                text_height: 1000,
+                baseline_distance: 850,
+                line_spacing: 600,
+                column_start_position: 10,
+                segment_width: 42520,
+                tag: 0x0060_0000,
+            },
+            Hwp5ParaLineSeg {
+                text_start_position: 35,
+                vertical_position: 1600,
+                line_height: 1000,
+                text_height: 1000,
+                baseline_distance: 850,
+                line_spacing: 600,
+                column_start_position: 10,
+                segment_width: 42520,
+                tag: 0x0016_0000,
+            },
+        ];
+        let cache = promote_line_segments(&segs).expect("promoted");
+        assert_eq!(cache.line_count(), 2);
+        // 필드 대응: 이름만 다르고 wire 의미 동일 (textpos/vertpos/vertsize/…)
+        assert_eq!(cache.lines[0].horzpos, 10);
+        assert_eq!(cache.lines[0].horzsize, 42520);
+        assert_eq!(cache.lines[1].textpos, 35);
+        assert_eq!(cache.lines[1].vertpos, 1600);
+        assert_eq!(cache.lines[1].vertsize, 1000);
+        assert_eq!(cache.lines[1].baseline, 850);
+        assert_eq!(cache.lines[1].spacing, 600);
+        assert_eq!(cache.lines[1].flags, 0x0016_0000);
+        // 세그먼트 없음 = 캐시 부재
+        assert!(promote_line_segments(&[]).is_none());
     }
 
     fn make_section(

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -315,6 +315,28 @@ fn convert_paragraph(
     let style_id =
         if hx.style_id_ref == 0 { None } else { Some(StyleIndex::new(hx.style_id_ref as usize)) };
 
+    // 줄 조판 캐시 승격 (decode-only): <hp:linesegarray> 를 wire 그대로
+    // Core LayoutCache 로 나른다. 인코더는 기본적으로 재방출하지 않는다.
+    let layout_cache = hx.linesegarray.as_ref().map(|array| {
+        hwpforge_core::layout::LayoutCache::new(
+            array
+                .items
+                .iter()
+                .map(|s| hwpforge_core::layout::LineSeg {
+                    textpos: s.textpos,
+                    vertpos: s.vertpos,
+                    vertsize: s.vertsize,
+                    textheight: s.textheight,
+                    baseline: s.baseline,
+                    spacing: s.spacing,
+                    horzpos: s.horzpos,
+                    horzsize: s.horzsize,
+                    flags: s.flags,
+                })
+                .collect(),
+        )
+    });
+
     let paragraph = Paragraph {
         runs,
         para_shape_id,
@@ -322,6 +344,7 @@ fn convert_paragraph(
         page_break: hx.page_break != 0,
         heading_level,
         style_id,
+        layout_cache,
     };
     Ok((paragraph, page_settings))
 }
@@ -1578,6 +1601,41 @@ mod tests {
         assert_eq!(para.para_shape_id.get(), 0);
         assert_eq!(para.runs.len(), 1);
         assert_eq!(para.runs[0].content.as_text(), Some("안녕하세요"));
+    }
+
+    #[test]
+    fn linesegarray_is_promoted_to_layout_cache() {
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0"><t>본문</t></run>
+                <linesegarray>
+                    <lineseg textpos="0" vertpos="0" vertsize="1000" textheight="1000"
+                             baseline="850" spacing="600" horzpos="0" horzsize="48188"
+                             flags="393216"/>
+                    <lineseg textpos="70" vertpos="1600" vertsize="1000" textheight="1000"
+                             baseline="850" spacing="600" horzpos="0" horzsize="48188"
+                             flags="1441792"/>
+                </linesegarray>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        let cache = result.paragraphs[0].layout_cache.as_ref().expect("cache promoted");
+        assert_eq!(cache.line_count(), 2);
+        assert_eq!(cache.lines[0].vertsize, 1000);
+        assert_eq!(cache.lines[1].textpos, 70);
+        assert_eq!(cache.lines[1].vertpos, 1600);
+        assert_eq!(cache.lines[1].flags, 1_441_792);
+    }
+
+    #[test]
+    fn paragraph_without_linesegarray_has_no_layout_cache() {
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0"><t>본문</t></run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        assert!(result.paragraphs[0].layout_cache.is_none());
     }
 
     #[test]

--- a/crates/hwpforge-smithy-hwpx/src/decoder/shapes.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/shapes.rs
@@ -1790,7 +1790,13 @@ mod tests {
             text_vertical_align: VerticalAlign::Center,
         };
         let mut hl = Vec::new();
-        let hx = crate::encoder::shapes::encode_ellipse_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let hx = crate::encoder::shapes::encode_ellipse_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            crate::encoder::EncodeOptions::default(),
+        )
+        .unwrap();
         assert_eq!(
             hx.draw_text.as_ref().unwrap().sub_list.vert_align,
             "CENTER",

--- a/crates/hwpforge-smithy-hwpx/src/encoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/mod.rs
@@ -476,6 +476,35 @@ use self::section::encode_section;
 
 // ── HwpxEncoder ─────────────────────────────────────────────────
 
+/// Encoder behavior options.
+///
+/// [`Default`] 는 현행 인코더 동작 그대로다 (출력 바이트 불변).
+/// `#[non_exhaustive]` — 외부에서는 [`EncodeOptions::default`] 후
+/// 세터로 조정한다.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct EncodeOptions {
+    /// `true` 면 [`Paragraph::layout_cache`](hwpforge_core::paragraph::Paragraph::layout_cache)
+    /// 를 `<hp:linesegarray>` 로 방출한다. 기본 `false`.
+    ///
+    /// ⚠️ 이 opt-in 은 **PDF 재생/비교 파이프라인 전용**이다 (HWP5→HWPX
+    /// convert carry). 편집 표면은 절대 켜지 않는다 — 승격된 캐시를
+    /// 무검증 방출하면 `layout_carry` 의 "이미 있으면 스킵" 안전장치가
+    /// fail-open 이 된다. 또한 과거 convert 가 HWP5 lineseg 를 carry 했다가
+    /// 한컴에서 다중행 텍스트 겹침을 일으켜 제거한 이력이 있다 — 이
+    /// 산출물은 한컴 재개봉 용도가 아니다.
+    pub emit_layout_cache: bool,
+}
+
+impl EncodeOptions {
+    /// 캐시 방출 여부를 설정한다 (기본 `false`).
+    #[must_use]
+    pub fn with_emit_layout_cache(mut self, emit: bool) -> Self {
+        self.emit_layout_cache = emit;
+        self
+    }
+}
+
 /// Encodes Core documents to HWPX format (ZIP + XML).
 ///
 /// This is the reverse of [`crate::HwpxDecoder`]: it takes a validated
@@ -526,6 +555,19 @@ impl HwpxEncoder {
         style_store: &HwpxStyleStore,
         image_store: &ImageStore,
     ) -> HwpxResult<Vec<u8>> {
+        Self::encode_with_options(document, style_store, image_store, EncodeOptions::default())
+    }
+
+    /// [`Self::encode`] 에 동작 옵션([`EncodeOptions`])을 더한 변형.
+    ///
+    /// `EncodeOptions::default()` 를 넘기면 [`Self::encode`] 와 바이트
+    /// 단위로 동일한 출력을 낸다.
+    pub fn encode_with_options(
+        document: &Document<Validated>,
+        style_store: &HwpxStyleStore,
+        image_store: &ImageStore,
+        options: EncodeOptions,
+    ) -> HwpxResult<Vec<u8>> {
         let sections = document.sections();
         let sec_cnt = sections.len() as u32;
 
@@ -542,8 +584,14 @@ impl HwpxEncoder {
         let mut embedded_ole_offset = 0usize;
         let mut section_results = Vec::with_capacity(sections.len());
         for (i, section) in sections.iter().enumerate() {
-            let result =
-                encode_section(section, i, chart_offset, masterpage_offset, embedded_ole_offset)?;
+            let result = encode_section(
+                section,
+                i,
+                chart_offset,
+                masterpage_offset,
+                embedded_ole_offset,
+                options,
+            )?;
             chart_offset += result.charts.len();
             masterpage_offset += result.master_pages.len();
             embedded_ole_offset += result.embedded_oles.len();

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -70,11 +70,13 @@ use hwpforge_foundation::{BookmarkType, DropCapStyle, HwpUnit, TextDirection};
 use crate::schema::section::{
     HxBookmark, HxCaption, HxCellAddr, HxCellSpan, HxCellSz, HxChart, HxCompose, HxComposeCharPr,
     HxCtrl, HxDutmal, HxEquation, HxFlip, HxFootNote, HxImg, HxImgClip, HxImgDim, HxImgRect,
-    HxIndexMark, HxMatrix, HxOffset, HxPageMargin, HxPagePr, HxParagraph, HxPic, HxPoint,
-    HxRenderingInfo, HxRotationInfo, HxRun, HxRunCase, HxRunSwitch, HxScript, HxSecPr, HxSection,
-    HxShapeComment, HxSizeAttr, HxSubList, HxTable, HxTableCell, HxTableMargin, HxTablePos,
-    HxTableRow, HxTableSz, HxText, HxTitleMark,
+    HxIndexMark, HxLineSeg, HxLineSegArray, HxMatrix, HxOffset, HxPageMargin, HxPagePr,
+    HxParagraph, HxPic, HxPoint, HxRenderingInfo, HxRotationInfo, HxRun, HxRunCase, HxRunSwitch,
+    HxScript, HxSecPr, HxSection, HxShapeComment, HxSizeAttr, HxSubList, HxTable, HxTableCell,
+    HxTableMargin, HxTablePos, HxTableRow, HxTableSz, HxText, HxTitleMark,
 };
+
+use super::EncodeOptions;
 
 use self::chart::{build_embedded_chart_run_xml, encode_chart_switch};
 use self::equation::encode_equation_to_hx;
@@ -180,6 +182,7 @@ pub(crate) fn encode_section(
     chart_offset: usize,
     masterpage_offset: usize,
     embedded_ole_offset: usize,
+    options: EncodeOptions,
 ) -> HwpxResult<SectionEncodeResult> {
     let mut chart_entries: Vec<(String, String)> = Vec::new();
     let mut embedded_oles: Vec<(String, Vec<u8>)> = Vec::new();
@@ -193,6 +196,7 @@ pub(crate) fn encode_section(
         &mut run_xml_replacements,
         chart_offset,
         embedded_ole_offset,
+        options,
     )?;
     let inner_xml = quick_xml::se::to_string(&hx_section)
         .map_err(|e| HwpxError::XmlSerialize { detail: e.to_string() })?;
@@ -207,7 +211,7 @@ pub(crate) fn encode_section(
     let mut enriched = enrich_sec_pr(inner_content, section, masterpage_offset);
 
     // Inject header/footer/page number controls after colPr
-    inject_header_footer_pagenum(&mut enriched, section, &mut run_xml_replacements)?;
+    inject_header_footer_pagenum(&mut enriched, section, &mut run_xml_replacements, options)?;
 
     // Replace hyperlink placeholder runs with real interleaved XML.
     // Serde cannot express the ctrl-text-ctrl interleaving required by
@@ -319,6 +323,7 @@ fn strip_root_element(xml: &str) -> &str {
 }
 
 /// Builds an `HxSection` from a Core `Section`.
+#[allow(clippy::too_many_arguments)]
 fn build_section(
     section: &Section,
     chart_entries: &mut Vec<(String, String)>,
@@ -326,6 +331,7 @@ fn build_section(
     hyperlink_entries: &mut Vec<(String, String)>,
     chart_offset: usize,
     embedded_ole_offset: usize,
+    options: EncodeOptions,
 ) -> HwpxResult<HxSection> {
     let paragraphs = section
         .paragraphs
@@ -346,6 +352,7 @@ fn build_section(
                 hyperlink_entries,
                 chart_offset,
                 embedded_ole_offset,
+                options,
             )
             // (signature already plumbs embedded chart OLE state through)
         })
@@ -372,6 +379,7 @@ fn build_paragraph(
     hyperlink_entries: &mut Vec<(String, String)>,
     chart_offset: usize,
     embedded_ole_offset: usize,
+    options: EncodeOptions,
 ) -> HwpxResult<HxParagraph> {
     let mut runs = build_runs(
         &para.runs,
@@ -384,6 +392,7 @@ fn build_paragraph(
         hyperlink_entries,
         chart_offset,
         embedded_ole_offset,
+        options,
     )?;
 
     // Inject <hp:titleMark ignore="false"/> into the first run when the
@@ -398,7 +407,31 @@ fn build_paragraph(
     // Previously we emitted a 1-seg placeholder, but justify alignment
     // relied on accurate per-line data — causing character overlap for
     // multi-line paragraphs. Omitting it forces 한글 to compute properly.
-    let linesegarray = None;
+    //
+    // Exception (opt-in, PDF 재생/비교 파이프라인 전용): emit_layout_cache
+    // 가 켜지면 Core 로 승격된 캐시를 wire 그대로 되돌려 방출한다.
+    // 편집 표면은 절대 켜지 않는다 — EncodeOptions::emit_layout_cache 문서 참조.
+    let linesegarray = if options.emit_layout_cache {
+        para.layout_cache.as_ref().map(|cache| HxLineSegArray {
+            items: cache
+                .lines
+                .iter()
+                .map(|l| HxLineSeg {
+                    textpos: l.textpos,
+                    vertpos: l.vertpos,
+                    vertsize: l.vertsize,
+                    textheight: l.textheight,
+                    baseline: l.baseline,
+                    spacing: l.spacing,
+                    horzpos: l.horzpos,
+                    horzsize: l.horzsize,
+                    flags: l.flags,
+                })
+                .collect(),
+        })
+    } else {
+        None
+    };
 
     Ok(HxParagraph {
         id: format!("{para_idx}"),
@@ -434,6 +467,7 @@ fn build_runs(
     hyperlink_entries: &mut Vec<(String, String)>,
     chart_offset: usize,
     embedded_ole_offset: usize,
+    options: EncodeOptions,
 ) -> HwpxResult<Vec<HxRun>> {
     let mut result = Vec::new();
     let mut sec_pr_injected = false;
@@ -489,46 +523,62 @@ fn build_runs(
                 texts.push(HxText::new(marker));
             }
             RunContent::Table(t) => {
-                tables.push(build_table(t, depth, hyperlink_entries)?);
+                tables.push(build_table(t, depth, hyperlink_entries, options)?);
             }
             RunContent::Image(img) => {
-                pictures.push(build_picture(img, depth, hyperlink_entries)?);
+                pictures.push(build_picture(img, depth, hyperlink_entries, options)?);
             }
             RunContent::Control(ctrl) => {
                 match ctrl.as_ref() {
                     Control::Footnote { .. } | Control::Endnote { .. } => {
                         if let Some(hx_ctrl) =
-                            encode_control_to_ctrl(ctrl, depth, hyperlink_entries)?
+                            encode_control_to_ctrl(ctrl, depth, hyperlink_entries, options)?
                         {
                             ctrls.push(hx_ctrl);
                         }
                     }
                     Control::TextBox { .. } => {
-                        rects.push(encode_textbox_to_rect(ctrl, depth, hyperlink_entries)?);
+                        rects.push(encode_textbox_to_rect(
+                            ctrl,
+                            depth,
+                            hyperlink_entries,
+                            options,
+                        )?);
                     }
                     Control::Rect { .. } => {
-                        rects.push(encode_rect_to_hx(ctrl, depth, hyperlink_entries)?);
+                        rects.push(encode_rect_to_hx(ctrl, depth, hyperlink_entries, options)?);
                     }
                     Control::Line { .. } => {
-                        lines.push(encode_line_to_hx(ctrl, depth, hyperlink_entries)?);
+                        lines.push(encode_line_to_hx(ctrl, depth, hyperlink_entries, options)?);
                     }
                     Control::Ellipse { .. } => {
-                        ellipses.push(encode_ellipse_to_hx(ctrl, depth, hyperlink_entries)?);
+                        ellipses.push(encode_ellipse_to_hx(
+                            ctrl,
+                            depth,
+                            hyperlink_entries,
+                            options,
+                        )?);
                     }
                     Control::Polygon { .. } => {
-                        polygons.push(encode_polygon_to_hx(ctrl, depth, hyperlink_entries)?);
+                        polygons.push(encode_polygon_to_hx(
+                            ctrl,
+                            depth,
+                            hyperlink_entries,
+                            options,
+                        )?);
                     }
                     Control::Arc { .. } => {
-                        ellipses.push(encode_arc_to_hx(ctrl, depth, hyperlink_entries)?);
+                        ellipses.push(encode_arc_to_hx(ctrl, depth, hyperlink_entries, options)?);
                     }
                     Control::Curve { .. } => {
-                        curves.push(encode_curve_to_hx(ctrl, depth, hyperlink_entries)?);
+                        curves.push(encode_curve_to_hx(ctrl, depth, hyperlink_entries, options)?);
                     }
                     Control::ConnectLine { .. } => {
                         connect_lines.push(encode_connect_line_to_hx(
                             ctrl,
                             depth,
                             hyperlink_entries,
+                            options,
                         )?);
                     }
                     Control::Equation { .. } => {
@@ -649,7 +699,7 @@ fn build_runs(
                     Control::IndexMark { .. }
                     | Control::Bookmark { bookmark_type: BookmarkType::Point, .. } => {
                         if let Some(hx_ctrl) =
-                            encode_control_to_ctrl(ctrl, depth, hyperlink_entries)?
+                            encode_control_to_ctrl(ctrl, depth, hyperlink_entries, options)?
                         {
                             ctrls.push(hx_ctrl);
                         }
@@ -843,7 +893,8 @@ fn build_runs(
                     Control::Memo { content, anchor_runs, metadata } => {
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPME", field_id);
-                        let sublist_xml = encode_memo_sublist(content, depth, hyperlink_entries)?;
+                        let sublist_xml =
+                            encode_memo_sublist(content, depth, hyperlink_entries, options)?;
                         let anchor_xml = build_memo_anchor_xml(anchor_runs);
                         let real_xml = build_memo_run_xml(
                             &sublist_xml,
@@ -864,8 +915,13 @@ fn build_runs(
                         // inside the container, so we build the full fragment
                         // and inject it via the marker-substitution path
                         // (mirroring hyperlink/memo/chart).
-                        let container_xml =
-                            super::shapes::encode_group_to_xml(ctrl, depth, 0, hyperlink_entries)?;
+                        let container_xml = super::shapes::encode_group_to_xml(
+                            ctrl,
+                            depth,
+                            0,
+                            hyperlink_entries,
+                            options,
+                        )?;
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPGRP", field_id);
                         let real_xml = format!(
@@ -976,19 +1032,30 @@ fn encode_control_to_ctrl(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<Option<HxCtrl>> {
     match ctrl {
         Control::Footnote { inst_id, paragraphs } => Ok(Some(HxCtrl {
             foot_note: Some(HxFootNote {
                 inst_id: inst_id.map(hwpforge_core::ObjectId::value),
-                sub_list: encode_paragraphs_to_sublist(paragraphs, depth, hyperlink_entries)?,
+                sub_list: encode_paragraphs_to_sublist(
+                    paragraphs,
+                    depth,
+                    hyperlink_entries,
+                    options,
+                )?,
             }),
             ..Default::default()
         })),
         Control::Endnote { inst_id, paragraphs } => Ok(Some(HxCtrl {
             end_note: Some(HxFootNote {
                 inst_id: inst_id.map(hwpforge_core::ObjectId::value),
-                sub_list: encode_paragraphs_to_sublist(paragraphs, depth, hyperlink_entries)?,
+                sub_list: encode_paragraphs_to_sublist(
+                    paragraphs,
+                    depth,
+                    hyperlink_entries,
+                    options,
+                )?,
             }),
             ..Default::default()
         })),
@@ -1013,8 +1080,9 @@ pub(crate) fn encode_paragraphs_to_sublist(
     paragraphs: &[Paragraph],
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxSubList> {
-    build_sublist(paragraphs, depth, "TOP", hyperlink_entries)
+    build_sublist(paragraphs, depth, "TOP", hyperlink_entries, options)
 }
 
 /// Encodes a `Vec<Paragraph>` into `HxSubList` with an explicit vertical
@@ -1025,8 +1093,9 @@ pub(crate) fn encode_paragraphs_to_sublist_with_align(
     depth: usize,
     vert_align: &str,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxSubList> {
-    build_sublist(paragraphs, depth, vert_align, hyperlink_entries)
+    build_sublist(paragraphs, depth, vert_align, hyperlink_entries, options)
 }
 
 fn build_sublist(
@@ -1034,6 +1103,7 @@ fn build_sublist(
     depth: usize,
     vert_align: &str,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxSubList> {
     let mut sub_chart_entries = Vec::new();
     let mut sub_embedded_oles: Vec<(String, Vec<u8>)> = Vec::new();
@@ -1053,6 +1123,7 @@ fn build_sublist(
                 hyperlink_entries,
                 0,
                 0,
+                options,
             )
         })
         .collect::<HwpxResult<Vec<_>>>()?;
@@ -1100,6 +1171,7 @@ pub(crate) fn build_hx_caption(
     parent_width: i32,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxCaption> {
     let side = match caption.side {
         CaptionSide::Left => "LEFT",
@@ -1111,7 +1183,8 @@ pub(crate) fn build_hx_caption(
 
     let width = caption.width.map(|w| w.as_i32()).unwrap_or(parent_width);
     let gap = caption.gap.as_i32();
-    let sub_list = encode_paragraphs_to_sublist(&caption.paragraphs, depth, hyperlink_entries)?;
+    let sub_list =
+        encode_paragraphs_to_sublist(&caption.paragraphs, depth, hyperlink_entries, options)?;
 
     // parent_width comes from HwpUnit::as_i32(), guaranteed non-negative
     Ok(HxCaption { side, full_sz: 0, width, gap, last_width: parent_width as u32, sub_list })
@@ -1211,7 +1284,7 @@ mod tests {
     #[test]
     fn encode_single_text_paragraph() {
         let section = simple_section("텍스트");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<?xml version="), "missing XML declaration");
         assert!(xml.contains("<hs:sec"), "missing <hs:sec> root");
@@ -1238,7 +1311,7 @@ mod tests {
     #[test]
     fn encode_text_paragraph_with_tab_emits_hp_tab_and_roundtrips() {
         let section = simple_section("LEFT\tRIGHT");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(
             xml.contains("<hp:t>LEFT<hp:tab/>RIGHT</hp:t>"),
@@ -1256,7 +1329,7 @@ mod tests {
     #[test]
     fn encode_section_roundtrip() {
         let section = simple_section("안녕하세요 round-trip test");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         // Parse back with the decoder
         let result =
@@ -1286,7 +1359,7 @@ mod tests {
             ..PageSettings::a4()
         };
         let section = Section::with_paragraphs(vec![text_paragraph("Content", 0, 0)], ps);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<hp:secPr"), "missing secPr");
         assert!(xml.contains(r#"textDirection="HORIZONTAL""#), "missing textDirection");
@@ -1327,7 +1400,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains(r#"rowCnt="1""#), "missing rowCnt");
         assert!(xml.contains(r#"colCnt="2""#), "missing colCnt");
@@ -1366,7 +1439,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains(r#"cellSpacing="120""#), "missing cellSpacing");
         assert!(xml.contains(r#"borderFillIDRef="9""#), "missing table borderFillIDRef");
@@ -1404,7 +1477,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(
             xml.contains(r#"cellSz width="7777" height="1226""#),
@@ -1433,7 +1506,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(
             xml.contains(r#"binaryItemIDRef="logo""#),
@@ -1455,7 +1528,7 @@ mod tests {
             ],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<hp:t>First</hp:t>"), "missing First");
         assert!(xml.contains("<hp:t>Second</hp:t>"), "missing Second");
@@ -1494,7 +1567,7 @@ mod tests {
         );
 
         // Should succeed within nesting limit
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:t>Deep</hp:t>"), "missing nested text");
     }
 
@@ -1517,7 +1590,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<hp:t>before</hp:t>"), "missing 'before' text");
         assert!(xml.contains("<hp:t>after</hp:t>"), "missing 'after' text");
@@ -1563,7 +1636,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<hp:t>before</hp:t>"), "missing 'before' text");
         assert!(xml.contains("<hp:t>after</hp:t>"), "missing 'after' text");
@@ -1581,7 +1654,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         // Should parse without error
         assert!(xml.contains("<hs:sec"), "missing root element");
@@ -1594,7 +1667,7 @@ mod tests {
     fn korean_text_preservation() {
         let korean = "우리는 수학을 공부한다.";
         let section = simple_section(korean);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         // Roundtrip through decoder
         let result =
@@ -1608,7 +1681,7 @@ mod tests {
     #[test]
     fn empty_section_produces_valid_xml() {
         let section = Section::new(PageSettings::a4());
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<hs:sec"), "missing root element");
         assert!(xml.contains("</hs:sec>"), "missing close tag");
@@ -1634,7 +1707,9 @@ mod tests {
     #[test]
     fn nesting_depth_exceeded() {
         let hx_table = Table::new(vec![]);
-        let err = build_table(&hx_table, MAX_NESTING_DEPTH, &mut Vec::new()).unwrap_err();
+        let err =
+            build_table(&hx_table, MAX_NESTING_DEPTH, &mut Vec::new(), EncodeOptions::default())
+                .unwrap_err();
         match &err {
             HwpxError::InvalidStructure { detail } => {
                 assert!(detail.contains("nesting depth"));
@@ -1655,7 +1730,7 @@ mod tests {
             1024,
         );
         let table = Table::new(vec![TableRow::new(vec![cell])]);
-        let err = build_table(&table, 0, &mut Vec::new()).unwrap_err();
+        let err = build_table(&table, 0, &mut Vec::new(), EncodeOptions::default()).unwrap_err();
         match &err {
             HwpxError::InvalidStructure { detail } => {
                 assert!(detail.contains("covered area"), "unexpected detail: {detail}");
@@ -1672,7 +1747,7 @@ mod tests {
             HwpUnit::new(500).unwrap(),
             ImageFormat::Jpeg,
         );
-        let hx = build_picture(&img, 0, &mut Vec::new()).unwrap();
+        let hx = build_picture(&img, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
         assert_eq!(
             hx.img.unwrap().binary_item_id_ref,
             "image",
@@ -1700,7 +1775,7 @@ mod tests {
             horz_offset: HwpUnit::new(3400).unwrap(),
         });
 
-        let hx = build_picture(&img, 0, &mut Vec::new()).unwrap();
+        let hx = build_picture(&img, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
         assert_eq!(hx.text_wrap, "SQUARE");
         assert_eq!(hx.text_flow, "RIGHT_ONLY");
         let pos = hx.pos.expect("position should be present");
@@ -1721,7 +1796,7 @@ mod tests {
             HwpUnit::new(5000).unwrap(),
             ImageFormat::Png,
         );
-        let hx = build_picture(&img, 0, &mut Vec::new()).unwrap();
+        let hx = build_picture(&img, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
         let pos = hx.pos.expect("picture position should exist");
 
         assert_eq!(hx.text_wrap, "TOP_AND_BOTTOM");
@@ -1741,7 +1816,7 @@ mod tests {
             vec![text_paragraph("p0", 3, 5), text_paragraph("p1", 7, 2)],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -1764,7 +1839,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -1793,7 +1868,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"pageBreak="TABLE""#), "missing table pageBreak override");
         assert!(xml.contains(r#"repeatHeader="0""#), "missing repeatHeader override");
         assert!(xml.contains(r#"header="1""#), "missing header row marker");
@@ -1822,7 +1897,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -1864,7 +1939,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -1895,7 +1970,7 @@ mod tests {
             ApplyPageType::Both,
         ));
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:header"), "XML should contain header element");
         assert!(xml.contains("Header Content"), "XML should contain header text");
 
@@ -1919,7 +1994,7 @@ mod tests {
             ApplyPageType::Even,
         ));
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:footer"), "XML should contain footer element");
 
         let result =
@@ -1943,7 +2018,7 @@ mod tests {
             "- ".to_string(),
         ));
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:pageNum"), "XML should contain pageNum element");
         assert!(xml.contains(r#"pos="BOTTOM_CENTER""#), "XML should contain pos attribute");
         assert!(xml.contains(r#"formatType="DIGIT""#), "XML should contain formatType");
@@ -1985,7 +2060,7 @@ mod tests {
             "".to_string(),
         ));
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         let sec_pr_end = xml.find("</hp:secPr>").expect("secPr must be present");
         let col_pr_pos = xml.find("<hp:colPr").expect("colPr must be present");
@@ -2014,7 +2089,7 @@ mod tests {
             .footers
             .push(HeaderFooter::new(vec![text_paragraph("My Footer", 0, 0)], ApplyPageType::Odd));
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
@@ -2051,7 +2126,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<hp:ctrl>"), "missing ctrl wrapper");
         assert!(xml.contains("<hp:footNote"), "missing footNote element");
@@ -2074,7 +2149,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<hp:endNote"), "missing endNote element");
         assert!(xml.contains("<hp:t>End note</hp:t>"), "missing endnote text");
@@ -2104,7 +2179,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         assert!(xml.contains("<hp:rect"), "missing rect element");
         assert!(xml.contains("<hp:drawText"), "missing drawText element");
@@ -2136,7 +2211,7 @@ mod tests {
             PageSettings::a4(),
         );
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -2177,7 +2252,7 @@ mod tests {
             PageSettings::a4(),
         );
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -2224,7 +2299,7 @@ mod tests {
             PageSettings::a4(),
         );
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -2263,7 +2338,7 @@ mod tests {
             ApplyPageType::Both,
         ));
 
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("A &amp; B &lt; C &gt; D"), "special chars must be escaped");
 
         let result =
@@ -2325,7 +2400,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         // First hyperlink: id=1100000000, fieldid=1628000000
         assert!(xml.contains(r#"<hp:fieldEnd beginIDRef="1100000000" fieldid="1628000000"/>"#));
@@ -2346,7 +2421,7 @@ mod tests {
     #[test]
     fn style_id_none_encodes_as_zero() {
         let section = simple_section("body text");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"styleIDRef="0""#), "None style_id should encode as styleIDRef=0");
     }
 
@@ -2359,7 +2434,7 @@ mod tests {
         )
         .with_style(StyleIndex::new(2));
         let section = Section::with_paragraphs(vec![para], PageSettings::a4());
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(
             xml.contains(r#"styleIDRef="2""#),
             "style_id=Some(2) should encode as styleIDRef=2"
@@ -2375,7 +2450,7 @@ mod tests {
         )
         .with_style(StyleIndex::new(3));
         let section = Section::with_paragraphs(vec![para], PageSettings::a4());
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
@@ -2386,7 +2461,7 @@ mod tests {
     #[test]
     fn decoder_zero_style_id_ref_gives_none() {
         let section = simple_section("normal");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
@@ -2399,7 +2474,7 @@ mod tests {
     #[test]
     fn text_direction_horizontal_is_default() {
         let section = simple_section("가로쓰기");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(
             xml.contains(r#"textDirection="HORIZONTAL""#),
             "default section should use HORIZONTAL"
@@ -2415,7 +2490,7 @@ mod tests {
         let section =
             Section::with_paragraphs(vec![text_paragraph("세로쓰기", 0, 0)], PageSettings::a4())
                 .with_text_direction(TextDirection::Vertical);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(
             xml.contains(r#"textDirection="VERTICAL""#),
             "vertical section should use VERTICAL"
@@ -2433,7 +2508,7 @@ mod tests {
             PageSettings::a4(),
         )
         .with_text_direction(TextDirection::VerticalAll);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(
             xml.contains(r#"textDirection="VERTICALALL""#),
             "verticalall section should use VERTICALALL"
@@ -2451,7 +2526,7 @@ mod tests {
             PageSettings::a4(),
         )
         .with_text_direction(TextDirection::Vertical);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -2464,7 +2539,7 @@ mod tests {
     fn landscape_encodes_as_narrowly() {
         let ps = PageSettings { landscape: true, ..PageSettings::a4() };
         let section = Section::with_paragraphs(vec![text_paragraph("landscape", 0, 0)], ps);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"landscape="NARROWLY""#), "landscape=true must encode as NARROWLY");
     }
 
@@ -2472,7 +2547,7 @@ mod tests {
     fn portrait_encodes_as_widely() {
         let ps = PageSettings { landscape: false, ..PageSettings::a4() };
         let section = Section::with_paragraphs(vec![text_paragraph("portrait", 0, 0)], ps);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"landscape="WIDELY""#), "landscape=false must encode as WIDELY");
     }
 
@@ -2480,7 +2555,7 @@ mod tests {
     fn landscape_roundtrips() {
         let ps = PageSettings { landscape: true, ..PageSettings::a4() };
         let section = Section::with_paragraphs(vec![text_paragraph("land", 0, 0)], ps);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -2492,7 +2567,7 @@ mod tests {
         use hwpforge_foundation::GutterType;
         let ps = PageSettings { gutter_type: GutterType::LeftRight, ..PageSettings::a4() };
         let section = Section::with_paragraphs(vec![text_paragraph("gutter", 0, 0)], ps);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"gutterType="LEFT_RIGHT""#));
     }
 
@@ -2501,7 +2576,7 @@ mod tests {
         use hwpforge_foundation::GutterType;
         let ps = PageSettings { gutter_type: GutterType::TopOnly, ..PageSettings::a4() };
         let section = Section::with_paragraphs(vec![text_paragraph("gutter", 0, 0)], ps);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"gutterType="TOP_ONLY""#));
     }
 
@@ -2510,7 +2585,7 @@ mod tests {
     #[test]
     fn visibility_defaults_encode() {
         let section = simple_section("text");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         // Default visibility: all zeros, SHOW_ALL
         assert!(xml.contains(r#"hideFirstHeader="0""#));
         assert!(xml.contains(r#"hideFirstFooter="0""#));
@@ -2534,7 +2609,7 @@ mod tests {
             border: ShowMode::HideAll,
             fill: ShowMode::ShowOdd,
         });
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"hideFirstHeader="1""#));
         assert!(xml.contains(r#"hideFirstFooter="1""#));
         assert!(xml.contains(r#"hideFirstMasterPage="0""#));
@@ -2565,7 +2640,7 @@ mod tests {
             distance: HwpUnit::new(1000).unwrap(),
             start_number: 3,
         });
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"restartType="1""#));
         assert!(xml.contains(r#"countBy="5""#));
         assert!(xml.contains(r#"distance="1000""#));
@@ -2576,7 +2651,7 @@ mod tests {
     fn line_number_shape_defaults_encode() {
         // Section with no line_number_shape uses all-zero defaults
         let section = simple_section("text");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"restartType="0""#));
         assert!(xml.contains(r#"countBy="0""#));
         assert!(xml.contains(r#"startNumber="0""#));
@@ -2587,7 +2662,7 @@ mod tests {
     #[test]
     fn page_border_fill_defaults_encode_three_entries() {
         let section = simple_section("text");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         // Default: BOTH, EVEN, ODD entries
         assert!(xml.contains(r#"type="BOTH""#));
         assert!(xml.contains(r#"type="EVEN""#));
@@ -2613,7 +2688,7 @@ mod tests {
                 HwpUnit::new(800).unwrap(),
             ],
         }]);
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"borderFillIDRef="5""#));
         assert!(xml.contains(r#"textBorder="PAGE""#));
         assert!(xml.contains(r#"headerInside="1""#));
@@ -2631,7 +2706,7 @@ mod tests {
         let mut section = simple_section("text");
         section.begin_num =
             Some(BeginNum { page: 3, footnote: 2, endnote: 1, pic: 4, tbl: 5, equation: 6 });
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"page="3""#));
         assert!(xml.contains(r#"pic="4""#));
         assert!(xml.contains(r#"tbl="5""#));
@@ -2644,7 +2719,7 @@ mod tests {
     #[test]
     fn begin_num_none_defaults_to_zero_in_startnum() {
         let section = simple_section("text");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         // When begin_num is None, startNum defaults page/pic/tbl/equation to 0
         assert!(xml.contains(r#"<hp:startNum pageStartsOn="BOTH" page="0""#));
     }
@@ -2658,7 +2733,7 @@ mod tests {
         let mut section = simple_section("body");
         section.master_pages =
             Some(vec![MasterPage::new(ApplyPageType::Both, vec![text_paragraph("bg text", 0, 0)])]);
-        let result = encode_section(&section, 0, 0, 0, 0).unwrap();
+        let result = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap();
         assert_eq!(result.master_pages.len(), 1);
         let (path, xml) = &result.master_pages[0];
         assert_eq!(path, "Contents/masterpage0.xml");
@@ -2676,7 +2751,7 @@ mod tests {
         section.master_pages =
             Some(vec![MasterPage::new(ApplyPageType::Even, vec![text_paragraph("mp", 0, 0)])]);
         // offset=5 → masterpage5
-        let result = encode_section(&section, 0, 0, 5, 0).unwrap();
+        let result = encode_section(&section, 0, 0, 5, 0, EncodeOptions::default()).unwrap();
         let (path, xml) = &result.master_pages[0];
         assert_eq!(path, "Contents/masterpage5.xml");
         assert!(xml.contains(r#"id="masterpage5""#));
@@ -2690,7 +2765,7 @@ mod tests {
         let mut section = simple_section("body");
         section.master_pages =
             Some(vec![MasterPage::new(ApplyPageType::Both, vec![text_paragraph("mp", 0, 0)])]);
-        let result = encode_section(&section, 0, 0, 0, 0).unwrap();
+        let result = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap();
         assert!(
             result.xml.contains(r#"<hp:masterPage idRef="masterpage0"/>"#),
             "secPr must reference the master page"
@@ -2705,7 +2780,7 @@ mod tests {
         para.page_break = true;
         let section =
             Section::with_paragraphs(vec![text_paragraph("first", 0, 0), para], PageSettings::a4());
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"pageBreak="1""#), "page_break=true must encode as pageBreak=1");
     }
 
@@ -2715,7 +2790,7 @@ mod tests {
         para.column_break = true;
         let section =
             Section::with_paragraphs(vec![text_paragraph("first", 0, 0), para], PageSettings::a4());
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"columnBreak="1""#));
     }
 
@@ -2725,7 +2800,7 @@ mod tests {
         para.page_break = true;
         let section =
             Section::with_paragraphs(vec![text_paragraph("first", 0, 0), para], PageSettings::a4());
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
@@ -2748,7 +2823,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:bookmark"), "must emit bookmark element");
         assert!(xml.contains(r#"name="mymark""#));
     }
@@ -2782,7 +2857,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         // SpanStart produces fieldBegin type="BOOKMARK"
         assert!(xml.contains(r#"type="BOOKMARK""#), "BOOKMARK fieldBegin required");
         assert!(xml.contains(r#"name="span1""#));
@@ -2814,7 +2889,7 @@ mod tests {
             PageSettings::a4(),
         );
         // Should not panic or error
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:t>text</hp:t>"), "text must still be present");
     }
 
@@ -2834,7 +2909,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:indexmark"), "indexmark element required");
         assert!(xml.contains("색인항목"), "primary key must be present");
         assert!(xml.contains("부항목"), "secondary key must be present");
@@ -2854,7 +2929,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(
             xml.contains(r#"<hp:autoNum num="1" numType="PAGE">"#),
             "autoNum for InlinePageNumber"
@@ -2880,7 +2955,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         // Date uses SUMMERY type (한글 typo)
         assert!(xml.contains(r#"type="SUMMERY""#), "Date field must use SUMMERY type");
         assert!(xml.contains(r#"fieldid="628321650""#), "Date field must use fieldid 628321650");
@@ -2905,7 +2980,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="SUMMERY""#));
         assert!(xml.contains("$createtime"));
     }
@@ -2928,7 +3003,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="SUMMERY""#));
         assert!(xml.contains("$author"));
     }
@@ -2955,7 +3030,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         // Body carries the cached value, NOT an empty `<hp:t/>`.
         assert!(xml.contains("<hp:t>hanyul</hp:t>"), "cached value missing from body: {xml}");
         // Round-trip: decode the field back and confirm display_text survives.
@@ -2990,7 +3065,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="PATH""#));
         assert!(xml.contains("<hp:t>/tmp/doc.hwpx</hp:t>"), "PATH cached value missing: {xml}");
     }
@@ -3013,7 +3088,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="SUMMERY""#));
         assert!(xml.contains("$lastsaveby"));
     }
@@ -3036,7 +3111,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="CLICK_HERE""#), "ClickHere field type");
         assert!(xml.contains(r#"fieldid="627272811""#), "ClickHere fieldid");
         assert!(xml.contains("클릭하세요"), "hint text must appear");
@@ -3062,7 +3137,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="SUMMERY""#), "DateCodeField surrogates SUMMERY");
         assert!(xml.contains("$createtime"), "time-mode → $createtime token");
     }
@@ -3085,7 +3160,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="PATH""#), "PathField must emit type=\"PATH\"");
         assert!(
             xml.contains(r#"fieldid="628121972""#),
@@ -3118,7 +3193,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="SUMMERY""#));
         assert!(xml.contains("$company"), "unknown raw token must surface in SUMMERY");
     }
@@ -3142,7 +3217,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         let parsed =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .expect("decoder must accept its own encoder output");
@@ -3376,7 +3451,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         // Note: `<hp:autoNumFormat>` is emitted unconditionally inside
         // `<hp:footNotePr>` / `<hp:endNotePr>` and is unrelated to
         // inline page numbers. Match the exact inline element form
@@ -3445,7 +3520,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="CROSSREF""#), "CROSSREF fieldBegin type");
         assert!(xml.contains("bookmark1"), "target name must appear");
         assert!(xml.contains("RefHyperLink"), "RefHyperLink param required");
@@ -3538,7 +3613,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"type="MEMO""#), "MEMO fieldBegin type");
         assert!(xml.contains("MemoShapeID"), "MemoShapeID param required");
         assert!(!xml.contains("__HWPME_"), "no leftover Memo marker");
@@ -3594,7 +3669,7 @@ mod tests {
             vec![Paragraph::with_runs(vec![Run::control(ctrl, CSI::new(0))], PSI::new(0))],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:dutmal"), "dutmal element required");
         assert!(xml.contains("漢"), "main text required");
         assert!(xml.contains("한"), "sub text required");
@@ -3657,7 +3732,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:compose"), "compose element required");
         assert!(xml.contains(r#"charPrCnt="10""#), "10 charPr entries required");
         assert!(xml.contains("AB"), "compose text required");
@@ -3695,7 +3770,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:equation"), "equation element required");
         assert!(xml.contains("{a} over {b}"), "equation script required");
         assert!(xml.contains(r#"width="10000""#));
@@ -3722,7 +3797,7 @@ mod tests {
             ],
             col_line: None,
         });
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"colCount="2""#));
         assert!(xml.contains(r#"sameSz="1""#));
         assert!(xml.contains(r#"sameGap="1134""#));
@@ -3748,7 +3823,7 @@ mod tests {
             ],
             col_line: None,
         });
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"colCount="3""#));
         assert!(xml.contains(r#"sameSz="0""#), "variable width must use sameSz=0");
         // Explicit hp:col children required
@@ -3775,7 +3850,7 @@ mod tests {
                 },
             ),
         );
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
 
         // Byte-exact match against the Hancom-native colPr+colLine wire.
         assert!(
@@ -3844,7 +3919,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let result = encode_section(&section, 0, 0, 0, 0);
+        let result = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default());
         assert!(result.is_err(), "javascript: URL must be rejected");
         match result.unwrap_err() {
             crate::error::HwpxError::InvalidStructure { detail } => {
@@ -3868,7 +3943,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let result = encode_section(&section, 0, 0, 0, 0);
+        let result = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default());
         assert!(result.is_ok(), "mailto: URL must be accepted");
     }
 
@@ -3889,7 +3964,8 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let result = encode_section(&section, 0, 0, 0, 0).expect("schemeless URL must be accepted");
+        let result = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default())
+            .expect("schemeless URL must be accepted");
         assert!(
             result.xml.contains("http://www.motie.go.kr"),
             "schemeless URL must be promoted to http://, got: {}",
@@ -3928,7 +4004,7 @@ mod tests {
             )],
             PageSettings::a4(),
         );
-        let result = encode_section(&section, 0, 0, 0, 0).unwrap();
+        let result = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap();
         assert_eq!(result.charts.len(), 1, "one chart entry expected");
         let (path, xml) = &result.charts[0];
         assert!(path.starts_with("Chart/chart"), "chart path format");
@@ -3966,7 +4042,7 @@ mod tests {
             PageSettings::a4(),
         );
         // chart_offset=5 → chart1 index becomes 5+1=6 → chart6.xml
-        let result = encode_section(&section, 0, 5, 0, 0).unwrap();
+        let result = encode_section(&section, 0, 5, 0, 0, EncodeOptions::default()).unwrap();
         assert_eq!(result.charts.len(), 1);
         assert_eq!(result.charts[0].0, "Chart/chart6.xml");
     }
@@ -4084,7 +4160,7 @@ mod tests {
         let mut para = text_paragraph("Heading", 0, 0);
         para.heading_level = Some(1);
         let section = Section::with_paragraphs(vec![para], PageSettings::a4());
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains("<hp:titleMark"), "titleMark required for headings");
         assert!(xml.contains(r#"ignore="false""#));
     }
@@ -4092,7 +4168,7 @@ mod tests {
     #[test]
     fn no_heading_level_no_title_mark() {
         let section = simple_section("Normal paragraph");
-        let xml = encode_section(&section, 0, 0, 0, 0).unwrap().xml;
+        let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(!xml.contains("<hp:titleMark"), "non-heading must NOT have titleMark");
     }
 

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/header_footer.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/header_footer.rs
@@ -111,6 +111,7 @@ pub(super) fn inject_header_footer_pagenum(
     xml: &mut String,
     section: &Section,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<()> {
     // Find insertion point: after the last </hp:ctrl> that contains colPr
     // (or after </hp:secPr> if no colPr).
@@ -125,12 +126,12 @@ pub(super) fn inject_header_footer_pagenum(
     // Header — emit each `<hp:header>` element preserving the HWPX
     // multi-cardinality wire shape (ADR-002).
     for header in &section.headers {
-        injection.push_str(&build_header_xml(header, "header", hyperlink_entries)?);
+        injection.push_str(&build_header_xml(header, "header", hyperlink_entries, options)?);
     }
 
     // Footer — same cardinality model.
     for footer in &section.footers {
-        injection.push_str(&build_header_xml(footer, "footer", hyperlink_entries)?);
+        injection.push_str(&build_header_xml(footer, "footer", hyperlink_entries, options)?);
     }
 
     // Page number
@@ -177,6 +178,7 @@ pub(super) fn build_header_xml(
     hf: &hwpforge_core::section::HeaderFooter,
     tag_name: &str,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<String> {
     use std::fmt::Write as _;
 
@@ -191,7 +193,7 @@ pub(super) fn build_header_xml(
     let mut xml = String::new();
     write!(xml, r#"<hp:ctrl><hp:{tag_name} applyPageType="{apply_page}" id="{hf_id}">"#,)
         .expect("write to String is infallible");
-    xml.push_str(&encode_memo_sublist(&hf.paragraphs, 0, hyperlink_entries)?);
+    xml.push_str(&encode_memo_sublist(&hf.paragraphs, 0, hyperlink_entries, options)?);
     write!(xml, "</hp:{tag_name}></hp:ctrl>").expect("write to String is infallible");
     Ok(xml)
 }
@@ -310,7 +312,8 @@ mod tests {
             (ApplyPageType::Odd, "ODD"),
         ] {
             let hf = HeaderFooter::new(Vec::new(), apply);
-            let xml = build_header_xml(&hf, "header", &mut entries).unwrap();
+            let xml =
+                build_header_xml(&hf, "header", &mut entries, EncodeOptions::default()).unwrap();
             assert!(xml.contains(&format!(r#"applyPageType="{want}""#)), "{want}: {xml}");
             assert!(xml.starts_with("<hp:ctrl><hp:header"));
         }

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/memo.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/memo.rs
@@ -158,8 +158,9 @@ pub(super) fn encode_memo_sublist(
     paragraphs: &[Paragraph],
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<String> {
-    let sublist = encode_paragraphs_to_sublist(paragraphs, depth, hyperlink_entries)?;
+    let sublist = encode_paragraphs_to_sublist(paragraphs, depth, hyperlink_entries, options)?;
     let xml = quick_xml::se::to_string(&sublist)
         .map_err(|e| HwpxError::InvalidStructure { detail: e.to_string() })?;
     // Fix root element: <HxSubList ...>...</HxSubList> → <hp:subList ...>...</hp:subList>

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/picture.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/picture.rs
@@ -25,6 +25,7 @@ pub(super) fn build_picture(
     img: &Image,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxPic> {
     let without_prefix = img.path.strip_prefix("BinData/").unwrap_or(&img.path);
     // Strip extension: "image1.png" → "image1"
@@ -102,7 +103,7 @@ pub(super) fn build_picture(
         caption: img
             .caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
             .transpose()?,
     })
 }

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/table.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/table.rs
@@ -10,6 +10,7 @@ pub(super) fn build_table(
     table: &Table,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxTable> {
     if depth >= MAX_NESTING_DEPTH {
         return Err(HwpxError::InvalidStructure {
@@ -55,6 +56,7 @@ pub(super) fn build_table(
                 table_border_fill_id,
                 depth,
                 hyperlink_entries,
+                options,
             )
         })
         .collect::<HwpxResult<Vec<_>>>()?;
@@ -115,7 +117,7 @@ pub(super) fn build_table(
         caption: table
             .caption
             .as_ref()
-            .map(|c| build_hx_caption(c, table_width, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, table_width, depth, hyperlink_entries, options))
             .transpose()?,
         in_margin: Some(DEFAULT_CELL_MARGIN),
         rows,
@@ -126,6 +128,7 @@ pub(super) fn build_table(
 ///
 /// `col_addrs` contains the precomputed grid column address for each cell,
 /// accounting for col_span/row_span from this and previous rows.
+#[allow(clippy::too_many_arguments)]
 fn build_table_row(
     row: &TableRow,
     row_idx: u32,
@@ -133,6 +136,7 @@ fn build_table_row(
     table_border_fill_id: u32,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxTableRow> {
     let row_fallback_height =
         (!row.cells.iter().any(|cell| cell.height.is_some())).then_some(row.height).flatten();
@@ -153,6 +157,7 @@ fn build_table_row(
                 },
                 depth,
                 hyperlink_entries,
+                options,
             )
         })
         .collect::<HwpxResult<Vec<_>>>()?;
@@ -178,6 +183,7 @@ fn build_table_cell(
     ctx: TableCellBuildContext,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxTableCell> {
     Ok(HxTableCell {
         name: String::new(),
@@ -192,6 +198,7 @@ fn build_table_cell(
             depth,
             encode_table_vertical_align(cell.vertical_align.unwrap_or(TableVerticalAlign::Center)),
             hyperlink_entries,
+            options,
         )?),
         cell_addr: Some(HxCellAddr { col_addr: ctx.col_idx, row_addr: ctx.row_idx }),
         cell_span: Some(HxCellSpan {

--- a/crates/hwpforge-smithy-hwpx/src/encoder/shapes.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/shapes.rs
@@ -41,6 +41,7 @@ use crate::schema::section::{
 
 use super::escape_xml;
 use super::section::{build_hx_caption, encode_paragraphs_to_sublist_with_align, generate_instid};
+use super::EncodeOptions;
 
 // ── Shape-common helpers ─────────────────────────────────────────
 
@@ -290,6 +291,7 @@ pub(crate) fn encode_textbox_to_rect(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxRect> {
     let (paragraphs, width, height, horz_offset, vert_offset, caption, style, text_vertical_align) =
         match ctrl {
@@ -327,6 +329,7 @@ pub(crate) fn encode_textbox_to_rect(
         depth,
         &text_vertical_align.to_string(),
         hyperlink_entries,
+        options,
     )?;
     let sc = build_shape_common(width_hwp, height_hwp, style.as_ref());
 
@@ -366,7 +369,7 @@ pub(crate) fn encode_textbox_to_rect(
         out_margin: Some(HxTableMargin { left: 0, right: 0, top: 0, bottom: 0 }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, width_hwp, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, width_hwp, depth, hyperlink_entries, options))
             .transpose()?,
 
         draw_text: Some(HxDrawText {
@@ -398,6 +401,7 @@ pub(crate) fn encode_rect_to_hx(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxRect> {
     let (width, height, horz_offset, vert_offset, caption, style) = match ctrl {
         Control::Rect { width, height, horz_offset, vert_offset, caption, style } => {
@@ -444,7 +448,7 @@ pub(crate) fn encode_rect_to_hx(
         out_margin: Some(HxTableMargin { left: 0, right: 0, top: 0, bottom: 0 }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, width_hwp, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, width_hwp, depth, hyperlink_entries, options))
             .transpose()?,
         // Pure rect: no embedded text content.
         draw_text: None,
@@ -461,6 +465,7 @@ pub(crate) fn encode_line_to_hx(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxLine> {
     let (start, end, width, height, horz_offset, vert_offset, caption, style) = match ctrl {
         Control::Line { start, end, width, height, horz_offset, vert_offset, caption, style } => {
@@ -506,7 +511,7 @@ pub(crate) fn encode_line_to_hx(
         shape_comment: Some(HxShapeComment { text: "선입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
             .transpose()?,
         start_pt: Some(HxPoint { x: start.x, y: start.y }),
         end_pt: Some(HxPoint { x: end.x, y: end.y }),
@@ -518,6 +523,7 @@ pub(crate) fn encode_ellipse_to_hx(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxEllipse> {
     let (
         center,
@@ -572,6 +578,7 @@ pub(crate) fn encode_ellipse_to_hx(
             depth,
             &text_vertical_align.to_string(),
             hyperlink_entries,
+            options,
         )?;
         Some(HxDrawText {
             last_width: 0,
@@ -617,7 +624,7 @@ pub(crate) fn encode_ellipse_to_hx(
         shape_comment: Some(HxShapeComment { text: "타원입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
             .transpose()?,
         draw_text,
         center: Some(HxPoint { x: center.x, y: center.y }),
@@ -635,6 +642,7 @@ pub(crate) fn encode_polygon_to_hx(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxPolygon> {
     let (
         vertices,
@@ -683,6 +691,7 @@ pub(crate) fn encode_polygon_to_hx(
             depth,
             &text_vertical_align.to_string(),
             hyperlink_entries,
+            options,
         )?;
         Some(HxDrawText {
             last_width: 0,
@@ -727,7 +736,7 @@ pub(crate) fn encode_polygon_to_hx(
         shape_comment: Some(HxShapeComment { text: "다각형입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
             .transpose()?,
         draw_text,
         points,
@@ -741,6 +750,7 @@ pub(crate) fn encode_arc_to_hx(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxEllipse> {
     let (
         arc_type,
@@ -831,7 +841,7 @@ pub(crate) fn encode_arc_to_hx(
         shape_comment: Some(HxShapeComment { text: "호입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
             .transpose()?,
         draw_text: None,
         center: Some(HxPoint { x: center.x, y: center.y }),
@@ -849,6 +859,7 @@ pub(crate) fn encode_curve_to_hx(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxCurve> {
     let (points, segment_types, width, height, horz_offset, vert_offset, caption, style) =
         match ctrl {
@@ -919,7 +930,7 @@ pub(crate) fn encode_curve_to_hx(
         shape_comment: Some(HxShapeComment { text: "곡선입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
             .transpose()?,
         points: vec![], // KS X 6101: coordinates are in <hp:seg> elements, not <hc:pt>
         segments,
@@ -931,6 +942,7 @@ pub(crate) fn encode_connect_line_to_hx(
     ctrl: &Control,
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<HxConnectLine> {
     let (
         start,
@@ -1029,7 +1041,7 @@ pub(crate) fn encode_connect_line_to_hx(
         shape_comment: Some(HxShapeComment { text: "연결선입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
             .transpose()?,
     })
 }
@@ -1244,6 +1256,7 @@ fn encode_group_child_xml(
     depth: usize,
     group_level: u32,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<Option<String>> {
     // Nested group (Wave B): recurse into a full `<hp:container>` fragment.
     // `encode_group_to_xml` bakes the correct `groupLevel` into the opening
@@ -1255,7 +1268,7 @@ fn encode_group_child_xml(
     // already stripped during their own recursion.
     if let Control::Group { .. } = child {
         let (x, y) = group_child_offset(child);
-        let raw = encode_group_to_xml(child, depth, group_level, hyperlink_entries)?;
+        let raw = encode_group_to_xml(child, depth, group_level, hyperlink_entries, options)?;
         let raw = set_group_child_offset(&raw, x, y);
         let raw = set_group_child_translate(&raw, x, y);
         let raw = zero_cur_sz(&raw);
@@ -1265,31 +1278,35 @@ fn encode_group_child_xml(
     }
     let raw = match child {
         Control::TextBox { .. } => serialize_with_root(
-            &encode_textbox_to_rect(child, depth, hyperlink_entries)?,
+            &encode_textbox_to_rect(child, depth, hyperlink_entries, options)?,
             "hp:rect",
         )?,
-        Control::Rect { .. } => {
-            serialize_with_root(&encode_rect_to_hx(child, depth, hyperlink_entries)?, "hp:rect")?
-        }
-        Control::Line { .. } => {
-            serialize_with_root(&encode_line_to_hx(child, depth, hyperlink_entries)?, "hp:line")?
-        }
+        Control::Rect { .. } => serialize_with_root(
+            &encode_rect_to_hx(child, depth, hyperlink_entries, options)?,
+            "hp:rect",
+        )?,
+        Control::Line { .. } => serialize_with_root(
+            &encode_line_to_hx(child, depth, hyperlink_entries, options)?,
+            "hp:line",
+        )?,
         Control::Ellipse { .. } => serialize_with_root(
-            &encode_ellipse_to_hx(child, depth, hyperlink_entries)?,
+            &encode_ellipse_to_hx(child, depth, hyperlink_entries, options)?,
             "hp:ellipse",
         )?,
-        Control::Arc { .. } => {
-            serialize_with_root(&encode_arc_to_hx(child, depth, hyperlink_entries)?, "hp:ellipse")?
-        }
+        Control::Arc { .. } => serialize_with_root(
+            &encode_arc_to_hx(child, depth, hyperlink_entries, options)?,
+            "hp:ellipse",
+        )?,
         Control::Polygon { .. } => serialize_with_root(
-            &encode_polygon_to_hx(child, depth, hyperlink_entries)?,
+            &encode_polygon_to_hx(child, depth, hyperlink_entries, options)?,
             "hp:polygon",
         )?,
-        Control::Curve { .. } => {
-            serialize_with_root(&encode_curve_to_hx(child, depth, hyperlink_entries)?, "hp:curve")?
-        }
+        Control::Curve { .. } => serialize_with_root(
+            &encode_curve_to_hx(child, depth, hyperlink_entries, options)?,
+            "hp:curve",
+        )?,
         Control::ConnectLine { .. } => serialize_with_root(
-            &encode_connect_line_to_hx(child, depth, hyperlink_entries)?,
+            &encode_connect_line_to_hx(child, depth, hyperlink_entries, options)?,
             "hp:connectLine",
         )?,
         Control::TextArt { .. } => encode_text_art_to_xml(child)?,
@@ -1327,6 +1344,7 @@ pub(crate) fn encode_group_to_xml(
     depth: usize,
     group_level: u32,
     hyperlink_entries: &mut Vec<(String, String)>,
+    options: EncodeOptions,
 ) -> HwpxResult<String> {
     let (children, width, height, horz_offset, vert_offset, inst_id) = match ctrl {
         Control::Group { children, width, height, horz_offset, vert_offset, inst_id } => {
@@ -1350,7 +1368,8 @@ pub(crate) fn encode_group_to_xml(
     // Children in z-order, each at the next group level.
     let mut children_xml = String::new();
     for child in children {
-        if let Some(xml) = encode_group_child_xml(child, depth, group_level + 1, hyperlink_entries)?
+        if let Some(xml) =
+            encode_group_child_xml(child, depth, group_level + 1, hyperlink_entries, options)?
         {
             children_xml.push_str(&xml);
         }
@@ -1547,7 +1566,8 @@ mod tests {
             inst_id: None,
         };
         let mut entries = Vec::new();
-        let xml = encode_group_to_xml(&group, 0, 0, &mut entries).unwrap();
+        let xml =
+            encode_group_to_xml(&group, 0, 0, &mut entries, EncodeOptions::default()).unwrap();
 
         assert!(xml.contains("<hp:container"), "missing container: {xml}");
         assert_eq!(xml.matches("<hp:rect").count(), 2, "expected 2 rect children");
@@ -1654,7 +1674,8 @@ mod tests {
             inst_id: None,
         };
         let mut entries = Vec::new();
-        let xml = encode_group_to_xml(&outer, 0, 0, &mut entries).unwrap();
+        let xml =
+            encode_group_to_xml(&outer, 0, 0, &mut entries, EncodeOptions::default()).unwrap();
 
         // Two nested containers: outer groupLevel=0, inner groupLevel=1.
         assert_eq!(xml.matches("<hp:container").count(), 2, "expected 2 containers: {xml}");
@@ -1889,7 +1910,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.has_arc_pr, 1, "Arc must have hasArcPr=1");
     }
 
@@ -1912,7 +1933,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.arc_type, "PIE");
     }
 
@@ -1935,7 +1956,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.center.as_ref().unwrap().x, 100);
         assert_eq!(result.center.as_ref().unwrap().y, 200);
         assert_eq!(result.ax1.as_ref().unwrap().x, 300);
@@ -1965,7 +1986,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.sz.as_ref().unwrap().width, 7000);
         assert_eq!(result.sz.as_ref().unwrap().height, 4000);
         // Non-zero offset → treat_as_char=0
@@ -1992,7 +2013,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "호입니다.");
     }
 
@@ -2015,7 +2036,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert!(result.draw_text.is_none(), "Arc should have no draw_text");
     }
 
@@ -2034,7 +2055,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert!(result.segments.is_empty());
         assert!(result.points.is_empty(), "KS X 6101: coords go in segments, not points");
     }
@@ -2056,7 +2077,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.segments.len(), 2);
         let seg0 = &result.segments[0];
         assert_eq!(seg0.seg_type, "CURVE");
@@ -2085,7 +2106,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert!(result.segments.is_empty(), "single point → no segments");
     }
 
@@ -2108,7 +2129,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.segments.len(), 3);
         assert_eq!(result.segments[0].seg_type, "LINE");
         // Remaining use default CurveSegmentType::Curve
@@ -2129,7 +2150,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "곡선입니다.");
     }
 
@@ -2146,7 +2167,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.pos.as_ref().unwrap().treat_as_char, 1);
     }
 
@@ -2167,7 +2188,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         let cp = result.control_points.as_ref().unwrap();
         // 1 intermediate + start + end = 3 total
         assert_eq!(cp.points.len(), 3);
@@ -2194,7 +2216,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         let cp = result.control_points.as_ref().unwrap();
         // Only start + end = 2
         assert_eq!(cp.points.len(), 2);
@@ -2217,7 +2240,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.connect_type, "CURVED");
     }
 
@@ -2237,7 +2261,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert!(result.fill_brush.is_none(), "connect lines must have no fill_brush");
     }
 
@@ -2260,7 +2285,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.numbering_type, "PICTURE");
         assert_eq!(result.text_wrap, "IN_FRONT_OF_TEXT");
         let pos = result.pos.as_ref().expect("connect line should carry a pos block");
@@ -2285,7 +2311,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.numbering_type, "NONE");
         assert_eq!(result.text_wrap, "TOP_AND_BOTTOM");
         let pos = result.pos.as_ref().expect("connect line should carry a pos block");
@@ -2308,7 +2335,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.start_pt.as_ref().unwrap().x, 111);
         assert_eq!(result.start_pt.as_ref().unwrap().y, 222);
         assert_eq!(result.end_pt.as_ref().unwrap().x, 333);
@@ -2330,7 +2358,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "연결선입니다.");
     }
 
@@ -2349,7 +2378,8 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_connect_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result =
+            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.pos.as_ref().unwrap().treat_as_char, 0);
     }
 
@@ -2368,7 +2398,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert!(result.fill_brush.is_none(), "lines have no fill brush per golden");
     }
 
@@ -2385,7 +2415,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "선입니다.");
     }
 
@@ -2402,7 +2432,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.start_pt.as_ref().unwrap().x, 50);
         assert_eq!(result.start_pt.as_ref().unwrap().y, 100);
         assert_eq!(result.end_pt.as_ref().unwrap().x, 500);
@@ -2422,7 +2452,7 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_line_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.numbering_type, "PICTURE");
         assert_eq!(result.text_wrap, "IN_FRONT_OF_TEXT");
         let pos = result.pos.as_ref().unwrap();
@@ -2450,7 +2480,7 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "타원입니다.");
     }
 
@@ -2470,7 +2500,7 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.has_arc_pr, 0, "Ellipse must have hasArcPr=0");
     }
 
@@ -2490,7 +2520,7 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert!(result.draw_text.is_none());
     }
 
@@ -2518,7 +2548,7 @@ mod tests {
         // so existing top-aligned shapes are byte-unchanged.
         let ctrl = ellipse_with_valign(VerticalAlign::Top);
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         let dt = result.draw_text.expect("ellipse with text must emit drawText");
         assert_eq!(dt.sub_list.vert_align, "TOP");
     }
@@ -2527,7 +2557,7 @@ mod tests {
     fn encode_ellipse_center_emits_center_sublist() {
         let ctrl = ellipse_with_valign(VerticalAlign::Center);
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         let dt = result.draw_text.expect("ellipse with text must emit drawText");
         assert_eq!(dt.sub_list.vert_align, "CENTER");
     }
@@ -2536,7 +2566,7 @@ mod tests {
     fn encode_ellipse_bottom_emits_bottom_sublist() {
         let ctrl = ellipse_with_valign(VerticalAlign::Bottom);
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         let dt = result.draw_text.expect("ellipse with text must emit drawText");
         assert_eq!(dt.sub_list.vert_align, "BOTTOM");
     }
@@ -2563,7 +2593,7 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.points.len(), 4);
         assert_eq!(result.points[0].x, 0);
         assert_eq!(result.points[0].y, 100);
@@ -2590,7 +2620,7 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "다각형입니다.");
     }
 
@@ -2613,7 +2643,7 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.numbering_type, "PICTURE");
         assert_eq!(result.text_wrap, "IN_FRONT_OF_TEXT");
         let pos = result.pos.as_ref().unwrap();
@@ -2627,7 +2657,7 @@ mod tests {
     fn encode_rect_pure_emits_no_draw_text() {
         let ctrl = Control::rect(HwpUnit::new(8000).unwrap(), HwpUnit::new(4000).unwrap()).unwrap();
         let mut hl = empty_hyperlinks();
-        let result = encode_rect_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_rect_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert!(result.draw_text.is_none(), "pure rect must not emit <hp:drawText>");
         let sz = result.sz.as_ref().unwrap();
         assert_eq!(sz.width, 8000);
@@ -2640,7 +2670,7 @@ mod tests {
     fn encode_rect_serializes_to_hp_rect_element() {
         let ctrl = Control::rect(HwpUnit::new(5000).unwrap(), HwpUnit::new(3000).unwrap()).unwrap();
         let mut hl = empty_hyperlinks();
-        let rect = encode_rect_to_hx(&ctrl, 0, &mut hl).unwrap();
+        let rect = encode_rect_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         let mut buf = String::new();
         let ser = quick_xml::se::Serializer::with_root(&mut buf, Some("hp:rect")).unwrap();
         serde::Serialize::serialize(&rect, ser).unwrap();
@@ -2661,7 +2691,7 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_textbox_to_rect(&ctrl, 0, &mut hl).unwrap();
+        let result = encode_textbox_to_rect(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
         assert_eq!(result.numbering_type, "PICTURE");
         assert_eq!(result.text_wrap, "IN_FRONT_OF_TEXT");
         let pos = result.pos.as_ref().unwrap();

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -86,7 +86,7 @@ pub use diff::{
     ParagraphChange, ParagraphChangeKind, RawChange, SemanticDiff, StructureChange,
     COMPARISON_NOTE, RAW_CAP,
 };
-pub use encoder::HwpxEncoder;
+pub use encoder::{EncodeOptions, HwpxEncoder};
 pub use error::{HwpxError, HwpxErrorCode, HwpxResult};
 pub use exchange::{
     ExportedDocument, ExportedSection, PreservedTextSlot, SectionPreservation, TextLocator,

--- a/crates/hwpforge-smithy-hwpx/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/schema/section.rs
@@ -2277,7 +2277,7 @@ mod tests {
     }
 
     #[test]
-    fn linesegarray_is_ignored() {
+    fn linesegarray_is_captured() {
         let xml = r#"
         <hs:sec>
           <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
@@ -2291,6 +2291,9 @@ mod tests {
         </hs:sec>"#;
         let sec = parse_section(xml);
         assert_eq!(sec.paragraphs[0].runs[0].texts[0].text(), "text");
+        let array = sec.paragraphs[0].linesegarray.as_ref().expect("captured");
+        assert_eq!(array.items.len(), 1);
+        assert_eq!(array.items[0].vertsize, 1000);
     }
 
     #[test]

--- a/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
@@ -539,10 +539,17 @@ pub(crate) fn encode_hwpx(doc: &HwpxDocument) -> Result<Vec<u8>, StamperError> {
 }
 
 pub(crate) fn admission_compare(a: &HwpxDocument, b: &HwpxDocument) -> Result<(), StamperError> {
-    if a.document != b.document {
+    // 캐시 정규화 비교: 줄 조판 캐시(layout_cache)는 Hancom 이 저장한 렌더
+    // 캐시라 원본(보유)과 우리 재인코드 산출물(미보유)이 당연히 다르다.
+    // 문서 의미 동등성 판정에서 제외하기 위해 양쪽 사본에서 제거 후 비교한다.
+    let mut doc_a = a.document.clone();
+    let mut doc_b = b.document.clone();
+    doc_a.strip_layout_caches();
+    doc_b.strip_layout_caches();
+    if doc_a != doc_b {
         return Err(StamperError::NotRoundTripSafe {
             component: "document".to_string(),
-            diff_path: first_diff_path(&a.document, &b.document),
+            diff_path: first_diff_path(&doc_a, &doc_b),
         });
     }
     if a.style_store != b.style_store {

--- a/crates/hwpforge-smithy-hwpx/tests/layout_cache_roundtrip.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/layout_cache_roundtrip.rs
@@ -1,0 +1,126 @@
+//! W1c 게이트: 인코더 opt-in 캐시 방출.
+//!
+//! - 기본 인코딩(양 진입점)은 `<hp:linesegarray>` 를 방출하지 않는다
+//!   (편집 표면 불변 — 바이트 수준 중립성은 기존 고정점 게이트가 잠근다).
+//! - `emit_layout_cache` opt-in 은 Core 로 승격된 캐시를 wire 로 되돌려
+//!   방출하고, 재디코드 시 본문·표 셀·머리말 캐시가 전부 보존돼야 한다.
+
+use hwpforge_core::document::{Document, Draft};
+use hwpforge_core::image::ImageStore;
+use hwpforge_core::layout::{LayoutCache, LineSeg};
+use hwpforge_core::page::PageSettings;
+use hwpforge_core::paragraph::Paragraph;
+use hwpforge_core::run::Run;
+use hwpforge_core::section::{HeaderFooter, Section};
+use hwpforge_core::table::{Table, TableCell, TableRow};
+use hwpforge_foundation::{CharShapeIndex, HwpUnit, ParaShapeIndex};
+use hwpforge_smithy_hwpx::{style_store_for_preset, EncodeOptions, HwpxDecoder, HwpxEncoder};
+
+fn seg(textpos: u32, vertpos: i32) -> LineSeg {
+    LineSeg {
+        textpos,
+        vertpos,
+        vertsize: 1000,
+        textheight: 1000,
+        baseline: 850,
+        spacing: 600,
+        horzpos: 0,
+        horzsize: 48188,
+        flags: 0x0060_0000,
+    }
+}
+
+fn cached_para(text: &str, lines: Vec<LineSeg>) -> Paragraph {
+    let mut p =
+        Paragraph::with_runs(vec![Run::text(text, CharShapeIndex::new(0))], ParaShapeIndex::new(0));
+    p.layout_cache = Some(LayoutCache::new(lines));
+    p
+}
+
+/// 본문(2줄 캐시) + 표 셀(1줄) + 머리말(1줄) — 컨테이너별 방출 경로 검증.
+fn build_doc() -> Document<Draft> {
+    let cell = TableCell::new(
+        vec![cached_para("셀 본문", vec![seg(0, 0)])],
+        HwpUnit::from_pt(100.0).unwrap(),
+    );
+    let mut host = cached_para("본문 문단", vec![seg(0, 0), seg(3, 1600)]);
+    host.add_run(Run::table(Table::new(vec![TableRow::new(vec![cell])]), CharShapeIndex::new(0)));
+
+    let mut section = Section::with_paragraphs(vec![host], PageSettings::a4());
+    section.headers.push(HeaderFooter::all_pages(vec![cached_para("머리말", vec![seg(0, 800)])]));
+
+    let mut doc = Document::new();
+    doc.add_section(section);
+    doc
+}
+
+fn section_xml(bytes: &[u8]) -> String {
+    use std::io::Read as _;
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes.to_vec())).expect("zip");
+    let mut xml = String::new();
+    archive
+        .by_name("Contents/section0.xml")
+        .expect("section0")
+        .read_to_string(&mut xml)
+        .expect("utf-8");
+    xml
+}
+
+#[test]
+fn default_encode_omits_linesegarray() {
+    // 주의: 같은 문서라도 인코딩마다 generate_instid() 산출 id 가 달라
+    // 두 encode 호출의 바이트 동일성은 성립하지 않는다. 옵션 플럼빙의
+    // 기본 경로 중립성은 기존 바이트 고정점 게이트(994 테스트)가 잠근다.
+    // 여기서는 "기본 = 캐시 미방출" 불변식만 두 진입점 모두에서 잠근다.
+    let store = style_store_for_preset("default").expect("preset");
+    let validated = build_doc().validate().expect("validate");
+    let images = ImageStore::new();
+
+    let plain = HwpxEncoder::encode(&validated, &store, &images).expect("encode");
+    assert!(!section_xml(&plain).contains("linesegarray"), "기본 인코딩은 캐시를 방출하지 않는다");
+
+    let with_default =
+        HwpxEncoder::encode_with_options(&validated, &store, &images, EncodeOptions::default())
+            .expect("encode_with_options");
+    assert!(
+        !section_xml(&with_default).contains("linesegarray"),
+        "EncodeOptions::default() 도 캐시를 방출하지 않는다"
+    );
+}
+
+#[test]
+fn optin_emits_linesegarray_and_roundtrips_all_containers() {
+    let store = style_store_for_preset("default").expect("preset");
+    let validated = build_doc().validate().expect("validate");
+    let bytes = HwpxEncoder::encode_with_options(
+        &validated,
+        &store,
+        &ImageStore::new(),
+        EncodeOptions::default().with_emit_layout_cache(true),
+    )
+    .expect("encode opt-in");
+
+    let xml = section_xml(&bytes);
+    assert!(xml.contains("<hp:linesegarray>"), "opt-in 은 캐시를 방출한다: {xml}");
+
+    // 재디코드 → 승격된 캐시가 컨테이너별로 전부 살아있는지
+    let decoded = HwpxDecoder::decode(&bytes).expect("decode");
+    let mut caches: Vec<(String, LayoutCache)> = Vec::new();
+    let mut doc = decoded.document;
+    doc.for_each_paragraph_mut(|p| {
+        if let Some(c) = &p.layout_cache {
+            caches.push((p.text_content(), c.clone()));
+        }
+    });
+
+    let get = |needle: &str| -> &LayoutCache {
+        &caches
+            .iter()
+            .find(|(t, _)| t.contains(needle))
+            .unwrap_or_else(|| panic!("{needle} 캐시 없음: {caches:?}"))
+            .1
+    };
+    assert_eq!(get("본문 문단").lines, vec![seg(0, 0), seg(3, 1600)], "본문 2줄 캐시 보존");
+    assert_eq!(get("셀 본문").lines, vec![seg(0, 0)], "표 셀 캐시 보존");
+    assert_eq!(get("머리말").lines, vec![seg(0, 800)], "머리말 캐시 보존");
+}


### PR DESCRIPTION
## 요약

PDF Export 에픽(설계: 내부 계획 문서 2026-07-26, 게이트 0~3 승인 완료)의 **W1: Core 승격 (decode-only + convert opt-in carry)** 구현입니다. 한컴이 저장한 줄 조판 캐시(`<hp:linesegarray>` / HWP5 `PARA_LINE_SEG`)를 공유 모델로 승격해, 이후 W2(smithy-pdf 캐시 재생 렌더러)의 입력을 성립시킵니다.

**semver: core `feat!` breaking → 0.x 마이너 범프 (0.11.7 → 0.12.0)**

## 커밋 구성 (4)

- `1d641cf` fix(core): non_exhaustive Metadata rustdoc 예제 수리 — nextest 미실행 사각에서 발견된 선재 doctest bit-rot
- `d3ddb00` feat(core)!: `core::layout::{LayoutCache, LineSeg}` 신설(9필드 wire 미러) + `Paragraph.layout_cache` + `for_each_paragraph_mut`(전 문단 컨테이너 재귀, Control match 와일드카드 없음 = 새 variant 컴파일 강제) + `strip_layout_caches` + HWPX 디코더 승격 + admission 캐시 정규화 비교
- `1a5ed72` feat(smithy-hwpx): `EncodeOptions.emit_layout_cache` opt-in (기본 off — 기본 인코더 출력 불변, serde 방출 경로 전부 스레딩)
- `4f07d71` feat(convert): HWP5 `PARA_LINE_SEG`→Core 승격 + `ConvertOptions.carry_layout_cache` opt-in (PDF 비교 파이프라인 전용)

## 설계 요점

- **decode-only**: 인코더는 기본적으로 캐시를 방출하지 않음 — `layout_carry`(바이트 스플라이스 보존)·`strip_line_segs`(E4) 불변식 그대로. opt-in 방출은 PDF 재생/비교 전용이며, 과거 convert 의 무조건 carry 가 한컴 다중행 겹침을 일으켜 제거된 이력을 rustdoc 에 명시.
- **비교 의미론 분리**: `Paragraph::PartialEq` 는 derive 유지(캐시 포함), admission 비교만 양쪽 사본 정규화 후 수행 — 네이티브 입력(캐시 보유) vs 재인코드 산출물(미보유) 차이를 의미 비교에서 제외.
- **serde 하위호환**: `layout_cache` 는 default+skip(None) — 구버전 to-json JSON 왕복 테스트 포함.

## 게이트 실측

- `make ci` 전체 green: fmt·clippy(workspace `-D warnings`)·**nextest 3,044/3,044** (전 편집 표면 delta 게이트·E5 diff 회귀 0)
- 기본 인코더 linesegarray 미방출 불변 ×3 진입점 잠금 + opt-in 왕복(본문·표 셀·머리말) 게이트
- convert opt-in 실픽스처(hwp5_00.hwp) 방출·재디코드 승격 왕복 검증
- **독립 리뷰 (분리 lane): Critical/High/Medium 0 · Low 3 · "머지 가능"** — Low 상환 내역: 커밋 메시지 과장 정정(재커밋, 트리 동일 검증), masterpage·메모 앵커 수동 XML 빌더 방출 갭은 현 opt-in 표면 도달 불가로 백로그 명시(후속 pdf-diff 에픽에서 상환)

## 후속 (이 PR 범위 아님)

- W2 smithy-pdf 골격 (bbox-diff 게이트) → W3 표 렌더 → W4 폰트 → W5 요소 → W6 표면(CLI/MCP)