### PR TITLE
feat(smithy-hwpx)!: W5-α 디코더 정합 — 다중 머리말 보존·pageStartsOn·경고 채널·subList 기하

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,10 @@ bacon test    # Auto-run tests
 - **commit 출력도 `| tail` 로 자르지 말 것** — 실패한 훅 라인·exit code 가 사라져 "커밋됐다" 오판. 파일 리다이렉트 후 grep (push 파이프 금지 규칙과 동일 계열).
 - **커밋 전 touched 크레이트만 `cargo clippy --all-targets -- -D warnings` 사전 점검** — 훅 거부 1회 = 2분+ 재사이클 (nextest/build 는 clippy lint 를 안 잡음).
 - `rm` 은 대화형 alias — stale `.git/index.lock`(0바이트·git 프로세스 없음 확인 후) 등 스크립트 삭제는 `rm -f`.
-- 대용량 정리: `target/`(수백 GB 가능)·`fuzz/target`·`.docs/papers/EAAI/eval/oracle-rs/target` 은 재생성 가능 빌드 산출물. `.docs/papers`(corpus·논문)·`fuzz/corpus` 는 자산 — 삭제 금지.
+- 대용량 정리: `target/`(수백 GB 가능)·`fuzz/target`·`.docs/papers/EAAI/eval/oracle-rs/target` 은 재생성 가능 빌드 산출물. `.docs/papers`(corpus·논문)·`fuzz/corpus` 는 자산 — 삭제 금지. **디스크 고갈 시 우선 삭제 = `target/debug/incremental`(94GB 실사고)·`target/llvm-cov-target`** — `target/debug/deps`(warm 의존성 캐시)는 보존해 cold 재빌드를 피한다.
+- pre-commit 은 **미스테이지 변경을 stash 하고 staged 트리만 검사** — 다파일 수정에서 하나라도 `git add` 누락하면 staged 트리가 컴파일 실패로 거부됨 (원인이 "숨은 미스테이지 파일"이라 오진하기 쉬움). 커밋 전 `git status --short` 로 관련 파일 전부 staged(`M`) 확인.
+- **zsh 는 미인용 변수를 word-split 하지 않음** — `CMD="node /x.mjs"; $CMD status` 는 전체가 하나의 명령명 (조용한 command-not-found → 루프/조건 오탐). 스크립트에서 명령을 변수에 담지 말고 인라인 전체 경로로 (`for x in $VAR` 미분리와 동계열).
+- Bash 작업 디렉터리는 **호출 간 지속** — 앞서 `cd` 한 상태에서 레포-루트 상대 경로(git add 등)를 쓰면 pathspec fatal. 커밋/스테이지 명령은 절대 경로 또는 루트 복귀 후 실행.
 
 ### Documentation & Coverage
 

--- a/crates/hwpforge-core/src/section.rs
+++ b/crates/hwpforge-core/src/section.rs
@@ -176,12 +176,33 @@ impl Default for PageBorderFillEntry {
 // BeginNum
 // ---------------------------------------------------------------------------
 
+/// Which page parity a section starts on.
+///
+/// Maps to HWPX `<hp:startNum pageStartsOn="BOTH|EVEN|ODD">`. 홀짝 강제
+/// 시작은 다중 섹션 쪽번호 연속성 계산의 입력이다 (W5-α C2 — 스키마에
+/// 있던 값을 디코더가 폐기하던 것을 승격).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+pub enum PageStartsOn {
+    /// 아무 쪽성에서나 시작한다 (기본).
+    #[default]
+    Both,
+    /// 짝수 쪽에서 시작한다.
+    Even,
+    /// 홀수 쪽에서 시작한다.
+    Odd,
+}
+
 /// Starting numbers for various auto-numbering sequences.
 ///
-/// Maps to `<hh:beginNum>` in header.xml.
+/// Maps to `<hh:beginNum>` in header.xml and per-section
+/// `<hp:startNum>` in section XML.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct BeginNum {
-    /// Starting page number (default: 1).
+    /// Starting page number.
+    ///
+    /// 섹션 `<hp:startNum>` 의미론 (OWPML §10.6.2): **`0` = 이전 구역에서
+    /// 계속**, `n > 0` = 이 구역을 `n` 번부터 재시작. ("기본값 1" 이
+    /// 아니다 — serde 기본 1 은 header.xml `<hh:beginNum>` 쪽 관례.)
     #[serde(default = "BeginNum::one")]
     pub page: u32,
     /// Starting footnote number (default: 1).
@@ -199,6 +220,16 @@ pub struct BeginNum {
     /// Starting equation number (default: 1).
     #[serde(default = "BeginNum::one")]
     pub equation: u32,
+    /// Which page parity this section starts on (`pageStartsOn`).
+    #[serde(default, skip_serializing_if = "PageStartsOn::is_default")]
+    pub page_starts_on: PageStartsOn,
+}
+
+impl PageStartsOn {
+    /// serde `skip_serializing_if` 용 기본값 판정.
+    fn is_default(&self) -> bool {
+        *self == Self::Both
+    }
 }
 
 impl BeginNum {
@@ -209,7 +240,15 @@ impl BeginNum {
 
 impl Default for BeginNum {
     fn default() -> Self {
-        Self { page: 1, footnote: 1, endnote: 1, pic: 1, tbl: 1, equation: 1 }
+        Self {
+            page: 1,
+            footnote: 1,
+            endnote: 1,
+            pic: 1,
+            tbl: 1,
+            equation: 1,
+            page_starts_on: PageStartsOn::Both,
+        }
     }
 }
 

--- a/crates/hwpforge-core/src/section.rs
+++ b/crates/hwpforge-core/src/section.rs
@@ -316,12 +316,36 @@ pub struct HeaderFooter {
     pub paragraphs: Vec<Paragraph>,
     /// Which pages this header/footer applies to.
     pub apply_page_type: ApplyPageType,
+    /// 컨테이너(subList) 세로 정렬 (W5-α H1 — 일반 꼬리말 실측 = BOTTOM).
+    ///
+    /// 밴드 안에서 문단 블록을 어디에 앉히는지 결정한다 — 렌더 재생의
+    /// 필수 입력. HWPX `<hp:subList vertAlign>`.
+    #[serde(default)]
+    pub vert_align: hwpforge_foundation::VerticalAlign,
+    /// 컨테이너 텍스트 폭 (HWPX `<hp:subList textWidth>`, 0 = 위임).
+    #[serde(default, skip_serializing_if = "HwpUnit::is_zero")]
+    pub text_width: HwpUnit,
+    /// 컨테이너 텍스트 높이 (HWPX `<hp:subList textHeight>`, 0 = 위임).
+    ///
+    /// 밴드(margin.header/footer)와 다를 수 있다 — 초과 시 동작은 실측
+    /// 전이므로 렌더는 fail-closed 로 다룬다 (W5-a).
+    #[serde(default, skip_serializing_if = "HwpUnit::is_zero")]
+    pub text_height: HwpUnit,
 }
 
 impl HeaderFooter {
     /// Creates a new header/footer with the given paragraphs and page scope.
+    ///
+    /// 컨테이너 기하는 기본값(Top/0/0 = 위임)으로 시작한다 — wire 승격은
+    /// 디코더가 채운다.
     pub fn new(paragraphs: Vec<Paragraph>, apply_page_type: ApplyPageType) -> Self {
-        Self { paragraphs, apply_page_type }
+        Self {
+            paragraphs,
+            apply_page_type,
+            vert_align: hwpforge_foundation::VerticalAlign::default(),
+            text_width: HwpUnit::ZERO,
+            text_height: HwpUnit::ZERO,
+        }
     }
 
     /// Creates a header/footer applied to **all** pages (both odd and even).
@@ -341,7 +365,7 @@ impl HeaderFooter {
     /// assert_eq!(hf.paragraphs.len(), 1);
     /// ```
     pub fn all_pages(paragraphs: Vec<Paragraph>) -> Self {
-        Self { paragraphs, apply_page_type: ApplyPageType::Both }
+        Self::new(paragraphs, ApplyPageType::Both)
     }
 
     /// Creates a header/footer applied to all pages.

--- a/crates/hwpforge-smithy-hwpx/examples/hwpx_complete_guide_parts/section4.rs
+++ b/crates/hwpforge-smithy-hwpx/examples/hwpx_complete_guide_parts/section4.rs
@@ -281,8 +281,7 @@ pub(crate) fn section4_charts_equations_advanced() -> Section {
     ]);
 
     // 시작 번호 리셋
-    section.begin_num =
-        Some(BeginNum { page: 1, footnote: 1, endnote: 1, pic: 1, tbl: 1, equation: 1 });
+    section.begin_num = Some(BeginNum::default());
 
     // 마스터페이지 (워터마크)
     section.master_pages = Some(vec![MasterPage::new(

--- a/crates/hwpforge-smithy-hwpx/examples/page_layout.rs
+++ b/crates/hwpforge-smithy-hwpx/examples/page_layout.rs
@@ -147,8 +147,7 @@ fn build_section_begin_num() -> Section {
         ],
         PageSettings::a4(),
     );
-    section.begin_num =
-        Some(BeginNum { page: 10, footnote: 5, endnote: 3, pic: 1, tbl: 1, equation: 1 });
+    section.begin_num = Some(BeginNum { page: 10, footnote: 5, endnote: 3, ..BeginNum::default() });
     section
 }
 

--- a/crates/hwpforge-smithy-hwpx/examples/shapes_and_references.rs
+++ b/crates/hwpforge-smithy-hwpx/examples/shapes_and_references.rs
@@ -281,8 +281,7 @@ fn section_border_fill_begin_num() -> Section {
         PageSettings::a4(),
     );
     section.page_border_fills = Some(entries);
-    section.begin_num =
-        Some(BeginNum { page: 10, footnote: 5, endnote: 3, pic: 1, tbl: 1, equation: 1 });
+    section.begin_num = Some(BeginNum { page: 10, footnote: 5, endnote: 3, ..BeginNum::default() });
     // Add page number display to make BeginNum visible (should show "10")
     section.page_number = Some(PageNumber::bottom_center());
     section

--- a/crates/hwpforge-smithy-hwpx/src/cell_edit.rs
+++ b/crates/hwpforge-smithy-hwpx/src/cell_edit.rs
@@ -520,7 +520,7 @@ impl HwpxCellEditor {
         admission_compare(&d0, &d1).map_err(map_admission_error)?;
         check_zip_carry(base, &e0).map_err(map_admission_error)?;
 
-        let HwpxDocument { mut document, style_store, image_store } = d0;
+        let HwpxDocument { mut document, style_store, image_store, .. } = d0;
         let outcome = apply_set_cells(&mut document, specs)?;
         let validated =
             document.validate().map_err(|e| CellEditError::Codec(format!("validate: {e}")))?;

--- a/crates/hwpforge-smithy-hwpx/src/decoder/header.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/header.rs
@@ -66,6 +66,9 @@ fn parse_begin_num(head: &HxHead) -> Option<BeginNum> {
         pic: bn.pic,
         tbl: bn.tbl,
         equation: bn.equation,
+        // header.xml <hh:beginNum> 에는 pageStartsOn 이 없다 — 섹션
+        // <hp:startNum> 전용 속성 (기본 Both).
+        ..BeginNum::default()
     })
 }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/header.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/header.rs
@@ -177,20 +177,27 @@ fn convert_numbering(hx: &HxNumbering) -> hwpforge_core::NumberingDef {
 ///
 /// Shared by header (numbering definitions) and section (page number format).
 pub(crate) fn parse_number_format(s: &str) -> hwpforge_foundation::NumberFormatType {
+    parse_number_format_opt(s).unwrap_or(hwpforge_foundation::NumberFormatType::Digit)
+}
+
+/// [`parse_number_format`] 의 판정 코어 — 미지/결측 = `None`.
+///
+/// 호출자가 폴백 사실을 표면화(디코드 경고)할 수 있게 분리했다 (W5-α M4).
+pub(crate) fn parse_number_format_opt(s: &str) -> Option<hwpforge_foundation::NumberFormatType> {
     use hwpforge_foundation::NumberFormatType;
     match s {
-        "DIGIT" => NumberFormatType::Digit,
-        "CIRCLED_DIGIT" => NumberFormatType::CircledDigit,
-        "ROMAN_CAPITAL" => NumberFormatType::RomanCapital,
-        "ROMAN_SMALL" => NumberFormatType::RomanSmall,
-        "LATIN_CAPITAL" => NumberFormatType::LatinCapital,
-        "LATIN_SMALL" => NumberFormatType::LatinSmall,
-        "CIRCLED_LATIN_SMALL" => NumberFormatType::CircledLatinSmall,
-        "HANGUL_SYLLABLE" => NumberFormatType::HangulSyllable,
-        "HANGUL_JAMO" => NumberFormatType::HangulJamo,
-        "HANJA_DIGIT" => NumberFormatType::HanjaDigit,
-        "CIRCLED_HANGUL_SYLLABLE" => NumberFormatType::CircledHangulSyllable,
-        _ => NumberFormatType::Digit,
+        "DIGIT" => Some(NumberFormatType::Digit),
+        "CIRCLED_DIGIT" => Some(NumberFormatType::CircledDigit),
+        "ROMAN_CAPITAL" => Some(NumberFormatType::RomanCapital),
+        "ROMAN_SMALL" => Some(NumberFormatType::RomanSmall),
+        "LATIN_CAPITAL" => Some(NumberFormatType::LatinCapital),
+        "LATIN_SMALL" => Some(NumberFormatType::LatinSmall),
+        "CIRCLED_LATIN_SMALL" => Some(NumberFormatType::CircledLatinSmall),
+        "HANGUL_SYLLABLE" => Some(NumberFormatType::HangulSyllable),
+        "HANGUL_JAMO" => Some(NumberFormatType::HangulJamo),
+        "HANJA_DIGIT" => Some(NumberFormatType::HanjaDigit),
+        "CIRCLED_HANGUL_SYLLABLE" => Some(NumberFormatType::CircledHangulSyllable),
+        _ => None,
     }
 }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
@@ -39,6 +39,28 @@ pub struct HwpxDocument {
     pub style_store: HwpxStyleStore,
     /// Binary image data extracted from `BinData/` ZIP entries.
     pub image_store: ImageStore,
+    /// 디코드 중 표면화된 비치명 경고 (W5-α M4 — warning-first).
+    pub warnings: Vec<DecodeWarning>,
+}
+
+/// 디코드 중 표면화된 비치명 경고.
+///
+/// 디코더가 미지 wire 값을 기본값으로 **조용히** 폴백하면 하류(렌더러
+/// 등)의 warning-first 는 증거가 세탁된 뒤라 무력해진다 (W5-α M4) —
+/// 폴백은 유지하되 사실을 표면화한다. 속성 결측(빈 문자열)은 기본값
+/// 적용이 정상이므로 경고 대상이 아니다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DecodeWarning {
+    /// 알 수 없는 enum 문자열을 기본값으로 폴백함.
+    UnknownEnumValue {
+        /// 요소@속성 경로 (예: `hp:header@applyPageType`).
+        attribute: &'static str,
+        /// 원본 wire 문자열.
+        raw: String,
+        /// 폴백한 값의 wire 표기.
+        fallback: &'static str,
+    },
 }
 
 // ── HwpxDecoder ──────────────────────────────────────────────────
@@ -95,10 +117,12 @@ impl HwpxDecoder {
         let section_count = pkg.section_count();
         // Track how many masterpages have been assigned across sections
         let mut masterpage_cursor = 0usize;
+        let mut warnings: Vec<DecodeWarning> = Vec::new();
 
         for i in 0..section_count {
             let section_xml = pkg.read_section_xml(i)?;
-            let result = section::parse_section(&section_xml, i, &chart_xmls)?;
+            let mut result = section::parse_section(&section_xml, i, &chart_xmls)?;
+            warnings.append(&mut result.warnings);
 
             let page_settings = result.page_settings.unwrap_or_else(PageSettings::a4);
 
@@ -157,7 +181,7 @@ impl HwpxDecoder {
         // Step 6: Extract binary image data from BinData/
         let image_store = pkg.read_all_bindata()?;
 
-        Ok(HwpxDocument { document, style_store, image_store })
+        Ok(HwpxDocument { document, style_store, image_store, warnings })
     }
 
     /// Decodes an HWPX file from a filesystem path.

--- a/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
@@ -122,14 +122,10 @@ impl HwpxDecoder {
             let section = Section {
                 paragraphs: result.paragraphs,
                 page_settings,
-                // ADR-002: Section now holds `Vec<HeaderFooter>`. The
-                // section parser still returns single Option slots
-                // (one section can only have one `<hp:header>` per
-                // applyPageType in the decoder's current shape);
-                // collect them into the Vec so multi-cardinality is
-                // representable end-to-end.
-                headers: result.header.into_iter().collect(),
-                footers: result.footer.into_iter().collect(),
+                // ADR-002 cardinality — 파서가 wire 순서 그대로의 Vec 을
+                // 돌려준다 (W5-α C1: ODD/EVEN 다중 머리말 보존).
+                headers: result.headers,
+                footers: result.footers,
                 page_number: result.page_number,
                 column_settings: result.column_settings,
                 visibility: result.visibility,

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -1432,7 +1432,21 @@ fn extract_begin_num(
         equation: sn.equation,
         footnote: 1,
         endnote: 1,
+        page_starts_on: parse_page_starts_on(&sn.page_starts_on),
     })
+}
+
+/// Parses an HWPX `pageStartsOn` string into [`PageStartsOn`].
+///
+/// 빈 문자열(속성 결측) = `Both` (스펙 기본). 미지 값도 `Both` 로
+/// 폴백한다 — W5-α α3 에서 디코드 경고 채널 표면화 대상.
+fn parse_page_starts_on(s: &str) -> hwpforge_core::section::PageStartsOn {
+    use hwpforge_core::section::PageStartsOn;
+    match s {
+        "EVEN" | "Even" | "even" => PageStartsOn::Even,
+        "ODD" | "Odd" | "odd" => PageStartsOn::Odd,
+        _ => PageStartsOn::Both,
+    }
 }
 
 /// Extracts [`PageBorderFillEntry`] list from an `HxSecPr`.
@@ -3736,6 +3750,33 @@ mod tests {
         assert_eq!(lns.count_by, 5);
         assert_eq!(lns.distance.as_i32(), 1000);
         assert_eq!(lns.start_number, 3);
+    }
+
+    // ── startNum pageStartsOn decoding (W5-α C2) ─────────────────
+
+    #[test]
+    fn start_num_page_starts_on_survives_decode() {
+        use hwpforge_core::section::PageStartsOn;
+        // pageStartsOn 은 스키마가 이미 파싱하는데 디코더가 폐기했다
+        // (Codex C2) — 쪽번호 홀짝 강제 시작은 W5-b PageIdentity 의 입력.
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <secPr textDirection="HORIZONTAL">
+                        <startNum pageStartsOn="EVEN" page="5" pic="1" tbl="1" equation="1"/>
+                        <pagePr landscape="WIDELY" width="59528" height="84188">
+                            <margin header="4252" footer="4252" gutter="0"
+                                    left="8504" right="8504" top="5668" bottom="4252"/>
+                        </pagePr>
+                    </secPr>
+                    <t>body</t>
+                </run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        let bn = result.begin_num.expect("should have begin_num");
+        assert_eq!(bn.page_starts_on, PageStartsOn::Even, "pageStartsOn 폐기 금지");
+        assert_eq!(bn.page, 5);
     }
 
     fn make_empty_sec_pr() -> crate::schema::section::HxSecPr {

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -1633,17 +1633,47 @@ fn convert_header_footer(
 ) -> HwpxResult<HeaderFooter> {
     let apply_page_type = parse_apply_page_type(&hx.apply_page_type, attribute, warnings);
 
-    let paragraphs = if let Some(sub_list) = &hx.sub_list {
-        sub_list
+    let hf = if let Some(sub_list) = &hx.sub_list {
+        let paragraphs = sub_list
             .paragraphs
             .iter()
             .map(|hx_para| convert_paragraph(hx_para, false, 0).map(|(para, _)| para))
-            .collect::<HwpxResult<Vec<_>>>()?
+            .collect::<HwpxResult<Vec<_>>>()?;
+        let mut hf = HeaderFooter::new(paragraphs, apply_page_type);
+        // W5-α H1: 컨테이너 기하 승격 — 밴드 재생(R6)의 필수 입력.
+        hf.vert_align = parse_vert_align(&sub_list.vert_align, warnings);
+        hf.text_width =
+            HwpUnit::new(i32::try_from(sub_list.text_width).unwrap_or(0)).unwrap_or(HwpUnit::ZERO);
+        hf.text_height =
+            HwpUnit::new(i32::try_from(sub_list.text_height).unwrap_or(0)).unwrap_or(HwpUnit::ZERO);
+        hf
     } else {
-        Vec::new()
+        HeaderFooter::new(Vec::new(), apply_page_type)
     };
+    Ok(hf)
+}
 
-    Ok(HeaderFooter::new(paragraphs, apply_page_type))
+/// Parses an HWPX `vertAlign` string into [`hwpforge_foundation::VerticalAlign`].
+///
+/// 결측(빈 문자열) = `Top` (기본, 경고 없음). 미지 값 = `Top` 폴백 + 경고.
+fn parse_vert_align(
+    s: &str,
+    warnings: &mut Vec<super::DecodeWarning>,
+) -> hwpforge_foundation::VerticalAlign {
+    use hwpforge_foundation::VerticalAlign;
+    match s {
+        "" | "TOP" => VerticalAlign::Top,
+        "CENTER" => VerticalAlign::Center,
+        "BOTTOM" => VerticalAlign::Bottom,
+        _ => {
+            warnings.push(super::DecodeWarning::UnknownEnumValue {
+                attribute: "hp:subList@vertAlign",
+                raw: s.to_string(),
+                fallback: "TOP",
+            });
+            VerticalAlign::Top
+        }
+    }
 }
 
 /// Extracts a [`PageNumber`] from an `HxCtrl`'s page_num element, if present.
@@ -3926,6 +3956,37 @@ mod tests {
             .collect();
         assert!(unknowns.contains(&"hp:pageNum@pos"), "{unknowns:?}");
         assert!(unknowns.contains(&"hp:pageNum@formatType"), "{unknowns:?}");
+    }
+
+    // ── 머리말 subList 기하 승격 (W5-α H1) ───────────────────────
+
+    #[test]
+    fn header_sublist_geometry_survives_decode() {
+        use hwpforge_foundation::VerticalAlign;
+        // R6 밴드 재생의 입력: 일반 꼬리말은 vertAlign=BOTTOM + 빈 간격
+        // 문단을 쓴다 (연구 실측 09-HEADER_FOOTER_PAGENUM_RESEARCH.md) —
+        // 디코더가 컨테이너 기하를 버리면 렌더가 재현할 수 없다.
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <ctrl>
+                        <header applyPageType="BOTH" id="1">
+                            <subList id="" textDirection="HORIZONTAL" vertAlign="BOTTOM"
+                                     textWidth="42520" textHeight="4252">
+                                <p paraPrIDRef="0"><run charPrIDRef="0"><t>H</t></run></p>
+                            </subList>
+                        </header>
+                    </ctrl>
+                    <t>Body</t>
+                </run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        let header = &result.headers[0];
+        assert_eq!(header.vert_align, VerticalAlign::Bottom);
+        assert_eq!(header.text_width.as_i32(), 42520);
+        assert_eq!(header.text_height.as_i32(), 4252);
+        assert!(result.warnings.is_empty(), "{:?}", result.warnings);
     }
 
     // ── startNum pageStartsOn decoding (W5-α C2) ─────────────────

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -3913,9 +3913,14 @@ mod tests {
     #[test]
     fn absent_enum_attributes_do_not_warn() {
         // 속성 결측(빈 문자열) = 기본값 적용은 정상 — 경고 없음.
+        // applyPageType·subList vertAlign·startNum pageStartsOn 전부 결측인
+        // 구성 (독립 리뷰 Low 4 상환 — applyPageType 단독 커버리지 확장).
         let xml = r#"<sec>
             <p paraPrIDRef="0">
                 <run charPrIDRef="0">
+                    <secPr textDirection="HORIZONTAL">
+                        <startNum page="0" pic="0" tbl="0" equation="0"/>
+                    </secPr>
                     <ctrl>
                         <header id="1">
                             <subList id="" textDirection="HORIZONTAL">
@@ -3929,6 +3934,16 @@ mod tests {
         </sec>"#;
         let result = parse_section(xml, 0, &HashMap::new()).unwrap();
         assert_eq!(result.headers[0].apply_page_type, ApplyPageType::Both);
+        assert_eq!(
+            result.headers[0].vert_align,
+            hwpforge_foundation::VerticalAlign::Top,
+            "vertAlign 결측 = Top 기본"
+        );
+        assert_eq!(
+            result.begin_num.expect("begin_num").page_starts_on,
+            hwpforge_core::section::PageStartsOn::Both,
+            "pageStartsOn 결측 = Both 기본"
+        );
         assert!(result.warnings.is_empty(), "{:?}", result.warnings);
     }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -102,10 +102,14 @@ pub struct SectionParseResult {
     pub paragraphs: Vec<Paragraph>,
     /// Page settings extracted from `<hp:secPr>`, if present.
     pub page_settings: Option<PageSettings>,
-    /// Header extracted from `<hp:ctrl><hp:header>`, if present.
-    pub header: Option<HeaderFooter>,
-    /// Footer extracted from `<hp:ctrl><hp:footer>`, if present.
-    pub footer: Option<HeaderFooter>,
+    /// Headers extracted from `<hp:ctrl><hp:header>`, in wire order.
+    ///
+    /// W5-α (Codex C1): HWPX 는 `applyPageType`(BOTH/ODD/EVEN) 별로 복수의
+    /// `<hp:header>` 를 허용한다 — 단수 first-wins 는 무음 데이터 손실이었다.
+    pub headers: Vec<HeaderFooter>,
+    /// Footers extracted from `<hp:ctrl><hp:footer>`, in wire order.
+    /// See `headers` for the cardinality rationale.
+    pub footers: Vec<HeaderFooter>,
     /// Page number extracted from `<hp:ctrl><hp:pageNum>`, if present.
     pub page_number: Option<PageNumber>,
     /// Multi-column settings extracted from `<hp:ctrl><hp:colPr>`, if present.
@@ -139,8 +143,8 @@ pub fn parse_section(
         .map_err(|e| HwpxError::XmlParse { file: file_hint, detail: e.to_string() })?;
 
     let mut page_settings = None;
-    let mut header = None;
-    let mut footer = None;
+    let mut headers = Vec::new();
+    let mut footers = Vec::new();
     let mut page_number = None;
     let mut column_settings = None;
     let mut visibility = None;
@@ -189,15 +193,13 @@ pub fn parse_section(
                             column_settings = Some(cs);
                         }
                     }
-                    if header.is_none() {
-                        if let Some(hf) = convert_ctrl_header(ctrl) {
-                            header = Some(hf);
-                        }
+                    // 다중 머리말/꼬리말 = wire 순서대로 전부 수집 (W5-α C1:
+                    // first-wins 는 ODD/EVEN 문서에서 무음 데이터 손실).
+                    if let Some(hf) = convert_ctrl_header(ctrl)? {
+                        headers.push(hf);
                     }
-                    if footer.is_none() {
-                        if let Some(hf) = convert_ctrl_footer(ctrl) {
-                            footer = Some(hf);
-                        }
+                    if let Some(hf) = convert_ctrl_footer(ctrl)? {
+                        footers.push(hf);
                     }
                     if page_number.is_none() {
                         if let Some(pn) = convert_ctrl_page_number(ctrl) {
@@ -235,8 +237,8 @@ pub fn parse_section(
     Ok(SectionParseResult {
         paragraphs,
         page_settings,
-        header,
-        footer,
+        headers,
+        footers,
         page_number,
         column_settings,
         visibility,
@@ -1558,35 +1560,44 @@ fn parse_mm_width(s: &str) -> HwpUnit {
 }
 
 /// Extracts a [`HeaderFooter`] from an `HxCtrl`'s header element, if present.
-fn convert_ctrl_header(ctrl: &HxCtrl) -> Option<HeaderFooter> {
-    let hx = ctrl.header.as_ref()?;
-    Some(convert_header_footer(hx))
+///
+/// # Errors
+///
+/// 머리말 내부 문단 변환 실패를 전파한다 (W5-α C1 — `filter_map` 무음
+/// 삼킴은 캐시·본문 소실을 숨겼다).
+fn convert_ctrl_header(ctrl: &HxCtrl) -> HwpxResult<Option<HeaderFooter>> {
+    ctrl.header.as_ref().map(convert_header_footer).transpose()
 }
 
 /// Extracts a [`HeaderFooter`] from an `HxCtrl`'s footer element, if present.
-fn convert_ctrl_footer(ctrl: &HxCtrl) -> Option<HeaderFooter> {
-    let hx = ctrl.footer.as_ref()?;
-    Some(convert_header_footer(hx))
+///
+/// # Errors
+///
+/// 꼬리말 내부 문단 변환 실패를 전파한다 (`convert_ctrl_header` 참조).
+fn convert_ctrl_footer(ctrl: &HxCtrl) -> HwpxResult<Option<HeaderFooter>> {
+    ctrl.footer.as_ref().map(convert_header_footer).transpose()
 }
 
 /// Converts an `HxHeaderFooter` into a Core [`HeaderFooter`].
-fn convert_header_footer(hx: &HxHeaderFooter) -> HeaderFooter {
+///
+/// # Errors
+///
+/// 내부 문단 변환 실패를 전파한다 — 머리말 문단이 조용히 사라지면
+/// 렌더/왕복이 결손을 인지할 수 없다 (fail-open 금지).
+fn convert_header_footer(hx: &HxHeaderFooter) -> HwpxResult<HeaderFooter> {
     let apply_page_type = parse_apply_page_type(&hx.apply_page_type);
 
     let paragraphs = if let Some(sub_list) = &hx.sub_list {
         sub_list
             .paragraphs
             .iter()
-            .filter_map(|hx_para| {
-                let (para, _) = convert_paragraph(hx_para, false, 0).ok()?;
-                Some(para)
-            })
-            .collect()
+            .map(|hx_para| convert_paragraph(hx_para, false, 0).map(|(para, _)| para))
+            .collect::<HwpxResult<Vec<_>>>()?
     } else {
         Vec::new()
     };
 
-    HeaderFooter::new(paragraphs, apply_page_type)
+    Ok(HeaderFooter::new(paragraphs, apply_page_type))
 }
 
 /// Extracts a [`PageNumber`] from an `HxCtrl`'s page_num element, if present.
@@ -2442,7 +2453,9 @@ mod tests {
             </p>
         </sec>"#;
         let result = parse_section(xml, 0, &HashMap::new()).unwrap();
-        let header = result.header.expect("should have header");
+        let [header] = result.headers.as_slice() else {
+            panic!("expected exactly one header, got {}", result.headers.len());
+        };
         assert_eq!(header.apply_page_type, ApplyPageType::Both);
         assert_eq!(header.paragraphs.len(), 1);
         assert_eq!(header.paragraphs[0].runs[0].content.as_text(), Some("Header Text"));
@@ -2468,7 +2481,9 @@ mod tests {
             </p>
         </sec>"#;
         let result = parse_section(xml, 0, &HashMap::new()).unwrap();
-        let footer = result.footer.expect("should have footer");
+        let [footer] = result.footers.as_slice() else {
+            panic!("expected exactly one footer, got {}", result.footers.len());
+        };
         assert_eq!(footer.apply_page_type, ApplyPageType::Even);
         assert_eq!(footer.paragraphs.len(), 1);
         assert_eq!(footer.paragraphs[0].runs[0].content.as_text(), Some("Footer Text"));
@@ -2527,11 +2542,15 @@ mod tests {
         </sec>"#;
         let result = parse_section(xml, 0, &HashMap::new()).unwrap();
 
-        let header = result.header.expect("should have header");
+        let [header] = result.headers.as_slice() else {
+            panic!("expected exactly one header, got {}", result.headers.len());
+        };
         assert_eq!(header.apply_page_type, ApplyPageType::Both);
         assert_eq!(header.paragraphs[0].runs[0].content.as_text(), Some("My Header"));
 
-        let footer = result.footer.expect("should have footer");
+        let [footer] = result.footers.as_slice() else {
+            panic!("expected exactly one footer, got {}", result.footers.len());
+        };
         assert_eq!(footer.apply_page_type, ApplyPageType::Odd);
         assert_eq!(footer.paragraphs[0].runs[0].content.as_text(), Some("My Footer"));
 
@@ -2549,8 +2568,8 @@ mod tests {
             </p>
         </sec>"#;
         let result = parse_section(xml, 0, &HashMap::new()).unwrap();
-        assert!(result.header.is_none());
-        assert!(result.footer.is_none());
+        assert!(result.headers.is_empty());
+        assert!(result.footers.is_empty());
         assert!(result.page_number.is_none());
     }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -127,6 +127,8 @@ pub struct SectionParseResult {
     pub text_direction: TextDirection,
     /// Starting numbers extracted from `<hp:startNum>` in secPr.
     pub begin_num: Option<hwpforge_core::section::BeginNum>,
+    /// 디코드 중 표면화된 비치명 경고 (W5-α M4 — 미지 enum 폴백 등).
+    pub warnings: Vec<super::DecodeWarning>,
 }
 
 /// Parses a section XML string into paragraphs and optional page settings.
@@ -145,6 +147,7 @@ pub fn parse_section(
     let mut page_settings = None;
     let mut headers = Vec::new();
     let mut footers = Vec::new();
+    let mut warnings: Vec<super::DecodeWarning> = Vec::new();
     let mut page_number = None;
     let mut column_settings = None;
     let mut visibility = None;
@@ -178,7 +181,7 @@ pub fn parse_section(
                             page_border_fills = extract_page_border_fills(sec_pr);
                         }
                         if begin_num.is_none() {
-                            begin_num = extract_begin_num(sec_pr);
+                            begin_num = extract_begin_num(sec_pr, &mut warnings);
                         }
                         text_direction = TextDirection::from_hwpx_str(&sec_pr.text_direction);
                     }
@@ -195,14 +198,14 @@ pub fn parse_section(
                     }
                     // 다중 머리말/꼬리말 = wire 순서대로 전부 수집 (W5-α C1:
                     // first-wins 는 ODD/EVEN 문서에서 무음 데이터 손실).
-                    if let Some(hf) = convert_ctrl_header(ctrl)? {
+                    if let Some(hf) = convert_ctrl_header(ctrl, &mut warnings)? {
                         headers.push(hf);
                     }
-                    if let Some(hf) = convert_ctrl_footer(ctrl)? {
+                    if let Some(hf) = convert_ctrl_footer(ctrl, &mut warnings)? {
                         footers.push(hf);
                     }
                     if page_number.is_none() {
-                        if let Some(pn) = convert_ctrl_page_number(ctrl) {
+                        if let Some(pn) = convert_ctrl_page_number(ctrl, &mut warnings) {
                             page_number = Some(pn);
                         }
                     }
@@ -247,6 +250,7 @@ pub fn parse_section(
         master_pages: None,
         text_direction,
         begin_num,
+        warnings,
     })
 }
 
@@ -1423,6 +1427,7 @@ fn extract_line_number_shape(
 /// Extracts [`BeginNum`] from an `HxSecPr`'s `<hp:startNum>` element.
 fn extract_begin_num(
     sec_pr: &crate::schema::section::HxSecPr,
+    warnings: &mut Vec<super::DecodeWarning>,
 ) -> Option<hwpforge_core::section::BeginNum> {
     let sn = sec_pr.start_num.as_ref()?;
     Some(hwpforge_core::section::BeginNum {
@@ -1432,20 +1437,31 @@ fn extract_begin_num(
         equation: sn.equation,
         footnote: 1,
         endnote: 1,
-        page_starts_on: parse_page_starts_on(&sn.page_starts_on),
+        page_starts_on: parse_page_starts_on(&sn.page_starts_on, warnings),
     })
 }
 
 /// Parses an HWPX `pageStartsOn` string into [`PageStartsOn`].
 ///
-/// 빈 문자열(속성 결측) = `Both` (스펙 기본). 미지 값도 `Both` 로
-/// 폴백한다 — W5-α α3 에서 디코드 경고 채널 표면화 대상.
-fn parse_page_starts_on(s: &str) -> hwpforge_core::section::PageStartsOn {
+/// 빈 문자열(속성 결측) = `Both` (스펙 기본, 경고 없음). 미지 값은
+/// `Both` 폴백 + 경고 표면화 (W5-α M4).
+fn parse_page_starts_on(
+    s: &str,
+    warnings: &mut Vec<super::DecodeWarning>,
+) -> hwpforge_core::section::PageStartsOn {
     use hwpforge_core::section::PageStartsOn;
     match s {
+        "" | "BOTH" | "Both" | "both" => PageStartsOn::Both,
         "EVEN" | "Even" | "even" => PageStartsOn::Even,
         "ODD" | "Odd" | "odd" => PageStartsOn::Odd,
-        _ => PageStartsOn::Both,
+        _ => {
+            warnings.push(super::DecodeWarning::UnknownEnumValue {
+                attribute: "hp:startNum@pageStartsOn",
+                raw: s.to_string(),
+                fallback: "BOTH",
+            });
+            PageStartsOn::Both
+        }
     }
 }
 
@@ -1579,8 +1595,14 @@ fn parse_mm_width(s: &str) -> HwpUnit {
 ///
 /// 머리말 내부 문단 변환 실패를 전파한다 (W5-α C1 — `filter_map` 무음
 /// 삼킴은 캐시·본문 소실을 숨겼다).
-fn convert_ctrl_header(ctrl: &HxCtrl) -> HwpxResult<Option<HeaderFooter>> {
-    ctrl.header.as_ref().map(convert_header_footer).transpose()
+fn convert_ctrl_header(
+    ctrl: &HxCtrl,
+    warnings: &mut Vec<super::DecodeWarning>,
+) -> HwpxResult<Option<HeaderFooter>> {
+    ctrl.header
+        .as_ref()
+        .map(|hx| convert_header_footer(hx, "hp:header@applyPageType", warnings))
+        .transpose()
 }
 
 /// Extracts a [`HeaderFooter`] from an `HxCtrl`'s footer element, if present.
@@ -1588,8 +1610,14 @@ fn convert_ctrl_header(ctrl: &HxCtrl) -> HwpxResult<Option<HeaderFooter>> {
 /// # Errors
 ///
 /// 꼬리말 내부 문단 변환 실패를 전파한다 (`convert_ctrl_header` 참조).
-fn convert_ctrl_footer(ctrl: &HxCtrl) -> HwpxResult<Option<HeaderFooter>> {
-    ctrl.footer.as_ref().map(convert_header_footer).transpose()
+fn convert_ctrl_footer(
+    ctrl: &HxCtrl,
+    warnings: &mut Vec<super::DecodeWarning>,
+) -> HwpxResult<Option<HeaderFooter>> {
+    ctrl.footer
+        .as_ref()
+        .map(|hx| convert_header_footer(hx, "hp:footer@applyPageType", warnings))
+        .transpose()
 }
 
 /// Converts an `HxHeaderFooter` into a Core [`HeaderFooter`].
@@ -1598,8 +1626,12 @@ fn convert_ctrl_footer(ctrl: &HxCtrl) -> HwpxResult<Option<HeaderFooter>> {
 ///
 /// 내부 문단 변환 실패를 전파한다 — 머리말 문단이 조용히 사라지면
 /// 렌더/왕복이 결손을 인지할 수 없다 (fail-open 금지).
-fn convert_header_footer(hx: &HxHeaderFooter) -> HwpxResult<HeaderFooter> {
-    let apply_page_type = parse_apply_page_type(&hx.apply_page_type);
+fn convert_header_footer(
+    hx: &HxHeaderFooter,
+    attribute: &'static str,
+    warnings: &mut Vec<super::DecodeWarning>,
+) -> HwpxResult<HeaderFooter> {
+    let apply_page_type = parse_apply_page_type(&hx.apply_page_type, attribute, warnings);
 
     let paragraphs = if let Some(sub_list) = &hx.sub_list {
         sub_list
@@ -1615,15 +1647,30 @@ fn convert_header_footer(hx: &HxHeaderFooter) -> HwpxResult<HeaderFooter> {
 }
 
 /// Extracts a [`PageNumber`] from an `HxCtrl`'s page_num element, if present.
-fn convert_ctrl_page_number(ctrl: &HxCtrl) -> Option<PageNumber> {
+fn convert_ctrl_page_number(
+    ctrl: &HxCtrl,
+    warnings: &mut Vec<super::DecodeWarning>,
+) -> Option<PageNumber> {
     let hx = ctrl.page_num.as_ref()?;
-    Some(convert_page_number(hx))
+    Some(convert_page_number(hx, warnings))
 }
 
 /// Converts an `HxPageNum` into a Core [`PageNumber`].
-fn convert_page_number(hx: &HxPageNum) -> PageNumber {
-    let position = parse_page_number_position(&hx.pos);
-    let number_format = super::header::parse_number_format(&hx.format_type);
+fn convert_page_number(hx: &HxPageNum, warnings: &mut Vec<super::DecodeWarning>) -> PageNumber {
+    let position = parse_page_number_position(&hx.pos, warnings);
+    let number_format = match super::header::parse_number_format_opt(&hx.format_type) {
+        Some(format) => format,
+        None => {
+            if !hx.format_type.is_empty() {
+                warnings.push(super::DecodeWarning::UnknownEnumValue {
+                    attribute: "hp:pageNum@formatType",
+                    raw: hx.format_type.clone(),
+                    fallback: "DIGIT",
+                });
+            }
+            hwpforge_foundation::NumberFormatType::Digit
+        }
+    };
     if hx.side_char.is_empty() {
         PageNumber::new(position, number_format)
     } else {
@@ -1632,21 +1679,38 @@ fn convert_page_number(hx: &HxPageNum) -> PageNumber {
 }
 
 /// Parses an HWPX `applyPageType` string into [`ApplyPageType`].
-fn parse_apply_page_type(s: &str) -> ApplyPageType {
+fn parse_apply_page_type(
+    s: &str,
+    attribute: &'static str,
+    warnings: &mut Vec<super::DecodeWarning>,
+) -> ApplyPageType {
     match s {
-        "BOTH" | "Both" | "both" => ApplyPageType::Both,
+        // 결측(빈 문자열) = 기본값 적용이 정상 — 경고 없음.
+        "" | "BOTH" | "Both" | "both" => ApplyPageType::Both,
         "EVEN" | "Even" | "even" => ApplyPageType::Even,
         "ODD" | "Odd" | "odd" => ApplyPageType::Odd,
-        _ => ApplyPageType::Both,
+        _ => {
+            // W5-α M4: 미지 값 폴백은 유지하되 표면화한다 (증거 세탁 금지).
+            warnings.push(super::DecodeWarning::UnknownEnumValue {
+                attribute,
+                raw: s.to_string(),
+                fallback: "BOTH",
+            });
+            ApplyPageType::Both
+        }
     }
 }
 
 /// Parses an HWPX `pos` string into [`PageNumberPosition`].
-fn parse_page_number_position(s: &str) -> PageNumberPosition {
+fn parse_page_number_position(
+    s: &str,
+    warnings: &mut Vec<super::DecodeWarning>,
+) -> PageNumberPosition {
     match s {
         "NONE" => PageNumberPosition::None,
+        // 결측(빈 문자열) = 기본값 적용이 정상 — 경고 없음.
+        "" | "TOP_CENTER" => PageNumberPosition::TopCenter,
         "TOP_LEFT" => PageNumberPosition::TopLeft,
-        "TOP_CENTER" => PageNumberPosition::TopCenter,
         "TOP_RIGHT" => PageNumberPosition::TopRight,
         "BOTTOM_LEFT" => PageNumberPosition::BottomLeft,
         "BOTTOM_CENTER" => PageNumberPosition::BottomCenter,
@@ -1655,7 +1719,15 @@ fn parse_page_number_position(s: &str) -> PageNumberPosition {
         "OUTSIDE_BOTTOM" => PageNumberPosition::OutsideBottom,
         "INSIDE_TOP" => PageNumberPosition::InsideTop,
         "INSIDE_BOTTOM" => PageNumberPosition::InsideBottom,
-        _ => PageNumberPosition::TopCenter,
+        _ => {
+            // W5-α M4: 미지 값 폴백 표면화.
+            warnings.push(super::DecodeWarning::UnknownEnumValue {
+                attribute: "hp:pageNum@pos",
+                raw: s.to_string(),
+                fallback: "TOP_CENTER",
+            });
+            PageNumberPosition::TopCenter
+        }
     }
 }
 
@@ -2898,27 +2970,53 @@ mod tests {
 
     #[test]
     fn parse_apply_page_type_values() {
-        assert_eq!(parse_apply_page_type("BOTH"), ApplyPageType::Both);
-        assert_eq!(parse_apply_page_type("EVEN"), ApplyPageType::Even);
-        assert_eq!(parse_apply_page_type("ODD"), ApplyPageType::Odd);
-        assert_eq!(parse_apply_page_type("Both"), ApplyPageType::Both);
-        assert_eq!(parse_apply_page_type("unknown"), ApplyPageType::Both);
+        let mut w = Vec::new();
+        let attr = "hp:header@applyPageType";
+        assert_eq!(parse_apply_page_type("BOTH", attr, &mut w), ApplyPageType::Both);
+        assert_eq!(parse_apply_page_type("EVEN", attr, &mut w), ApplyPageType::Even);
+        assert_eq!(parse_apply_page_type("ODD", attr, &mut w), ApplyPageType::Odd);
+        assert_eq!(parse_apply_page_type("Both", attr, &mut w), ApplyPageType::Both);
+        assert_eq!(parse_apply_page_type("", attr, &mut w), ApplyPageType::Both);
+        assert!(w.is_empty(), "정상·결측 값은 경고 없음: {w:?}");
+        assert_eq!(parse_apply_page_type("unknown", attr, &mut w), ApplyPageType::Both);
+        assert_eq!(w.len(), 1, "미지 값 = 경고 1건");
     }
 
     #[test]
     fn parse_page_number_position_values() {
-        assert_eq!(parse_page_number_position("NONE"), PageNumberPosition::None);
-        assert_eq!(parse_page_number_position("TOP_LEFT"), PageNumberPosition::TopLeft);
-        assert_eq!(parse_page_number_position("TOP_CENTER"), PageNumberPosition::TopCenter);
-        assert_eq!(parse_page_number_position("TOP_RIGHT"), PageNumberPosition::TopRight);
-        assert_eq!(parse_page_number_position("BOTTOM_LEFT"), PageNumberPosition::BottomLeft);
-        assert_eq!(parse_page_number_position("BOTTOM_CENTER"), PageNumberPosition::BottomCenter);
-        assert_eq!(parse_page_number_position("BOTTOM_RIGHT"), PageNumberPosition::BottomRight);
-        assert_eq!(parse_page_number_position("OUTSIDE_TOP"), PageNumberPosition::OutsideTop);
-        assert_eq!(parse_page_number_position("OUTSIDE_BOTTOM"), PageNumberPosition::OutsideBottom);
-        assert_eq!(parse_page_number_position("INSIDE_TOP"), PageNumberPosition::InsideTop);
-        assert_eq!(parse_page_number_position("INSIDE_BOTTOM"), PageNumberPosition::InsideBottom);
-        assert_eq!(parse_page_number_position("unknown"), PageNumberPosition::TopCenter);
+        let mut w = Vec::new();
+        assert_eq!(parse_page_number_position("NONE", &mut w), PageNumberPosition::None);
+        assert_eq!(parse_page_number_position("TOP_LEFT", &mut w), PageNumberPosition::TopLeft);
+        assert_eq!(parse_page_number_position("TOP_CENTER", &mut w), PageNumberPosition::TopCenter);
+        assert_eq!(parse_page_number_position("TOP_RIGHT", &mut w), PageNumberPosition::TopRight);
+        assert_eq!(
+            parse_page_number_position("BOTTOM_LEFT", &mut w),
+            PageNumberPosition::BottomLeft
+        );
+        assert_eq!(
+            parse_page_number_position("BOTTOM_CENTER", &mut w),
+            PageNumberPosition::BottomCenter
+        );
+        assert_eq!(
+            parse_page_number_position("BOTTOM_RIGHT", &mut w),
+            PageNumberPosition::BottomRight
+        );
+        assert_eq!(
+            parse_page_number_position("OUTSIDE_TOP", &mut w),
+            PageNumberPosition::OutsideTop
+        );
+        assert_eq!(
+            parse_page_number_position("OUTSIDE_BOTTOM", &mut w),
+            PageNumberPosition::OutsideBottom
+        );
+        assert_eq!(parse_page_number_position("INSIDE_TOP", &mut w), PageNumberPosition::InsideTop);
+        assert_eq!(
+            parse_page_number_position("INSIDE_BOTTOM", &mut w),
+            PageNumberPosition::InsideBottom
+        );
+        assert!(w.is_empty(), "정상 값은 경고 없음: {w:?}");
+        assert_eq!(parse_page_number_position("unknown", &mut w), PageNumberPosition::TopCenter);
+        assert_eq!(w.len(), 1, "미지 값 = 경고 1건");
     }
 
     #[test]
@@ -3750,6 +3848,84 @@ mod tests {
         assert_eq!(lns.count_by, 5);
         assert_eq!(lns.distance.as_i32(), 1000);
         assert_eq!(lns.start_number, 3);
+    }
+
+    // ── 미지 enum 경고 표면화 (W5-α M4 — 증거 세탁 방지) ─────────
+
+    #[test]
+    fn unknown_apply_page_type_surfaces_warning_and_keeps_fallback() {
+        use crate::decoder::DecodeWarning;
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <ctrl>
+                        <header applyPageType="WEIRD_VALUE" id="1">
+                            <subList id="" textDirection="HORIZONTAL">
+                                <p paraPrIDRef="0"><run charPrIDRef="0"><t>H</t></run></p>
+                            </subList>
+                        </header>
+                    </ctrl>
+                    <t>Body</t>
+                </run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        // 기존 동작(Both 폴백)은 유지하되, 렌더러가 원본이 unknown 이었음을
+        // 알 수 있게 경고를 표면화한다 (디코더의 증거 세탁 금지).
+        assert_eq!(result.headers[0].apply_page_type, ApplyPageType::Both);
+        assert_eq!(result.warnings.len(), 1, "{:?}", result.warnings);
+        let DecodeWarning::UnknownEnumValue { attribute, raw, fallback } = &result.warnings[0];
+        assert_eq!(*attribute, "hp:header@applyPageType");
+        assert_eq!(raw, "WEIRD_VALUE");
+        assert_eq!(*fallback, "BOTH");
+    }
+
+    #[test]
+    fn absent_enum_attributes_do_not_warn() {
+        // 속성 결측(빈 문자열) = 기본값 적용은 정상 — 경고 없음.
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <ctrl>
+                        <header id="1">
+                            <subList id="" textDirection="HORIZONTAL">
+                                <p paraPrIDRef="0"><run charPrIDRef="0"><t>H</t></run></p>
+                            </subList>
+                        </header>
+                    </ctrl>
+                    <t>Body</t>
+                </run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        assert_eq!(result.headers[0].apply_page_type, ApplyPageType::Both);
+        assert!(result.warnings.is_empty(), "{:?}", result.warnings);
+    }
+
+    #[test]
+    fn unknown_page_num_enums_surface_warnings() {
+        use crate::decoder::DecodeWarning;
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <ctrl>
+                        <pageNum pos="MIDDLE_EARTH" formatType="KLINGON" sideChar=""/>
+                    </ctrl>
+                    <t>Body</t>
+                </run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        let unknowns: Vec<&'static str> = result
+            .warnings
+            .iter()
+            .map(|w| {
+                let DecodeWarning::UnknownEnumValue { attribute, .. } = w;
+                *attribute
+            })
+            .collect();
+        assert!(unknowns.contains(&"hp:pageNum@pos"), "{unknowns:?}");
+        assert!(unknowns.contains(&"hp:pageNum@formatType"), "{unknowns:?}");
     }
 
     // ── startNum pageStartsOn decoding (W5-α C2) ─────────────────

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -2730,8 +2730,35 @@ mod tests {
     fn begin_num_encodes_in_startnum() {
         use hwpforge_core::section::BeginNum;
         let mut section = simple_section("text");
-        section.begin_num =
-            Some(BeginNum { page: 3, footnote: 2, endnote: 1, pic: 4, tbl: 5, equation: 6 });
+        section.begin_num = Some(BeginNum {
+            page: 3,
+            footnote: 2,
+            endnote: 1,
+            pic: 4,
+            tbl: 5,
+            equation: 6,
+            ..BeginNum::default()
+        });
+        // 기본(Both) 은 wire "BOTH" 로 방출된다.
+        {
+            let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
+            assert!(xml.contains(r#"pageStartsOn="BOTH""#));
+        }
+        // W5-α C2: 홀짝 강제 시작은 실값 왕복 ("BOTH" 고정 회귀 방지).
+        section.begin_num.as_mut().unwrap().page_starts_on =
+            hwpforge_core::section::PageStartsOn::Even;
+        {
+            let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
+            assert!(xml.contains(r#"pageStartsOn="EVEN""#), "pageStartsOn 실값 방출");
+            let parsed =
+                crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
+                    .unwrap();
+            assert_eq!(
+                parsed.begin_num.expect("begin_num").page_starts_on,
+                hwpforge_core::section::PageStartsOn::Even,
+                "왕복 보존"
+            );
+        }
         let xml = encode_section(&section, 0, 0, 0, 0, EncodeOptions::default()).unwrap().xml;
         assert!(xml.contains(r#"page="3""#));
         assert!(xml.contains(r#"pic="4""#));

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -1993,7 +1993,9 @@ mod tests {
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
-        let header = result.header.expect("decoded section should have header");
+        let [header] = result.headers.as_slice() else {
+            panic!("decoded section should have exactly one header");
+        };
         assert_eq!(header.apply_page_type, ApplyPageType::Both);
         assert_eq!(header.paragraphs.len(), 1);
         assert_eq!(header.paragraphs[0].runs[0].content.as_text(), Some("Header Content"));
@@ -2016,7 +2018,9 @@ mod tests {
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
-        let footer = result.footer.expect("decoded section should have footer");
+        let [footer] = result.footers.as_slice() else {
+            panic!("decoded section should have exactly one footer");
+        };
         assert_eq!(footer.apply_page_type, ApplyPageType::Even);
         assert_eq!(footer.paragraphs.len(), 1);
         assert_eq!(footer.paragraphs[0].runs[0].content.as_text(), Some("Footer Content"));
@@ -2110,8 +2114,12 @@ mod tests {
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
-        let header = result.header.expect("should have header");
-        let footer = result.footer.expect("should have footer");
+        let [header] = result.headers.as_slice() else {
+            panic!("should have exactly one header");
+        };
+        let [footer] = result.footers.as_slice() else {
+            panic!("should have exactly one footer");
+        };
 
         assert_eq!(header.paragraphs[0].runs[0].content.as_text(), Some("My Header"));
         assert_eq!(header.apply_page_type, ApplyPageType::Both);
@@ -2360,7 +2368,9 @@ mod tests {
         let result =
             crate::decoder::section::parse_section(&xml, 0, &std::collections::HashMap::new())
                 .unwrap();
-        let header = result.header.expect("should have header");
+        let [header] = result.headers.as_slice() else {
+            panic!("should have exactly one header");
+        };
         assert_eq!(header.paragraphs[0].runs[0].content.as_text(), Some("A & B < C > D"),);
     }
 

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/header_footer.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/header_footer.rs
@@ -193,7 +193,27 @@ pub(super) fn build_header_xml(
     let mut xml = String::new();
     write!(xml, r#"<hp:ctrl><hp:{tag_name} applyPageType="{apply_page}" id="{hf_id}">"#,)
         .expect("write to String is infallible");
-    xml.push_str(&encode_memo_sublist(&hf.paragraphs, 0, hyperlink_entries, options)?);
+    // W5-α H1: 컨테이너 기하(vertAlign/textWidth/textHeight) 실값 왕복 —
+    // 일반 꼬리말은 vertAlign=BOTTOM 을 쓰므로 하드코딩하면 데이터 손실.
+    let vert_align = match hf.vert_align {
+        hwpforge_foundation::VerticalAlign::Center => "CENTER",
+        hwpforge_foundation::VerticalAlign::Bottom => "BOTTOM",
+        _ => "TOP",
+    };
+    let mut sub_list = crate::encoder::section::encode_paragraphs_to_sublist_with_align(
+        &hf.paragraphs,
+        0,
+        vert_align,
+        hyperlink_entries,
+        options,
+    )?;
+    sub_list.text_width = u32::try_from(hf.text_width.as_i32()).unwrap_or(0);
+    sub_list.text_height = u32::try_from(hf.text_height.as_i32()).unwrap_or(0);
+    let sub_xml = quick_xml::se::to_string(&sub_list)
+        .map_err(|e| crate::error::HwpxError::InvalidStructure { detail: e.to_string() })?;
+    let sub_xml = sub_xml.replacen("<HxSubList", "<hp:subList", 1);
+    let sub_xml = sub_xml.replacen("</HxSubList>", "</hp:subList>", 1);
+    xml.push_str(&sub_xml);
     write!(xml, "</hp:{tag_name}></hp:ctrl>").expect("write to String is infallible");
     Ok(xml)
 }
@@ -317,6 +337,20 @@ mod tests {
             assert!(xml.contains(&format!(r#"applyPageType="{want}""#)), "{want}: {xml}");
             assert!(xml.starts_with("<hp:ctrl><hp:header"));
         }
+    }
+
+    #[test]
+    fn header_xml_carries_sublist_geometry() {
+        // W5-α H1: 컨테이너 기하 실값 왕복 — 일반 꼬리말 = vertAlign BOTTOM.
+        let mut entries = Vec::new();
+        let mut hf = HeaderFooter::new(Vec::new(), ApplyPageType::Both);
+        hf.vert_align = hwpforge_foundation::VerticalAlign::Bottom;
+        hf.text_width = hwpforge_foundation::HwpUnit::new(42520).unwrap();
+        hf.text_height = hwpforge_foundation::HwpUnit::new(4252).unwrap();
+        let xml = build_header_xml(&hf, "footer", &mut entries, EncodeOptions::default()).unwrap();
+        assert!(xml.contains(r#"vertAlign="BOTTOM""#), "{xml}");
+        assert!(xml.contains(r#"textWidth="42520""#), "{xml}");
+        assert!(xml.contains(r#"textHeight="4252""#), "{xml}");
     }
 
     #[test]

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/section_pr.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/section_pr.rs
@@ -76,9 +76,17 @@ pub(super) fn build_sec_pr_pre_elements(section: &Section) -> String {
     let pic = bn.map_or(0, |b| b.pic);
     let tbl = bn.map_or(0, |b| b.tbl);
     let equation = bn.map_or(0, |b| b.equation);
+    // W5-α C2: pageStartsOn 은 "BOTH" 고정이 아니라 실값 왕복 (홀짝 강제
+    // 시작 = 쪽번호 연속성 입력).
+    use hwpforge_core::section::PageStartsOn;
+    let page_starts_on = match bn.map_or(PageStartsOn::Both, |b| b.page_starts_on) {
+        PageStartsOn::Both => "BOTH",
+        PageStartsOn::Even => "EVEN",
+        PageStartsOn::Odd => "ODD",
+    };
     let _ = write!(
         xml,
-        r#"<hp:startNum pageStartsOn="BOTH" page="{page}" pic="{pic}" tbl="{tbl}" equation="{equation}"/>"#,
+        r#"<hp:startNum pageStartsOn="{page_starts_on}" page="{page}" pic="{pic}" tbl="{tbl}" equation="{equation}"/>"#,
     );
     let _ = write!(
         xml,

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -79,7 +79,7 @@ pub use cell_edit::{
     HwpxCellEditor, SetCellOutcome, SetCellResult,
 };
 pub use decoder::package::{PackageEntryInfo, PackageReader};
-pub use decoder::{HwpxDecoder, HwpxDocument};
+pub use decoder::{DecodeWarning, HwpxDecoder, HwpxDocument};
 pub use default_styles::{DefaultStyleEntry, HancomStyleSet};
 pub use diff::{
     CellTextChange, DocumentDiff, FieldChange, FieldChangeKind, HwpxDiffer, PackageDiff,

--- a/crates/hwpforge-smithy-hwpx/src/patch.rs
+++ b/crates/hwpforge-smithy-hwpx/src/patch.rs
@@ -1843,8 +1843,8 @@ mod tests {
         let section = Section {
             paragraphs: parsed.paragraphs,
             page_settings: parsed.page_settings.unwrap_or_default(),
-            headers: parsed.header.into_iter().collect(),
-            footers: parsed.footer.into_iter().collect(),
+            headers: parsed.headers,
+            footers: parsed.footers,
             page_number: parsed.page_number,
             column_settings: parsed.column_settings,
             visibility: parsed.visibility,
@@ -1900,13 +1900,13 @@ mod tests {
         "#;
 
         let parsed = parse_section(xml, 0, &HashMap::new()).unwrap();
-        assert!(parsed.footer.is_none(), "nested footer must not become section footer");
+        assert!(parsed.footers.is_empty(), "nested footer must not become section footer");
 
         let section = Section {
             paragraphs: parsed.paragraphs,
             page_settings: parsed.page_settings.unwrap_or_default(),
-            headers: parsed.header.into_iter().collect(),
-            footers: parsed.footer.into_iter().collect(),
+            headers: parsed.headers,
+            footers: parsed.footers,
             page_number: parsed.page_number,
             column_settings: parsed.column_settings,
             visibility: parsed.visibility,
@@ -1959,8 +1959,8 @@ mod tests {
         let section = Section {
             paragraphs: parsed.paragraphs,
             page_settings: parsed.page_settings.unwrap_or_default(),
-            headers: parsed.header.into_iter().collect(),
-            footers: parsed.footer.into_iter().collect(),
+            headers: parsed.headers,
+            footers: parsed.footers,
             page_number: parsed.page_number,
             column_settings: parsed.column_settings,
             visibility: parsed.visibility,

--- a/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
+++ b/crates/hwpforge-smithy-hwpx/src/stamp/stamper.rs
@@ -243,7 +243,7 @@ impl HwpxStamper {
         check_zip_carry(base, &e0)?;
 
         // ── apply on the admitted decode ────────────────────────────
-        let HwpxDocument { mut document, style_store, image_store } = d0;
+        let HwpxDocument { mut document, style_store, image_store, .. } = d0;
         let outcome = apply(&mut document, specs)?;
         let validated =
             document.validate().map_err(|e| StamperError::Codec(format!("validate: {e}")))?;
@@ -292,7 +292,7 @@ impl HwpxStamper {
         check_zip_carry(base, &e0)?;
 
         // ── unified preflight, then mutate ──────────────────────────
-        let HwpxDocument { mut document, style_store, image_store } = d0;
+        let HwpxDocument { mut document, style_store, image_store, .. } = d0;
         let reserved: HashSet<String> = request
             .text
             .iter()
@@ -309,6 +309,7 @@ impl HwpxStamper {
         let text_outcome = apply(&mut document, &request.text)?;
         // Text-only reference for the reverse-delta gate (before cells).
         let text_only = HwpxDocument {
+            warnings: Vec::new(),
             document: document.clone(),
             style_store: style_store.clone(),
             image_store: image_store.clone(),
@@ -409,6 +410,7 @@ fn verify_and_reverse_cells(
     }
 
     let reverted = HwpxDocument {
+        warnings: Vec::new(),
         document: reverted,
         style_store: d2.style_store.clone(),
         image_store: d2.image_store.clone(),
@@ -769,6 +771,7 @@ mod tests {
             PageSettings::default(),
         ));
         HwpxDocument {
+            warnings: Vec::new(),
             document: doc,
             style_store: HwpxStyleStore::with_default_fonts("함초롬돋움"),
             image_store: ImageStore::new(),

--- a/crates/hwpforge-smithy-hwpx/src/structural.rs
+++ b/crates/hwpforge-smithy-hwpx/src/structural.rs
@@ -398,6 +398,7 @@ impl HwpxStructuralEditor {
 
         // ── reverse-delta self-verify: output ≡ declared delta ──
         let expected_doc = HwpxDocument {
+            warnings: Vec::new(),
             document: expected,
             style_store: d0.style_store.clone(),
             image_store: d0.image_store.clone(),
@@ -522,6 +523,7 @@ impl HwpxStructuralEditor {
         // Encode the declared delta once; its section XML holds the new
         // paragraph in the exact form the codec round-trips.
         let encoded = encode_hwpx(&HwpxDocument {
+            warnings: Vec::new(),
             document: expected.clone(),
             style_store: d0.style_store.clone(),
             image_store: d0.image_store.clone(),
@@ -596,6 +598,7 @@ impl HwpxStructuralEditor {
 
         // ── reverse-delta self-verify ──
         let expected_doc = HwpxDocument {
+            warnings: Vec::new(),
             document: expected,
             style_store: d0.style_store.clone(),
             image_store: d0.image_store.clone(),
@@ -1431,6 +1434,7 @@ mod tests {
         let mut wrong = decoded.document.clone();
         wrong.sections_mut()[0].paragraphs.pop();
         let expected = HwpxDocument {
+            warnings: Vec::new(),
             document: wrong,
             style_store: decoded.style_store.clone(),
             image_store: decoded.image_store.clone(),
@@ -1446,6 +1450,7 @@ mod tests {
         let base = fixture("plain_paragraphs.hwpx");
         let decoded = HwpxDecoder::decode(&base).unwrap();
         let expected = HwpxDocument {
+            warnings: Vec::new(),
             document: decoded.document.clone(),
             style_store: decoded.style_store.clone(),
             image_store: decoded.image_store.clone(),
@@ -1616,6 +1621,7 @@ mod tests {
             document,
             style_store: d0.style_store.clone(),
             image_store: d0.image_store.clone(),
+            warnings: Vec::new(),
         })
         .expect("encode");
 

--- a/crates/hwpforge-smithy-hwpx/tests/header_footer_cardinality.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/header_footer_cardinality.rs
@@ -1,0 +1,57 @@
+//! W5-α 게이트 — 머리말/꼬리말 cardinality 보존 (Codex C1).
+//!
+//! 디코더가 ODD/EVEN 다중 머리말을 first-wins 로 무음 폐기하던 fail-open
+//! 을 골든으로 잠근다. fixture = 한컴 직접 제작 실물
+//! (`sample-header-footer-odd-even.hwpx`): wire 실측 = `<hp:header
+//! applyPageType="ODD">` "홀수페이지 머리말" + `EVEN` "짝수페이지 머리말",
+//! 각자 lineseg 1개 보유. 인코더는 원래 Vec 전체를 방출하므로 디코더만
+//! 고치면 왕복이 닫힌다.
+
+use hwpforge_foundation::ApplyPageType;
+use hwpforge_smithy_hwpx::{HwpxDecoder, HwpxEncoder};
+
+fn fixture_bytes() -> Vec<u8> {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../tests/fixtures/user_samples/pages/sample-header-footer-odd-even.hwpx"
+    );
+    std::fs::read(path).expect("odd-even fixture")
+}
+
+#[test]
+fn odd_even_headers_both_survive_decode() {
+    let decoded = HwpxDecoder::decode(&fixture_bytes()).expect("decode");
+    let section = &decoded.document.sections()[0];
+    let kinds: Vec<ApplyPageType> = section.headers.iter().map(|h| h.apply_page_type).collect();
+    assert_eq!(
+        kinds,
+        vec![ApplyPageType::Odd, ApplyPageType::Even],
+        "wire 순서대로 ODD/EVEN 둘 다 보존"
+    );
+    let texts: Vec<String> =
+        section.headers.iter().map(|h| h.paragraphs[0].text_content()).collect();
+    assert_eq!(texts, vec!["홀수페이지 머리말", "짝수페이지 머리말"]);
+    // PDF 재생 재료 — 각 머리말 문단의 조판 캐시도 함께 보존돼야 한다.
+    for header in &section.headers {
+        assert!(
+            header.paragraphs[0].layout_cache.is_some(),
+            "{:?} 머리말의 layout_cache 소실",
+            header.apply_page_type
+        );
+    }
+}
+
+#[test]
+fn odd_even_headers_roundtrip_cardinality() {
+    let decoded = HwpxDecoder::decode(&fixture_bytes()).expect("decode");
+    let validated = decoded.document.validate().expect("validate");
+    let bytes = HwpxEncoder::encode(&validated, &decoded.style_store, &decoded.image_store)
+        .expect("encode");
+    let again = HwpxDecoder::decode(&bytes).expect("re-decode");
+    let headers = &again.document.sections()[0].headers;
+    assert_eq!(headers.len(), 2, "재인코드 왕복 후에도 머리말 2개");
+    assert_eq!(
+        headers.iter().map(|h| h.apply_page_type).collect::<Vec<_>>(),
+        vec![ApplyPageType::Odd, ApplyPageType::Even]
+    );
+}

--- a/crates/hwpforge-smithy-hwpx/tests/header_footer_cardinality.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/header_footer_cardinality.rs
@@ -54,4 +54,11 @@ fn odd_even_headers_roundtrip_cardinality() {
         headers.iter().map(|h| h.apply_page_type).collect::<Vec<_>>(),
         vec![ApplyPageType::Odd, ApplyPageType::Even]
     );
+    // subList 기하 실물 왕복 (독립 리뷰 Low 1 상환): 합성 단위테스트는
+    // 방향별로만 잠갔었다 — 실물 값(42520/4252)이 인코더에서 떨어지면
+    // 여기서 잡힌다.
+    for header in headers {
+        assert_eq!(header.text_width.as_i32(), 42520, "{:?}", header.apply_page_type);
+        assert_eq!(header.text_height.as_i32(), 4252, "{:?}", header.apply_page_type);
+    }
 }


### PR DESCRIPTION
## 요약

PDF Export 에픽 W5 의 선행 수리 슬라이스 — **디코더 정합**. 적대 설계 리뷰가 확증한 "디코더가 증거를 폐기/세탁해 하류 warning-first 가 무력해지는" 결함 4건을 교정한다. 렌더 확장(W5-a/b 머리말/꼬리말·쪽번호)은 후속 PR.

## 변경 사항

### 다중 머리말/꼬리말 cardinality 보존 (`de00f31`, `feat!`)
- `SectionParseResult.header/footer: Option` → `headers/footers: Vec` — HWPX 는 `applyPageType`(BOTH/ODD/EVEN)별 복수 `<hp:header>` 를 허용하는데 디코더가 첫 항목만 남기고 **무음 폐기**했다. 인코더는 원래 Vec 전체를 방출하므로 재저장 왕복에서 실데이터가 사라지던 fail-open.
- `convert_header_footer` 의 `filter_map(...ok()?)` 오류 삼킴 제거 — 머리말 내부 문단 변환 실패는 전파.
- 골든: `sample-header-footer-odd-even.hwpx` (한컴 제작 실물, ODD+EVEN 머리말) — 디코드 2개 보존·문단 텍스트·layout_cache·재인코드 왕복.

### pageStartsOn 승격 (`bf28b1b`, `feat!`)
- `core::section::PageStartsOn{Both,Even,Odd}` + `BeginNum.page_starts_on` — 스키마가 이미 파싱하던 값을 디코더가 폐기했고, 인코더는 `"BOTH"` 를 하드코딩했다. 실값 왕복으로 교정.
- `BeginNum.page` 문서 정정: 섹션 `startNum` 의미론은 **0 = 이전 구역에서 계속**, n>0 = n 재시작 (OWPML §10.6.2).

### 디코드 경고 채널 (`b8331e7`, `feat` — additive)
- `HwpxDocument.warnings` + `DecodeWarning::UnknownEnumValue{attribute, raw, fallback}` — 미지 enum 값의 기본값 폴백은 유지하되 표면화 (applyPageType·pageNum pos/formatType·pageStartsOn·vertAlign). **속성 결측(빈 문자열) = 정상 기본값 적용이라 경고 없음** (테스트 잠금).

### 머리말 subList 기하 승격 (`382af19`, `feat!`)
- `HeaderFooter.{vert_align, text_width, text_height}` — 일반 꼬리말 실측은 `vertAlign=BOTTOM` 이라 컨테이너 기하 없이는 밴드 재생(R6)이 불가능. 인코더도 memo 공용(TOP 하드코딩) 대신 실값 방출.

### 기타
- `docs`: CLAUDE.md Tooling Gotchas 실사고 4건 (디스크 정리 우선순위·staged 완전성·zsh 함정·cwd 잔류)
- `test`: 독립 리뷰 상환 — 실물 기하(42520/4252) 왕복 단언·결측 무경고 커버리지 확장

## 검증

- smithy-hwpx 1,504+/core 포함 4크레이트 1,963+ 전부 그린 · `make ci` 통과
- 독립 리뷰 **승인** (Critical/High/Medium 0): 수집 루프 전 문단 커버·경고 다중 섹션 누적·인코더 신경로 = 기존 메커니즘 동일·다운스트림(convert/cli) 컴파일 clean·admission/reverse-delta 게이트 무영향 확증. Low 2건 즉시 상환, 2건은 설계 문서 백로그.

## Breaking

`hwpforge-core`: `BeginNum.page_starts_on`·`HeaderFooter.{vert_align,text_width,text_height}` 필드 추가 (리터럴 생성자 영향, serde 는 default 로 하위호환). `hwpforge-smithy-hwpx`: `SectionParseResult` header/footer → Vec (크레이트 내부 소비만 실측 확인). 0.x 규칙상 마이너 bump.
