### PR TITLE
feat(bindings-cli): W6 PDF 표면 — to-pdf CLI·corpus 검증·스킬 + 쪽 over-split 수정

### DIFF
--- a/.claude/skills/hwpforge/SKILL.md
+++ b/.claude/skills/hwpforge/SKILL.md
@@ -81,6 +81,9 @@ What does the user want?
 │     → to-md   (full lossy flatten, for human reading)
 │     → to-json (whole document JSON, for machine editing ONLY)
 │
+├─ Render to PDF (한컴과 같은 출력 — layout-cache replay)
+│     → to-pdf  (needs a 한컴-saved document: cacheless files are rejected)
+│
 └─ Need the JSON shape, or the list of styles
       → schema        (JSON Schema for document/section types)
       → templates list (available style presets)
@@ -174,6 +177,13 @@ hwpforge to-json doc.hwpx --section 0 --no-styles -o sec.json
 # Write back
 hwpforge patch doc.hwpx --section 0 sec.json -o doc.hwpx          # text-only
 hwpforge from-json full.json -o doc.hwpx --base doc.hwpx          # rebuild (inherit images)
+
+# Render to PDF (layout-cache replay — 한컴 재저장본만; format detected by content)
+hwpforge to-pdf doc.hwpx [-o out.pdf] [--font-dir DIR] [--discovery explicit|hancom|platform] \
+    [--degraded] [--partial-cache-reject] [--json]
+# macOS + 한컴오피스 설치 시: --discovery hancom 으로 번들 폰트 자동 발견.
+# 실무 문서는 언어축 혼합이 흔해 --degraded 권장 (경고로 표면화됨).
+# 실패는 fail-closed: cacheless → 한컴에서 열어 재저장 후 재시도.
 
 # Read out / schema / styles
 hwpforge to-md doc.hwpx -o doc.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,17 @@ jobs:
       - name: cargo +1.88 check
         # smithy-pdf 는 krilla(rust-version 1.92) 의존으로 워크스페이스 MSRV(1.88) 초과 —
         # publish=false 라 MSRV 소비자 계약이 없어 MSRV 검증에서만 제외한다 (W2 계획 §6-7).
-        run: cargo +1.88 check --workspace --all-features --exclude hwpforge-smithy-pdf
+        # bindings-cli 는 W6a 부터 smithy-pdf 를 소비 (rust-version 1.92 명시) — 1.88
+        # 레인에서 제외하고 아래 1.92 스텝이 커버한다.
+        run: >-
+          cargo +1.88 check --workspace --all-features
+          --exclude hwpforge-smithy-pdf
+          --exclude hwpforge-bindings-cli
+      - name: Install PDF MSRV toolchain (1.92)
+        run: rustup toolchain install 1.92 --profile minimal
+      - name: cargo +1.92 check (PDF 소비 크레이트)
+        # smithy-pdf + 소비자(bindings-cli)의 실질 MSRV 검증 레인.
+        run: cargo +1.92 check --all-features -p hwpforge-smithy-pdf -p hwpforge-bindings-cli
 
   workflow-compat:
     name: "Standalone › Workflow Lint"

--- a/crates/hwpforge-bindings-cli/Cargo.toml
+++ b/crates/hwpforge-bindings-cli/Cargo.toml
@@ -7,7 +7,8 @@ license.workspace = true
 publish = false
 readme.workspace = true
 repository.workspace = true
-rust-version.workspace = true
+# smithy-pdf(krilla) 의존으로 워크스페이스 MSRV(1.88) 초과 — ci.yml MSRV 레인 분리.
+rust-version = "1.92"
 description = "Hammer — AI-first CLI for HwpForge document generation and editing"
 
 [[bin]]
@@ -23,6 +24,7 @@ hwpforge-foundation = { path = "../hwpforge-foundation" }
 hwpforge-smithy-hwp5 = { path = "../hwpforge-smithy-hwp5" }
 hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", features = ["schemars"] }
 hwpforge-smithy-md = { path = "../hwpforge-smithy-md" }
+hwpforge-smithy-pdf = { path = "../hwpforge-smithy-pdf" }
 quick-xml = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/crates/hwpforge-bindings-cli/src/commands/mod.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/mod.rs
@@ -17,3 +17,4 @@ pub mod structural;
 pub mod templates;
 pub mod to_json;
 pub mod to_md;
+pub mod to_pdf;

--- a/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
@@ -355,3 +355,108 @@ pub fn run(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_format_by_content() {
+        assert_eq!(detect_format(&CFB_MAGIC), Some("hwp5"));
+        assert_eq!(detect_format(b"PK\x03\x04zipzip"), Some("hwpx"));
+        assert_eq!(detect_format(b"not a container"), None);
+        assert_eq!(detect_format(b""), None);
+    }
+
+    #[test]
+    fn convert_warning_dto_maps_every_variant() {
+        let cases = [
+            (Hwp5Warning::UnsupportedTag { tag_id: 0x5B, offset: 12 }, "UNSUPPORTED_TAG"),
+            (Hwp5Warning::SkippedStream { name: "Scripts".into() }, "SKIPPED_STREAM"),
+            (
+                Hwp5Warning::DroppedControl { control: "ole_object", reason: "x".into() },
+                "DROPPED_CONTROL",
+            ),
+            (
+                Hwp5Warning::ProjectionFallback { subject: "s", reason: "r".into() },
+                "PROJECTION_FALLBACK",
+            ),
+            (Hwp5Warning::ParserFallback { subject: "s", reason: "r".into() }, "PARSER_FALLBACK"),
+        ];
+        for (w, code) in cases {
+            let dto = convert_warning_dto(&w);
+            assert_eq!(dto.stage, "convert");
+            assert_eq!(dto.code, code);
+        }
+    }
+
+    #[test]
+    fn decode_warning_dto_carries_attribute_location() {
+        let dto = decode_warning_dto(&DecodeWarning::UnknownEnumValue {
+            attribute: "hp:header@applyPageType",
+            raw: "WEIRD".into(),
+            fallback: "BOTH",
+        });
+        assert_eq!((dto.stage, dto.code), ("decode", "UNKNOWN_ENUM_VALUE"));
+        assert_eq!(dto.location.as_deref(), Some("hp:header@applyPageType"));
+    }
+
+    #[test]
+    fn render_warning_dto_maps_every_variant() {
+        use hwpforge_smithy_pdf::font::FaceStyle;
+        let loc = || "s0/p1/l2".to_string();
+        let cases: Vec<(PdfWarning, &str)> = vec![
+            (PdfWarning::ParagraphSkipped { location: loc() }, "PARAGRAPH_SKIPPED"),
+            (
+                PdfWarning::FontStyleFallback {
+                    face: "f".into(),
+                    requested: FaceStyle::Bold,
+                    location: loc(),
+                },
+                "FONT_STYLE_FALLBACK",
+            ),
+            (
+                PdfWarning::FontAxisFallback { fonts: vec!["a".into()], location: loc() },
+                "FONT_AXIS_FALLBACK",
+            ),
+            (
+                PdfWarning::FontEmbedPreviewPrint {
+                    face: "f".into(),
+                    path: "/x".into(),
+                    fingerprint: "00".into(),
+                },
+                "FONT_EMBED_PREVIEW_PRINT",
+            ),
+            (PdfWarning::AlignmentApproximated { location: loc() }, "ALIGNMENT_APPROXIMATED"),
+            (PdfWarning::NonTextRunDropped { location: loc() }, "NON_TEXT_RUN_DROPPED"),
+            (PdfWarning::TablePaginationComputed { location: loc() }, "TABLE_PAGINATION_COMPUTED"),
+            (PdfWarning::TableDeficitDistributed { location: loc() }, "TABLE_DEFICIT_DISTRIBUTED"),
+            (
+                PdfWarning::UnsupportedTableStyle { location: loc(), what: "cell fill" },
+                "UNSUPPORTED_TABLE_STYLE",
+            ),
+            (PdfWarning::BandOverflow { kind: "header", location: loc() }, "BAND_OVERFLOW"),
+            (PdfWarning::PageStartsOnFallback { section: 0 }, "PAGE_STARTS_ON_FALLBACK"),
+            (PdfWarning::VertAlignFallback { location: loc() }, "VERT_ALIGN_FALLBACK"),
+            (PdfWarning::PageNumberSkipped { section: 0, what: "position" }, "PAGE_NUMBER_SKIPPED"),
+            (PdfWarning::PageNumberStyleFallback { section: 0 }, "PAGE_NUMBER_STYLE_FALLBACK"),
+            (
+                PdfWarning::MissingGlyphs { face: "f".into(), count: 2, location: loc() },
+                "MISSING_GLYPHS",
+            ),
+            (PdfWarning::LineOverflow { location: loc(), excess: 190 }, "LINE_OVERFLOW"),
+        ];
+        for (w, code) in &cases {
+            let dto = render_warning_dto(w);
+            assert_eq!(dto.stage, "render");
+            assert_eq!(&dto.code, code, "{w:?}");
+        }
+    }
+
+    #[test]
+    fn parse_discovery_accepts_documented_modes() {
+        assert!(matches!(parse_discovery("explicit", false), FontDiscovery::ExplicitOnly));
+        assert!(matches!(parse_discovery("hancom", false), FontDiscovery::HancomBundle));
+        assert!(matches!(parse_discovery("platform", false), FontDiscovery::Platform));
+    }
+}

--- a/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
@@ -1,0 +1,338 @@
+//! Render HWPX/HWP5 to PDF (layout-cache replay — W6a).
+//!
+//! Format dispatch is **content sniffing**, not extension: this repo's own
+//! corpus study found 79 HWP5 binaries shipped with `.hwpx` extensions.
+//! The extension is only a hint — a mismatch is surfaced as a warning.
+//!
+//! Warnings keep their provenance across the three pipeline stages
+//! (`convert` → `decode` → `render`) as structured DTOs — flattening them
+//! would hide HWP5 conversion loss behind a green render.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use hwpforge_convert::{hwp5_to_hwpx_bytes_with_options, ConvertOptions};
+use hwpforge_smithy_hwp5::Hwp5Warning;
+use hwpforge_smithy_hwpx::{DecodeWarning, HwpxDecoder};
+use hwpforge_smithy_pdf::font::FontDiscovery;
+use hwpforge_smithy_pdf::{
+    render_document, FontFallbackMode, PartialCachePolicy, PdfInput, PdfOptions, PdfWarning,
+};
+
+use crate::error::{check_file_size, CliError};
+
+/// OLE2/CFB magic — HWP5 컨테이너.
+const CFB_MAGIC: [u8; 8] = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
+
+#[derive(Serialize)]
+struct WarningDto {
+    /// 발생 단계: `convert`(HWP5→HWPX) | `decode`(HWPX 해석) | `render`(PDF).
+    stage: &'static str,
+    /// 안정 코드 (variant 유래 — 스크립트 필터링용).
+    code: &'static str,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    location: Option<String>,
+}
+
+#[derive(Serialize)]
+struct WarningCounts {
+    convert: usize,
+    decode: usize,
+    render: usize,
+}
+
+#[derive(Serialize)]
+struct ToPdfResult {
+    status: &'static str,
+    input: String,
+    output: String,
+    detected_format: &'static str,
+    size_bytes: u64,
+    warnings: Vec<WarningDto>,
+    warning_counts: WarningCounts,
+}
+
+/// 콘텐츠 스니핑 — CFB=HWP5, ZIP=HWPX 후보 (mimetype 은 디코더가 검증).
+fn detect_format(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&CFB_MAGIC) {
+        return Some("hwp5");
+    }
+    if bytes.starts_with(b"PK") {
+        return Some("hwpx");
+    }
+    None
+}
+
+fn convert_warning_dto(w: &Hwp5Warning) -> WarningDto {
+    let (code, message, location) = match w {
+        Hwp5Warning::UnsupportedTag { tag_id, offset } => (
+            "UNSUPPORTED_TAG",
+            format!("unsupported record tag 0x{tag_id:02X}"),
+            Some(format!("offset {offset}")),
+        ),
+        Hwp5Warning::SkippedStream { name } => {
+            ("SKIPPED_STREAM", format!("stream skipped: {name}"), None)
+        }
+        Hwp5Warning::DroppedControl { control, reason } => {
+            ("DROPPED_CONTROL", format!("{control}: {reason}"), None)
+        }
+        Hwp5Warning::ProjectionFallback { subject, reason } => {
+            ("PROJECTION_FALLBACK", format!("{subject}: {reason}"), None)
+        }
+        Hwp5Warning::ParserFallback { subject, reason } => {
+            ("PARSER_FALLBACK", format!("{subject}: {reason}"), None)
+        }
+        other => ("OTHER", format!("{other:?}"), None),
+    };
+    WarningDto { stage: "convert", code, message, location }
+}
+
+fn decode_warning_dto(w: &DecodeWarning) -> WarningDto {
+    let (code, message, location) = match w {
+        DecodeWarning::UnknownEnumValue { attribute, raw, fallback } => (
+            "UNKNOWN_ENUM_VALUE",
+            format!("\"{raw}\" unknown — fell back to {fallback}"),
+            Some((*attribute).to_string()),
+        ),
+        other => ("OTHER", format!("{other:?}"), None),
+    };
+    WarningDto { stage: "decode", code, message, location }
+}
+
+fn render_warning_dto(w: &PdfWarning) -> WarningDto {
+    let (code, message, location) = match w {
+        PdfWarning::ParagraphSkipped { location } => (
+            "PARAGRAPH_SKIPPED",
+            "paragraph without layout cache skipped".to_string(),
+            Some(location.clone()),
+        ),
+        PdfWarning::FontStyleFallback { face, requested, location } => (
+            "FONT_STYLE_FALLBACK",
+            format!("{face:?} has no {requested:?} face — rendered regular"),
+            Some(location.clone()),
+        ),
+        PdfWarning::FontAxisFallback { fonts, location } => (
+            "FONT_AXIS_FALLBACK",
+            format!("per-language axis fonts {fonts:?} — rendered with hangul axis"),
+            Some(location.clone()),
+        ),
+        PdfWarning::FontEmbedPreviewPrint { face, path, .. } => (
+            "FONT_EMBED_PREVIEW_PRINT",
+            format!("{face:?} ({}) is Preview & Print licensed", path.display()),
+            None,
+        ),
+        PdfWarning::AlignmentApproximated { location } => (
+            "ALIGNMENT_APPROXIMATED",
+            "distributed alignment approximated".to_string(),
+            Some(location.clone()),
+        ),
+        PdfWarning::NonTextRunDropped { location } => (
+            "NON_TEXT_RUN_DROPPED",
+            "non-text run (control/image) dropped".to_string(),
+            Some(location.clone()),
+        ),
+        PdfWarning::TablePaginationComputed { location } => (
+            "TABLE_PAGINATION_COMPUTED",
+            "split-table page boundary computed (cache has no signal)".to_string(),
+            Some(location.clone()),
+        ),
+        PdfWarning::TableDeficitDistributed { location } => (
+            "TABLE_DEFICIT_DISTRIBUTED",
+            "merged-cell height deficit redistributed".to_string(),
+            Some(location.clone()),
+        ),
+        PdfWarning::UnsupportedTableStyle { location, what } => (
+            "UNSUPPORTED_TABLE_STYLE",
+            format!("unsupported table style dropped: {what}"),
+            Some(location.clone()),
+        ),
+        PdfWarning::BandOverflow { kind, location } => (
+            "BAND_OVERFLOW",
+            format!("{kind} exceeds its band — replayed unclipped (Hancom behavior)"),
+            Some(location.clone()),
+        ),
+        PdfWarning::PageStartsOnFallback { section } => (
+            "PAGE_STARTS_ON_FALLBACK",
+            "pageStartsOn != BOTH is unmeasured — rendered as BOTH".to_string(),
+            Some(format!("s{section}")),
+        ),
+        PdfWarning::VertAlignFallback { location } => (
+            "VERT_ALIGN_FALLBACK",
+            "header/footer vertAlign != TOP is unmeasured — rendered as TOP".to_string(),
+            Some(location.clone()),
+        ),
+        PdfWarning::PageNumberSkipped { section, what } => (
+            "PAGE_NUMBER_SKIPPED",
+            format!("page number skipped — unmeasured {what}"),
+            Some(format!("s{section}")),
+        ),
+        PdfWarning::PageNumberStyleFallback { section } => (
+            "PAGE_NUMBER_STYLE_FALLBACK",
+            "\"쪽 번호\" CHAR style absent — fell back to default char shape".to_string(),
+            Some(format!("s{section}")),
+        ),
+        other => ("OTHER", format!("{other:?}"), None),
+    };
+    WarningDto { stage: "render", code, message, location }
+}
+
+fn parse_discovery(s: &str, json_mode: bool) -> FontDiscovery {
+    match s {
+        "explicit" => FontDiscovery::ExplicitOnly,
+        "hancom" => FontDiscovery::HancomBundle,
+        "platform" => FontDiscovery::Platform,
+        other => CliError::new(
+            "INVALID_DISCOVERY",
+            format!("unknown discovery mode '{other}' (expected explicit|hancom|platform)"),
+        )
+        .exit(json_mode, 2),
+    }
+}
+
+/// Run the to-pdf command.
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    input: &Path,
+    output: Option<&Path>,
+    font_dirs: &[PathBuf],
+    discovery: &str,
+    degraded: bool,
+    partial_cache_reject: bool,
+    json_mode: bool,
+) {
+    check_file_size(input, json_mode);
+    let bytes = std::fs::read(input).unwrap_or_else(|err| {
+        CliError::new("FILE_READ_FAILED", format!("Cannot read '{}': {err}", input.display()))
+            .exit(json_mode, 1)
+    });
+
+    let Some(detected) = detect_format(&bytes) else {
+        CliError::new(
+            "UNRECOGNIZED_FORMAT",
+            format!("'{}' is neither an OLE2 (HWP5) nor a ZIP (HWPX) container", input.display()),
+        )
+        .with_hint("to-pdf detects the format by content — the extension is only a hint")
+        .exit(json_mode, 2)
+    };
+
+    let mut warnings: Vec<WarningDto> = Vec::new();
+    // 확장자는 힌트 — 실물과 다르면 경고 (corpus 실측: .hwpx 탈 HWP5 79건).
+    let ext = input.extension().and_then(|e| e.to_str()).map(str::to_ascii_lowercase);
+    let ext_implies = match ext.as_deref() {
+        Some("hwp") => Some("hwp5"),
+        Some("hwpx") => Some("hwpx"),
+        _ => None,
+    };
+    if let Some(implied) = ext_implies {
+        if implied != detected {
+            warnings.push(WarningDto {
+                stage: "decode",
+                code: "EXTENSION_MISMATCH",
+                message: format!("extension implies {implied} but content is {detected}"),
+                location: None,
+            });
+        }
+    }
+
+    // HWP5 → HWPX (조판 캐시 carry — 렌더 재료).
+    let hwpx_bytes = if detected == "hwp5" {
+        let (converted, convert_warnings) = hwp5_to_hwpx_bytes_with_options(
+            &bytes,
+            ConvertOptions::default().with_carry_layout_cache(true),
+        )
+        .unwrap_or_else(|err| {
+            CliError::new(
+                "HWP5_CONVERT_FAILED",
+                format!("Cannot convert '{}' to HWPX: {err}", input.display()),
+            )
+            .exit(json_mode, 2)
+        });
+        warnings.extend(convert_warnings.iter().map(convert_warning_dto));
+        converted
+    } else {
+        bytes
+    };
+
+    let decoded = HwpxDecoder::decode(&hwpx_bytes).unwrap_or_else(|err| {
+        CliError::new("HWPX_DECODE_FAILED", format!("Cannot decode '{}': {err}", input.display()))
+            .exit(json_mode, 2)
+    });
+    warnings.extend(decoded.warnings.iter().map(decode_warning_dto));
+
+    let validated = decoded.document.validate().unwrap_or_else(|err| {
+        CliError::new("VALIDATION_FAILED", format!("Document validation failed: {err}"))
+            .exit(json_mode, 2)
+    });
+
+    let mut options = PdfOptions::default();
+    options.font_dirs = font_dirs.to_vec();
+    options.discovery = parse_discovery(discovery, json_mode);
+    options.font_fallback =
+        if degraded { FontFallbackMode::Degraded } else { FontFallbackMode::Fatal };
+    options.partial_cache = if partial_cache_reject {
+        PartialCachePolicy::Reject
+    } else {
+        PartialCachePolicy::WarnAndSkip
+    };
+
+    let rendered =
+        render_document(&PdfInput { document: &validated, styles: &decoded.style_store }, &options)
+            .unwrap_or_else(|err| {
+                CliError::new("PDF_RENDER_FAILED", format!("Cannot render PDF: {err}"))
+                    .with_hint(
+                        "cacheless documents need a Hancom re-save; font errors may need \
+                         --font-dir/--discovery or --degraded",
+                    )
+                    .exit(json_mode, 2)
+            });
+    warnings.extend(rendered.warnings.iter().map(render_warning_dto));
+
+    // 산출 경로: 미지정 = 입력의 .pdf 교체. 쓰기는 원자적 (tmp → rename).
+    let out_path = output.map_or_else(|| input.with_extension("pdf"), Path::to_path_buf);
+    let tmp_path = out_path.with_extension("pdf.tmp");
+    std::fs::write(&tmp_path, &rendered.bytes)
+        .and_then(|()| std::fs::rename(&tmp_path, &out_path))
+        .unwrap_or_else(|err| {
+            CliError::new(
+                "FILE_WRITE_FAILED",
+                format!("Cannot write '{}': {err}", out_path.display()),
+            )
+            .exit(json_mode, 1)
+        });
+
+    let counts = WarningCounts {
+        convert: warnings.iter().filter(|w| w.stage == "convert").count(),
+        decode: warnings.iter().filter(|w| w.stage == "decode").count(),
+        render: warnings.iter().filter(|w| w.stage == "render").count(),
+    };
+    let result = ToPdfResult {
+        status: "ok",
+        input: input.display().to_string(),
+        output: out_path.display().to_string(),
+        detected_format: detected,
+        size_bytes: rendered.bytes.len() as u64,
+        warnings,
+        warning_counts: counts,
+    };
+    if json_mode {
+        println!("{}", serde_json::to_string(&result).unwrap());
+    } else {
+        println!(
+            "PDF written: {} ({} bytes, {} 경고 — convert {} · decode {} · render {})",
+            result.output,
+            result.size_bytes,
+            result.warnings.len(),
+            result.warning_counts.convert,
+            result.warning_counts.decode,
+            result.warning_counts.render,
+        );
+        for w in &result.warnings {
+            match &w.location {
+                Some(loc) => eprintln!("[{}] {} ({loc}): {}", w.stage, w.code, w.message),
+                None => eprintln!("[{}] {}: {}", w.stage, w.code, w.message),
+            }
+        }
+    }
+}

--- a/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
@@ -27,7 +27,8 @@ const CFB_MAGIC: [u8; 8] = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
 
 #[derive(Serialize)]
 struct WarningDto {
-    /// 발생 단계: `convert`(HWP5→HWPX) | `decode`(HWPX 해석) | `render`(PDF).
+    /// 발생 단계: `input`(디스패치) | `convert`(HWP5→HWPX) | `decode`(HWPX 해석)
+    /// | `render`(PDF).
     stage: &'static str,
     /// 안정 코드 (variant 유래 — 스크립트 필터링용).
     code: &'static str,
@@ -38,6 +39,7 @@ struct WarningDto {
 
 #[derive(Serialize)]
 struct WarningCounts {
+    input: usize,
     convert: usize,
     decode: usize,
     render: usize,
@@ -202,6 +204,8 @@ pub fn run(
     partial_cache_reject: bool,
     json_mode: bool,
 ) {
+    // 플래그 오류는 파이프라인 진입 전에 (독립 리뷰 L1 — .hwp 변환 후 exit 방지).
+    let discovery = parse_discovery(discovery, json_mode);
     check_file_size(input, json_mode);
     let bytes = std::fs::read(input).unwrap_or_else(|err| {
         CliError::new("FILE_READ_FAILED", format!("Cannot read '{}': {err}", input.display()))
@@ -228,7 +232,7 @@ pub fn run(
     if let Some(implied) = ext_implies {
         if implied != detected {
             warnings.push(WarningDto {
-                stage: "decode",
+                stage: "input",
                 code: "EXTENSION_MISMATCH",
                 message: format!("extension implies {implied} but content is {detected}"),
                 location: None,
@@ -268,7 +272,7 @@ pub fn run(
 
     let mut options = PdfOptions::default();
     options.font_dirs = font_dirs.to_vec();
-    options.discovery = parse_discovery(discovery, json_mode);
+    options.discovery = discovery;
     options.font_fallback =
         if degraded { FontFallbackMode::Degraded } else { FontFallbackMode::Fatal };
     options.partial_cache = if partial_cache_reject {
@@ -289,12 +293,14 @@ pub fn run(
             });
     warnings.extend(rendered.warnings.iter().map(render_warning_dto));
 
-    // 산출 경로: 미지정 = 입력의 .pdf 교체. 쓰기는 원자적 (tmp → rename).
+    // 산출 경로: 미지정 = 입력의 .pdf 교체. 쓰기는 원자적 (tmp → rename) —
+    // tmp 이름에 pid 를 넣어 동시 실행 충돌을 피하고, 실패 시 잔여물을 정리한다.
     let out_path = output.map_or_else(|| input.with_extension("pdf"), Path::to_path_buf);
-    let tmp_path = out_path.with_extension("pdf.tmp");
+    let tmp_path = out_path.with_extension(format!("pdf.tmp.{}", std::process::id()));
     std::fs::write(&tmp_path, &rendered.bytes)
         .and_then(|()| std::fs::rename(&tmp_path, &out_path))
         .unwrap_or_else(|err| {
+            let _ = std::fs::remove_file(&tmp_path);
             CliError::new(
                 "FILE_WRITE_FAILED",
                 format!("Cannot write '{}': {err}", out_path.display()),
@@ -303,6 +309,7 @@ pub fn run(
         });
 
     let counts = WarningCounts {
+        input: warnings.iter().filter(|w| w.stage == "input").count(),
         convert: warnings.iter().filter(|w| w.stage == "convert").count(),
         decode: warnings.iter().filter(|w| w.stage == "decode").count(),
         render: warnings.iter().filter(|w| w.stage == "render").count(),

--- a/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
@@ -175,6 +175,18 @@ fn render_warning_dto(w: &PdfWarning) -> WarningDto {
             "\"쪽 번호\" CHAR style absent — fell back to default char shape".to_string(),
             Some(format!("s{section}")),
         ),
+        PdfWarning::MissingGlyphs { face, count, location } => (
+            "MISSING_GLYPHS",
+            format!("{face:?} lacks glyphs for {count} character(s) — rendered as tofu"),
+            Some(location.clone()),
+        ),
+        PdfWarning::LineOverflow { location, excess } => (
+            "LINE_OVERFLOW",
+            format!(
+                "line exceeds its cached box by {excess} HWPUNIT (char spacing/scale not carried)"
+            ),
+            Some(location.clone()),
+        ),
         other => ("OTHER", format!("{other:?}"), None),
     };
     WarningDto { stage: "render", code, message, location }

--- a/crates/hwpforge-bindings-cli/src/main.rs
+++ b/crates/hwpforge-bindings-cli/src/main.rs
@@ -69,6 +69,32 @@ enum Commands {
         output: PathBuf,
     },
 
+    /// Render a document (HWPX or HWP5) to PDF via layout-cache replay.
+    ToPdf {
+        /// Input document — format is detected by content, not extension.
+        input: PathBuf,
+
+        /// Output PDF path (default: input path with .pdf extension).
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Font directory to search (repeatable).
+        #[arg(long = "font-dir")]
+        font_dirs: Vec<PathBuf>,
+
+        /// Font auto-discovery: explicit (deterministic, default) | hancom | platform.
+        #[arg(long, default_value = "explicit")]
+        discovery: String,
+
+        /// Degrade missing style/axis fonts to regular with warnings.
+        #[arg(long)]
+        degraded: bool,
+
+        /// Reject documents with any cache-missing paragraph (default: warn and skip).
+        #[arg(long = "partial-cache-reject")]
+        partial_cache_reject: bool,
+    },
+
     /// Convert Markdown to HWPX.
     Convert {
         /// Input markdown file (use '-' for stdin).
@@ -399,6 +425,17 @@ fn main() {
         }
         Commands::ConvertHwp5 { input, output } => {
             commands::convert_hwp5::run(&input, &output, cli.json);
+        }
+        Commands::ToPdf { input, output, font_dirs, discovery, degraded, partial_cache_reject } => {
+            commands::to_pdf::run(
+                &input,
+                output.as_deref(),
+                &font_dirs,
+                &discovery,
+                degraded,
+                partial_cache_reject,
+                cli.json,
+            );
         }
         Commands::Convert { input, output, preset } => {
             commands::convert::run(&input, &output, &preset, cli.json);

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -4541,6 +4541,7 @@ fn hancom_ttf_dir() -> Option<PathBuf> {
 }
 
 #[test]
+#[ignore = "requires Hancom TTF bundle (macOS) — run with --run-ignored all"]
 fn to_pdf_renders_hwpx_fixture() {
     if hancom_ttf_dir().is_none() {
         return;
@@ -4564,6 +4565,7 @@ fn to_pdf_renders_hwpx_fixture() {
 }
 
 #[test]
+#[ignore = "requires Hancom TTF bundle (macOS) — run with --run-ignored all"]
 fn to_pdf_sniffs_content_over_extension() {
     // corpus 실측(.hwpx 탈 HWP5 79건)의 역방향 재현: HWPX 를 .hwp 로 위장 —
     // 확장자가 아니라 콘텐츠로 라우팅하고 불일치를 경고한다.

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -4530,3 +4530,86 @@ fn stamp_v2_uncovered_cell_and_unknown_field_rejected() {
     assert_eq!(code, 1);
     assert_eq!(value["code"], "INVALID_STAMP_MAP");
 }
+
+// ─── W6a: to-pdf (조판 캐시 재생 렌더) ───
+
+/// 한컴 폰트 번들 (fixture-optional 관례 — CI 에는 없음).
+fn hancom_ttf_dir() -> Option<PathBuf> {
+    let dir =
+        PathBuf::from("/Applications/Hancom Office HWP.app/Contents/Resources/Hnc/Shared/TTF");
+    dir.exists().then_some(dir)
+}
+
+#[test]
+fn to_pdf_renders_hwpx_fixture() {
+    if hancom_ttf_dir().is_none() {
+        return;
+    }
+    let dir = test_tmp();
+    let out = dir.join("pagenum.pdf");
+    let (value, _stderr, code) = run_json(&[
+        "to-pdf",
+        fixture("pdf-rules/rules-pagenum.hwpx").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--discovery",
+        "hancom",
+    ]);
+    assert_eq!(code, 0, "{value}");
+    assert_eq!(value["status"], "ok");
+    assert_eq!(value["detected_format"], "hwpx");
+    assert_eq!(value["warning_counts"]["render"], 0);
+    let bytes = std::fs::read(&out).expect("output pdf");
+    assert!(bytes.starts_with(b"%PDF-"), "PDF 헤더");
+}
+
+#[test]
+fn to_pdf_sniffs_content_over_extension() {
+    // corpus 실측(.hwpx 탈 HWP5 79건)의 역방향 재현: HWPX 를 .hwp 로 위장 —
+    // 확장자가 아니라 콘텐츠로 라우팅하고 불일치를 경고한다.
+    if hancom_ttf_dir().is_none() {
+        return;
+    }
+    let dir = test_tmp();
+    let misnamed = dir.join("misnamed.hwp");
+    std::fs::copy(fixture("pdf-rules/rules-headerfooter.hwpx"), &misnamed).expect("copy");
+    let out = dir.join("misnamed.pdf");
+    let (value, _stderr, code) = run_json(&[
+        "to-pdf",
+        misnamed.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--discovery",
+        "hancom",
+    ]);
+    assert_eq!(code, 0, "{value}");
+    assert_eq!(value["detected_format"], "hwpx");
+    let mismatch = value["warnings"]
+        .as_array()
+        .expect("warnings array")
+        .iter()
+        .any(|w| w["code"] == "EXTENSION_MISMATCH");
+    assert!(mismatch, "{value}");
+}
+
+#[test]
+fn to_pdf_rejects_unrecognized_container() {
+    let dir = test_tmp();
+    let garbage = dir.join("garbage.hwpx");
+    std::fs::write(&garbage, b"not a container at all").expect("write");
+    let (value, _stderr, code) = run_json(&["to-pdf", garbage.to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert_eq!(value["code"], "UNRECOGNIZED_FORMAT");
+}
+
+#[test]
+fn to_pdf_hwp5_path_fails_closed_on_unnormalized_textpos() {
+    // 실측 잠금 (W6a): convert 의 HWP5 텍스트 위치 정규화 미완으로 carry 캐시가
+    // admission(textpos 정합)에서 거부된다 — 조용한 오출력 대신 깨끗한 에러.
+    // convert 정규화가 개선되면 이 게이트를 성공 게이트로 갱신할 것.
+    let (value, _stderr, code) =
+        run_json(&["to-pdf", fixture("pdf-rules/rules-header-multi.hwp").to_str().unwrap()]);
+    assert_eq!(code, 2, "{value}");
+    assert_eq!(value["status"], "error");
+    assert_eq!(value["code"], "PDF_RENDER_FAILED");
+}

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -4615,3 +4615,45 @@ fn to_pdf_hwp5_path_fails_closed_on_unnormalized_textpos() {
     assert_eq!(value["status"], "error");
     assert_eq!(value["code"], "PDF_RENDER_FAILED");
 }
+
+#[test]
+fn to_pdf_rejects_cacheless_hwpx_fail_closed() {
+    // 폰트 무관 CI 경로: 순수 생성 HWPX(캐시 없음) → 스니핑·디코드·검증까지
+    // 통과 후 렌더에서 fail-closed (한컴 재저장 안내 힌트).
+    let dir = test_tmp();
+    let md = dir.join("doc.md");
+    std::fs::write(&md, "# 제목\n\n본문 문단.\n").expect("write md");
+    let hwpx = dir.join("doc.hwpx");
+    let (_v, _s, code) = run_json(&["convert", md.to_str().unwrap(), "-o", hwpx.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let (value, _stderr, code) = run_json(&["to-pdf", hwpx.to_str().unwrap()]);
+    assert_eq!(code, 2, "{value}");
+    assert_eq!(value["code"], "PDF_RENDER_FAILED");
+}
+
+#[test]
+fn to_pdf_extension_mismatch_detected_without_fonts() {
+    // 위장 확장자(.hwp 탈 HWPX)도 폰트 없이 스니핑 라우팅까지는 CI 에서 검증
+    // 가능 — 이후 캐시 결손 fail-closed 는 위 게이트와 동일.
+    let dir = test_tmp();
+    let md = dir.join("doc.md");
+    std::fs::write(&md, "# 제목\n").expect("write md");
+    let hwpx = dir.join("doc.hwpx");
+    let (_v, _s, code) = run_json(&["convert", md.to_str().unwrap(), "-o", hwpx.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let misnamed = dir.join("doc-misnamed.hwp");
+    std::fs::copy(&hwpx, &misnamed).expect("copy");
+    let (value, _stderr, code) = run_json(&["to-pdf", misnamed.to_str().unwrap()]);
+    assert_eq!(code, 2, "{value}"); // cacheless — 렌더 거부는 동일
+    assert_eq!(value["code"], "PDF_RENDER_FAILED");
+}
+
+#[test]
+fn to_pdf_human_mode_error_output() {
+    let dir = test_tmp();
+    let garbage = dir.join("garbage.bin");
+    std::fs::write(&garbage, b"???").expect("write");
+    let (_stdout, stderr, code) = run(&["to-pdf", garbage.to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert!(stderr.contains("UNRECOGNIZED_FORMAT"), "{stderr}");
+}

--- a/crates/hwpforge-smithy-pdf/src/font/mod.rs
+++ b/crates/hwpforge-smithy-pdf/src/font/mod.rs
@@ -375,18 +375,21 @@ impl FontResolver {
                 .map(|c| c.tier)
                 .chain(contras.iter().map(|(t, _)| *t))
                 .min()
-                .expect("key exists in at least one map");
+                .ok_or_else(|| PdfError::InternalInvariant {
+                    detail: format!("font key {key:?} in neither candidate nor contradiction map"),
+                })?;
             if let Some((_, detail)) = contras.iter().find(|(t, _)| *t == min_tier) {
                 ambiguous.insert(key, detail.clone());
                 continue;
             }
             let target = key.1.target_weight();
             let tier_cands: Vec<&Candidate> = cands.iter().filter(|c| c.tier == min_tier).collect();
-            let best = tier_cands
-                .iter()
-                .map(|c| (c.weight - target).abs())
-                .min()
-                .expect("non-empty bucket");
+            let best =
+                tier_cands.iter().map(|c| (c.weight - target).abs()).min().ok_or_else(|| {
+                    PdfError::InternalInvariant {
+                        detail: format!("font key {key:?}: empty candidate bucket at min tier"),
+                    }
+                })?;
             // 동일 실물(같은 fingerprint + face 인덱스)의 중복 배치는 충돌이
             // 아니다 — 먼저 스캔된 경로가 canonical 로 남는다.
             let mut distinct: Vec<&Candidate> = Vec::new();

--- a/crates/hwpforge-smithy-pdf/src/lib.rs
+++ b/crates/hwpforge-smithy-pdf/src/lib.rs
@@ -222,6 +222,24 @@ pub enum PdfWarning {
         /// 섹션 인덱스.
         section: usize,
     },
+    /// 폰트에 없는 글리프(notdef)를 tofu(□)로 렌더함 (Degraded 옵트인 —
+    /// 기본 Fatal 모드는 [`PdfError::GlyphsUnavailable`]).
+    MissingGlyphs {
+        /// face 이름.
+        face: String,
+        /// notdef 로 찍힌 문자 수.
+        count: usize,
+        /// 문서 내 위치.
+        location: String,
+    },
+    /// 줄 자연폭이 캐시 줄 상자를 초과 — 자간/장평 미carry 갭의 표면화
+    /// (줄 시작은 캐시-정확하나 우측으로 넘칠 수 있음 — corpus 실측 §5f).
+    LineOverflow {
+        /// 문서 내 위치.
+        location: String,
+        /// 초과 폭 (HWPUNIT).
+        excess: i32,
+    },
 }
 
 /// 렌더 실패 (fail-closed — 출력 바이트 없음).
@@ -261,6 +279,20 @@ pub enum PdfError {
     InternalInvariant {
         /// 위반 상세 (위치 포함).
         detail: String,
+    },
+    /// 폰트에 없는 글리프(notdef) 포함 — 기본([`FontFallbackMode::Fatal`])
+    /// 모드 (조용한 tofu(□) 출력 금지 — Degraded 옵트인은 경고 후 렌더).
+    #[error(
+        "font {face:?} lacks glyphs for {count} character(s) at {location} \
+         (would render as tofu — opt in to FontFallbackMode::Degraded to render with a warning)"
+    )]
+    GlyphsUnavailable {
+        /// face 이름.
+        face: String,
+        /// notdef 문자 수.
+        count: usize,
+        /// 문서 내 위치.
+        location: String,
     },
     /// 같은 쪽에 머리말/꼬리말 후보가 2개 이상 매치 (BOTH+ODD 중복 등) —
     /// 한컴 우선순위 미실측이라 첫 항목 선택 대신 거부한다 (게이트2 H2).

--- a/crates/hwpforge-smithy-pdf/src/lib.rs
+++ b/crates/hwpforge-smithy-pdf/src/lib.rs
@@ -15,13 +15,15 @@
 //! backend/  krilla PDF 쓰기
 //! ```
 //!
-//! # 웨이브 스테이징
+//! # 지원 범위 (W2~W5 출하 기준)
 //!
-//! - **W2a (현재)**: Paint IR 타입 계약 + regular exact-face 폰트 resolver + 옵션/에러 표면
-//! - W2b: 셰이핑(공백 0.5em)·정렬 배분(R2) — W2c: 배치소스·admission — W2d: krilla 백엔드
-//!   + `render_document` 공개 (미구현 표면을 미리 노출하지 않는다)
-//! - W2 스코프: **regular 텍스트 전용** — 표 포함 문서 거부(다쪽 표 page-ordinal 미보장),
-//!   bold/italic run 경고, 머리말/꼬리말/쪽번호(W5)·폰트 스타일 선택/라이선스(W4) 제외
+//! - 텍스트: 셰이핑(공백 0.5em)·정렬 배분(R2)·bold/italic face 선택·언어축 검사·
+//!   임베드 라이선스 게이트(fsType fail-closed)
+//! - 표: 열폭/행높이(R1)·쪽걸침 분할·제목행 반복·셀 배경/괘선
+//! - 머리말/꼬리말: 밴드-상대 캐시 재생(R6) · ODD/EVEN parity · 무클립 overflow
+//! - 쪽번호: BOTTOM_CENTER+DIGIT 합성 (전용 "쪽 번호" 스타일 출처)
+//! - 미지원 (경고 or fail-closed 거부): 이미지·GSO 도형·각주/미주/메모·차트/OLE·
+//!   무캐시 문서(자체 조판 없음 — 한컴 재저장 필요)
 //!
 //! # 입력 계약
 //!
@@ -252,6 +254,13 @@ pub enum PdfError {
         kind: &'static str,
         /// 문서 내 위치.
         location: String,
+    },
+    /// 내부 불변식 위반 — 코드 결함의 안전망 (W6-α: corpus 대량 실행에서
+    /// panic 대신 문서 단위 fail-closed 오류로 표면화한다).
+    #[error("internal invariant violated: {detail}")]
+    InternalInvariant {
+        /// 위반 상세 (위치 포함).
+        detail: String,
     },
     /// 같은 쪽에 머리말/꼬리말 후보가 2개 이상 매치 (BOTH+ODD 중복 등) —
     /// 한컴 우선순위 미실측이라 첫 항목 선택 대신 거부한다 (게이트2 H2).

--- a/crates/hwpforge-smithy-pdf/src/render.rs
+++ b/crates/hwpforge-smithy-pdf/src/render.rs
@@ -246,6 +246,26 @@ pub fn render_document(input: &PdfInput<'_>, options: &PdfOptions) -> PdfResult<
                 )?;
                 let font = &table.fonts[key.0];
                 let shaped = shape_text(&font.data, font.face_index, text, size_hwpunit)?;
+                // tofu 게이트 (W6 §5f): 폰트에 없는 글리프는 조용히 □ 로
+                // 찍힌다 — 기본 fatal, Degraded 만 경고 후 렌더.
+                if shaped.missing_glyphs > 0 {
+                    match options.font_fallback {
+                        FontFallbackMode::Fatal => {
+                            return Err(PdfError::GlyphsUnavailable {
+                                face: font.face_name.clone(),
+                                count: shaped.missing_glyphs,
+                                location: line.location.clone(),
+                            });
+                        }
+                        FontFallbackMode::Degraded => {
+                            warnings.push(PdfWarning::MissingGlyphs {
+                                face: font.face_name.clone(),
+                                count: shaped.missing_glyphs,
+                                location: line.location.clone(),
+                            });
+                        }
+                    }
+                }
                 prepared.push(PreparedRun {
                     key,
                     size_hwpunit,
@@ -260,6 +280,15 @@ pub fn render_document(input: &PdfInput<'_>, options: &PdfOptions) -> PdfResult<
                 width: prepared.iter().map(|p| p.shaped.natural_width()).sum(),
                 space_count: prepared.iter().map(|p| p.shaped.space_count()).sum(),
             };
+            // 줄 넘침 표면화 (W6 §5f): 자간/장평 미carry 로 우리 자연폭이
+            // 캐시 줄 상자를 넘으면 우측으로 삐져나간다 — 무음 금지.
+            let overflow = natural.width - f64::from(line.line_box.horzsize);
+            if overflow > 10.0 {
+                warnings.push(PdfWarning::LineOverflow {
+                    location: line.location.clone(),
+                    excess: overflow.round() as i32,
+                });
+            }
             let placement = place_line(line.alignment, line.line_box, natural, line.is_last_line);
             if placement.needs_warning {
                 warnings
@@ -310,6 +339,24 @@ pub fn render_document(input: &PdfInput<'_>, options: &PdfOptions) -> PdfResult<
             )?;
             let font = &table.fonts[key.0];
             let shaped = shape_text(&font.data, font.face_index, &pn.text, size_hwpunit)?;
+            if shaped.missing_glyphs > 0 {
+                match options.font_fallback {
+                    FontFallbackMode::Fatal => {
+                        return Err(PdfError::GlyphsUnavailable {
+                            face: font.face_name.clone(),
+                            count: shaped.missing_glyphs,
+                            location: pn.location.clone(),
+                        });
+                    }
+                    FontFallbackMode::Degraded => {
+                        warnings.push(PdfWarning::MissingGlyphs {
+                            face: font.face_name.clone(),
+                            count: shaped.missing_glyphs,
+                            location: pn.location.clone(),
+                        });
+                    }
+                }
+            }
             // 가로 = 페이지 폭 중앙 − 자연폭/2 (여백 무관 — R6 실측 Δ0.08pt).
             let origin_x = (f64::from(page.width) - shaped.natural_width()) / 2.0;
             let baseline_y = f64::from(pn.anchor_bottom) - shaped.descent;

--- a/crates/hwpforge-smithy-pdf/src/source/mod.rs
+++ b/crates/hwpforge-smithy-pdf/src/source/mod.rs
@@ -521,11 +521,23 @@ fn replay_section(
                 pages,
                 warnings,
             )?;
-            pending_table_anchor =
-                Some((outcome.expected_next_v, outcome.anchor_slack, location.clone()));
-            // 분할 표는 흐름 좌표를 마지막 조각 쪽으로 옮긴다 — prev_v 를
-            // host v 로 두면 후속 문단의 (작아진) v 가 "새 쪽"으로 오판된다.
-            prev_v = Some(outcome.expected_next_v);
+            // 흐름 앵커 (over-split 수정 — 두 모델 실측):
+            // ① 글자취급(인라인) 표 = host lineseg 가 표를 담아 vertsize ≈
+            //   표높이 — 흐름 = host_v + vertsize (기재부 corpus 실측: 계산치
+            //   의 outMargin 합산이 실제 간격보다 +190HU 과대 → 다음 문단을
+            //   새 쪽으로 오판했다).
+            // ② 앵커형 표 = host lineseg 는 순수 줄높이(vertsize ≪ 표높이) —
+            //   흐름 = 계산치 host_v+om+Σ행높이+om (rules-table 실측 정확 일치).
+            // 판별 = host.vertsize ≥ 계산 총높이. 분할 표는 항상 계산 흐름
+            // (캐시가 연속 조각을 표현 못 함 — prev_v 를 host v 로 두면 후속
+            // 문단의 작아진 v 가 "새 쪽"으로 오판되는 기존 근거 유지).
+            let flow_next = if !outcome.split && host.vertsize >= outcome.total_height {
+                host_v + host.vertsize
+            } else {
+                outcome.expected_next_v
+            };
+            pending_table_anchor = Some((flow_next, outcome.anchor_slack, location.clone()));
+            prev_v = Some(flow_next);
             renderable += 1;
             continue;
         }
@@ -1233,6 +1245,56 @@ mod tests {
     }
 
     #[test]
+    fn unsplit_table_flow_uses_host_cache_not_computed_margins() {
+        // 기재부 corpus over-split 실측 (p64→p65): 미분할 표의 계산치
+        // (outMargin 합산 = host_v + om.top + 표높이 + om.bottom)가 캐시
+        // 흐름(host_v + vertsize + spacing)보다 커서, 다음 문단 v 를
+        // "새 쪽"으로 오판해 한 쪽을 둘로 쪼갰다. 흐름 앵커 = host lineseg.
+        let mut table = one_cell_cached_table();
+        table.out_margin = Some(hwpforge_core::table::TableMargin {
+            left: HwpUnit::new(283).expect("283"),
+            right: HwpUnit::new(283).expect("283"),
+            top: HwpUnit::new(283).expect("283"),
+            bottom: HwpUnit::new(283).expect("283"),
+        });
+        let mut host = table_host(table, 0);
+        // 캐시 진실: host lineseg vertsize = 표높이 1000 (corpus 실측: vertsize
+        // = sz.h, outMargin 미포함).
+        host.layout_cache.as_mut().expect("host cache").lines[0].vertsize = 1000;
+        // 다음 문단 = 캐시 흐름 그대로 (1000 + 문단 간격 376) — 계산치
+        // 1566(= om 283 + 표높이 1000 + om 283) 보다 작아 구 코드는 새 쪽으로
+        // 오판했다 (corpus p64→p65 와 동일 비율).
+        let next = para_with_cache("다음 문단", vec![seg(0, 1376)]);
+        let doc = doc_of(vec![host, next]);
+        let layout = replay(&doc, &PdfOptions::default()).expect("replay");
+        assert_eq!(layout.pages.len(), 1, "미분할 표 뒤 문단은 같은 쪽에 남아야 함");
+    }
+
+    #[test]
+    fn anchored_table_flow_uses_computed_margins() {
+        // 앵커형(비-글자취급) 표: host lineseg 는 순수 줄높이(1000 ≪ 표높이)
+        // — 흐름 = host_v + om + Σ행높이 + om (rules-table 실물 wire 정확 일치
+        // 모델). 인라인 판별(vertsize ≥ 표높이)에 걸리지 않아야 한다.
+        let tall_cell = TableCell::new(
+            vec![para_with_cache("셀", vec![seg(0, 0), seg(1, 1500)])],
+            HwpUnit::from_pt(100.0).unwrap(),
+        );
+        let mut table = Table::new(vec![TableRow::new(vec![tall_cell])])
+            .with_layout_cache(hwpforge_core::table::TableLayoutCache::new(None, true));
+        table.out_margin = Some(hwpforge_core::table::TableMargin {
+            left: HwpUnit::new(283).expect("283"),
+            right: HwpUnit::new(283).expect("283"),
+            top: HwpUnit::new(283).expect("283"),
+            bottom: HwpUnit::new(283).expect("283"),
+        });
+        // H = 셀 extent 2500 (= 1500 + 1000) → 흐름 = 0 + 283 + 2500 + 283 = 3066.
+        let next = para_with_cache("다음", vec![seg(0, 3066)]);
+        let doc = doc_of(vec![table_host(table, 0), next]);
+        let layout = replay(&doc, &PdfOptions::default()).expect("replay");
+        assert_eq!(layout.pages.len(), 1, "앵커형 계산 흐름과 캐시가 정합");
+    }
+
+    #[test]
     fn table_mixed_with_visible_text_is_rejected() {
         let mut host = para_with_cache("표 호스트", vec![seg(0, 0)]);
         host.add_run(Run::table(one_cell_cached_table(), CharShapeIndex::new(0)));
@@ -1327,7 +1389,11 @@ mod tests {
         // "C"(행1 셀) baseline = body_top + 행0 높이(1000, 최소 유지) + 850
         // — 부족분이 행0 이 아니라 행1 하단으로 갔다는 증명 (독립리뷰 M1).
         let follow = para_with_cache("후속", vec![seg(0, 5000)]);
-        let doc = doc_of(vec![table_host(make(), 0), follow]);
+        // host lineseg vertsize = 표 흐름 소비(총높이 5000) — corpus 실측 규칙
+        // (미분할 표의 흐름 앵커 = 캐시). 이전 합성값 1000 은 실물과 다른 거짓말.
+        let mut host = table_host(make(), 0);
+        host.layout_cache.as_mut().expect("host cache").lines[0].vertsize = 5000;
+        let doc = doc_of(vec![host, follow]);
         let layout = replay(&doc, &PdfOptions::default()).expect("deficit replay");
         assert!(
             layout.warnings.iter().any(|w| matches!(w, PdfWarning::TableDeficitDistributed { .. })),
@@ -1345,7 +1411,9 @@ mod tests {
         // 어긋난 앵커(6000 > 기대 5000, 쪽분할 아님) = 캐시 모순 fatal.
         // (기대보다 작은 v 는 쪽분할로 해석돼 앵커를 못 건다 — 문서화된 사각.)
         let stale = para_with_cache("후속", vec![seg(0, 6000)]);
-        let doc = doc_of(vec![table_host(make(), 0), stale]);
+        let mut host2 = table_host(make(), 0);
+        host2.layout_cache.as_mut().expect("host cache").lines[0].vertsize = 5000;
+        let doc = doc_of(vec![host2, stale]);
         let err = replay(&doc, &PdfOptions::default()).unwrap_err();
         assert!(matches!(err, PdfError::InvalidCache { .. }), "{err:?}");
     }

--- a/crates/hwpforge-smithy-pdf/src/source/mod.rs
+++ b/crates/hwpforge-smithy-pdf/src/source/mod.rs
@@ -506,7 +506,9 @@ fn replay_section(
                     RunContent::Table(t) => Some(t.as_ref()),
                     _ => None,
                 })
-                .expect("counted above");
+                .ok_or_else(|| PdfError::InternalInvariant {
+                    detail: format!("{location}: table run vanished after count"),
+                })?;
             let geom = table::SectionGeom { body_top, body_left, body_height };
             let outcome = table::replay_table(
                 input,
@@ -583,7 +585,9 @@ fn replay_section(
                 cache.lines.get(line_idx + 1).map_or(utf16.len(), |next| next.textpos as usize);
             let runs = slice_line_runs(&utf16, &run_spans, start, end);
 
-            let page = pages.last_mut().expect("page pushed at section start");
+            let page = pages.last_mut().ok_or_else(|| PdfError::InternalInvariant {
+                detail: "section replay has no current page".to_string(),
+            })?;
             page.lines.push(LaidLine {
                 location: format!("{location}/l{line_idx}"),
                 runs,

--- a/crates/hwpforge-smithy-pdf/src/source/table.rs
+++ b/crates/hwpforge-smithy-pdf/src/source/table.rs
@@ -53,6 +53,14 @@ pub(crate) struct TableReplayOutcome {
     /// 단위로 어긋나므로 "마지막 조각 최소 행높이 미만의 양의 편차"만
     /// 허용하면 오류 포착력은 유지된다.
     pub anchor_slack: i32,
+    /// 쪽 경계 분할 여부 — 분할 표는 계산 페이지네이션으로만 흐름 전진 가능
+    /// (캐시가 연속 조각을 표현하지 못함).
+    pub split: bool,
+    /// 계산된 표 총높이 (Σ행높이, outMargin 미포함) — 미분할 표의 흐름 모델
+    /// 판별용: host lineseg vertsize ≥ 이 값이면 글자취급(인라인) 표라
+    /// host 줄이 흐름 소비를 담고(기재부 corpus 실측), 미만이면 앵커형이라
+    /// 계산치(`expected_next_v`)가 흐름이다 (rules-table 실측).
+    pub total_height: i32,
 }
 
 /// 표 host 문단 하나를 재생한다. 분할 시 `pages` 에 새 쪽을 만든다.
@@ -317,7 +325,12 @@ pub(crate) fn replay_table(
         .min()
         .unwrap_or(1)
         .max(1);
-    Ok(TableReplayOutcome { expected_next_v, anchor_slack })
+    Ok(TableReplayOutcome {
+        expected_next_v,
+        anchor_slack,
+        split: frags.len() > 1,
+        total_height: row_heights.iter().sum(),
+    })
 }
 
 /// 앵커 제약(`x[c+span] − x[c] = width`)으로 열 경계 오프셋을 푼다.

--- a/crates/hwpforge-smithy-pdf/src/source/table.rs
+++ b/crates/hwpforge-smithy-pdf/src/source/table.rs
@@ -307,7 +307,9 @@ pub(crate) fn replay_table(
     }
 
     // ── 앵커: 다음 문단 v 기대값 ─────────────────────────────────
-    let last = frags.last().expect("at least one fragment");
+    let last = frags.last().ok_or_else(|| PdfError::InternalInvariant {
+        detail: format!("{location}: table replay produced no fragments"),
+    })?;
     let expected_next_v = last.top_offset + (last.y1 - last.y0) + om_bottom;
     let anchor_slack = (0..row_count)
         .filter(|&ri| row_tops[ri] < last.y1 && row_tops[ri + 1] > last.y0)
@@ -359,7 +361,7 @@ fn solve_column_offsets(
             location: location.to_string(),
         });
     }
-    Ok(x.into_iter().map(|v| v.expect("checked") as i32).collect())
+    Ok(x.into_iter().flatten().map(|v| v as i32).collect())
 }
 
 fn cell_of<'t>(table: &'t Table, anchor: &GridCell) -> &'t TableCell {
@@ -383,7 +385,9 @@ fn cell_content_extent(
         let Some(cache) = para.layout_cache.as_ref().filter(|c| !c.is_empty()) else {
             return Ok(None);
         };
-        let last = cache.lines.last().expect("non-empty cache");
+        let last = cache.lines.last().ok_or_else(|| PdfError::InternalInvariant {
+            detail: format!("{location}: non-empty cache lost its last line"),
+        })?;
         let mut e = last.vertpos + last.vertsize;
         // 중첩 표 host 문단: lineseg 는 한 줄 높이만 알므로 표 흐름 소비
         // (host.v + om.top + Σ행높이 + om.bottom, R5)를 별도 가산한다.
@@ -712,7 +716,9 @@ fn emit_anchor_clipped(
         if let Some(id) = cell.border_fill_id.or(table.border_fill_id) {
             match input.styles.border_fill_face(id) {
                 Some(FillKind::Solid(color)) => {
-                    let page = pages.last_mut().expect("page exists");
+                    let page = pages.last_mut().ok_or_else(|| PdfError::InternalInvariant {
+                        detail: format!("{cell_loc}: no current page in table emit"),
+                    })?;
                     page.rects.push(LaidRect {
                         location: cell_loc.clone(),
                         x: x0,
@@ -741,7 +747,10 @@ fn emit_anchor_clipped(
                 for (line, from, to) in edges {
                     match line.kind {
                         BorderLineKind::Solid => {
-                            let page = pages.last_mut().expect("page exists");
+                            let page =
+                                pages.last_mut().ok_or_else(|| PdfError::InternalInvariant {
+                                    detail: format!("{cell_loc}: no current page in table emit"),
+                                })?;
                             page.borders.push(LaidBorder {
                                 location: cell_loc.clone(),
                                 from,
@@ -825,7 +834,9 @@ fn emit_anchor_clipped(
                 let start = seg.textpos as usize;
                 let end = cache.lines.get(li + 1).map_or(utf16.len(), |n| n.textpos as usize);
                 let runs = slice_line_runs(&utf16, &run_spans, start, end);
-                let page = pages.last_mut().expect("page exists");
+                let page = pages.last_mut().ok_or_else(|| PdfError::InternalInvariant {
+                    detail: format!("{para_loc}: no current page in table emit"),
+                })?;
                 page.lines.push(LaidLine {
                     location: format!("{para_loc}/l{li}"),
                     runs,

--- a/crates/hwpforge-smithy-pdf/src/text/shape.rs
+++ b/crates/hwpforge-smithy-pdf/src/text/shape.rs
@@ -36,6 +36,12 @@ pub struct ShapedText {
     /// W5-b 쪽번호 세로 앵커에 사용: baseline = em 하단 앵커 − descent
     /// (한컴 콘텐트 스트림 실측 — rules-pagenum §8c, 모델 오차 ≤0.16pt).
     pub descent: f64,
+    /// 폰트에 글리프가 없는(notdef, glyph_id 0) 입력 문자 수.
+    ///
+    /// 조용한 tofu(□) 방출 방지 신호 (W6 §5f — corpus 실측: 한자/특수기호가
+    /// 폴백 폰트에 없으면 무음으로 □ 가 찍혔다). 소비자가 Fatal/Degraded
+    /// 정책으로 처리한다.
+    pub missing_glyphs: usize,
 }
 
 impl ShapedText {
@@ -97,7 +103,8 @@ pub fn shape_text(
         });
     }
     let descent = f64::from(face.descender()).abs() / upem * size;
-    Ok(ShapedText { glyphs, descent })
+    let missing_glyphs = glyphs.iter().filter(|g| g.glyph_id == 0).count();
+    Ok(ShapedText { glyphs, descent, missing_glyphs })
 }
 
 #[cfg(test)]

--- a/crates/hwpforge-smithy-pdf/tests/render_ci.rs
+++ b/crates/hwpforge-smithy-pdf/tests/render_ci.rs
@@ -320,3 +320,51 @@ fn whitespace_only_line_renders_without_glyphs() {
     assert_eq!(page_count(&output.bytes), 1);
     assert!(output.warnings.is_empty(), "{:?}", output.warnings);
 }
+
+// ── W6 §5f: 무음 시각 결함의 신호화 (tofu·줄 넘침) ──────────────
+
+#[test]
+fn missing_glyph_is_fatal_by_default() {
+    // corpus 실측: 폴백 폰트에 없는 한자/기호가 조용히 □ 로 찍혔다 — 기본 fatal.
+    let doc = doc_of(vec![para_with_cache("高", vec![seg(0, 0)])]);
+    let styles = TestStyles::default();
+    let err =
+        render_document(&PdfInput { document: &doc, styles: &styles }, &options()).unwrap_err();
+    assert!(matches!(err, PdfError::GlyphsUnavailable { count: 1, .. }), "{err:?}");
+}
+
+#[test]
+fn degraded_mode_renders_tofu_with_missing_glyphs_warning() {
+    let doc = doc_of(vec![para_with_cache("高가", vec![seg(0, 0)])]);
+    let styles = TestStyles::default();
+    let mut opts = options();
+    opts.font_fallback = FontFallbackMode::Degraded;
+    let out =
+        render_document(&PdfInput { document: &doc, styles: &styles }, &opts).expect("render");
+    assert!(
+        out.warnings.iter().any(|w| matches!(w, PdfWarning::MissingGlyphs { count: 1, .. })),
+        "{:?}",
+        out.warnings
+    );
+}
+
+#[test]
+fn line_overflow_is_surfaced() {
+    // 자연폭(가나다라 = 4000HU @10pt) > 캐시 줄 상자(2000HU) — 자간/장평
+    // 미carry 갭의 최소형. 렌더는 되고 경고만 표면화된다.
+    let mut para = para_with_cache("가나다라", vec![seg(0, 0)]);
+    if let Some(cache) = para.layout_cache.as_mut() {
+        cache.lines[0].horzsize = 2000;
+    }
+    let doc = doc_of(vec![para]);
+    let out =
+        render_document(&PdfInput { document: &doc, styles: &TestStyles::default() }, &options())
+            .expect("render");
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| matches!(w, PdfWarning::LineOverflow { excess, .. } if *excess >= 1900)),
+        "{:?}",
+        out.warnings
+    );
+}

--- a/scripts/pdf_corpus_run.py
+++ b/scripts/pdf_corpus_run.py
@@ -31,6 +31,34 @@ import time
 from pathlib import Path
 
 
+HANCOM_TTF = Path("/Applications/Hancom Office HWP.app/Contents/Resources/Hnc/Shared/TTF")
+
+
+def font_inventory(extra_args: list[str]) -> dict:
+    """실행 환경 폰트 인벤토리 (§3 manifest 요구 — 성공률·축 폴백 수치의 재현 조건).
+
+    resolver 내부를 모르므로 정직한 프록시: 발견 대상 디렉터리의 폰트 파일명 집합.
+    """
+    dirs: list[Path] = []
+    if "hancom" in extra_args or "platform" in extra_args:
+        dirs.append(HANCOM_TTF)
+    dirs += [Path(a) for i, a in enumerate(extra_args) if i > 0 and extra_args[i - 1] == "--font-dir"]
+    inventory = {}
+    for d in dirs:
+        if d.is_dir():
+            names = sorted(
+                p.name for p in d.rglob("*") if p.suffix.lower() in (".ttf", ".ttc", ".otf")
+            )
+            inventory[str(d)] = {
+                "count": len(names),
+                "names_sha256": hashlib.sha256("\n".join(names).encode()).hexdigest()[:16],
+                "names": names,
+            }
+        else:
+            inventory[str(d)] = {"count": 0, "missing": True}
+    return inventory
+
+
 def git_commit(repo: Path) -> str:
     try:
         out = subprocess.run(
@@ -167,6 +195,7 @@ def main() -> int:
         "os": platform.platform(),
         "bin": str(args.bin),
         "extra_args": args.extra,
+        "font_inventory": font_inventory(args.extra),
         "timeout_s": args.timeout,
         "corpus": str(args.corpus),
         "total_manifested": total_manifested,

--- a/scripts/pdf_corpus_run.py
+++ b/scripts/pdf_corpus_run.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""PDF corpus 검증 러너 (W6b — 커밋된 파라미터화 러너, 일회성 스크립트 금지).
+
+corpus 의 각 문서를 `hwpforge to-pdf` 로 **프로세스 격리** 실행하고,
+per-doc 타임아웃·RSS 실측·경고 버킷을 manifest(JSONL) 로 남긴다.
+corpus 자체는 `.docs` 내부 자산(미커밋)이라 경로를 인자로 받는다.
+
+판정 계층 (Codex 게이트 2 반영 — "panic 0" 단독은 빈 게이트):
+  ok            : exit 0 — PDF 산출 (경고 버킷·문단 스킵은 별도 지표)
+  fail_closed   : exit 2 + 구조화 오류 JSON (convert/decode/render 거부)
+  crash         : 그 외 exit / 시그널 — **게이트 위반**
+  timeout       : per-doc 예산 초과 — **게이트 위반**
+
+사용:
+  python3 scripts/pdf_corpus_run.py --corpus <dir> --out <dir> \
+      [--bin target/debug/hwpforge] [--timeout 60] [--sample 100] [--seed 42] \
+      [-- extra to-pdf args...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import random
+import resource
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def git_commit(repo: Path) -> str:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=10, check=True,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def sha256_head(path: Path, cap: int = 1 << 20) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        h.update(f.read(cap))
+    return h.hexdigest()[:16]
+
+
+def last_json(text: str) -> dict:
+    try:
+        return json.loads(text.strip().splitlines()[-1]) if text.strip() else {}
+    except (json.JSONDecodeError, IndexError):
+        return {}
+
+
+def classify(exit_code: int, stdout: str, stderr: str, timed_out: bool) -> tuple[str, str | None]:
+    """(outcome, error_code). CLI 는 json 모드 오류를 **stderr** 로 낸다."""
+    if timed_out:
+        return "timeout", None
+    if exit_code == 0:
+        return "ok", None
+    if exit_code < 0:
+        return "crash", f"signal {-exit_code}"
+    code = last_json(stderr).get("code") or last_json(stdout).get("code")
+    if exit_code in (1, 2) and code:
+        return "fail_closed", code
+    return "crash", f"exit {exit_code} without structured error"
+
+
+def run_one(bin_path: Path, doc: Path, out_pdf: Path, timeout: float, extra: list[str]) -> dict:
+    cmd = [str(bin_path), "--json", "to-pdf", str(doc), "-o", str(out_pdf), *extra]
+    before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    start = time.monotonic()
+    timed_out = False
+    stderr = ""
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        exit_code, stdout, stderr = proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired as e:
+        timed_out = True
+        exit_code = -999
+        stdout = (e.stdout or b"").decode("utf-8", "replace") if isinstance(e.stdout, bytes) else (e.stdout or "")
+    duration = time.monotonic() - start
+    # ru_maxrss 는 자식 프로세스 최대값의 고수위 — 문서별 근사치 (macOS bytes, Linux KB).
+    peak_rss = max(resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss, before)
+
+    outcome, error_code = classify(exit_code, stdout, stderr, timed_out)
+    record: dict = {
+        "input": str(doc),
+        "sha256_head": sha256_head(doc),
+        "size_bytes": doc.stat().st_size,
+        "outcome": outcome,
+        "error_code": error_code,
+        "duration_s": round(duration, 3),
+        "peak_rss_highwater": peak_rss,
+    }
+    if outcome == "ok":
+        try:
+            payload = json.loads(stdout.strip().splitlines()[-1])
+            record["warning_counts"] = payload.get("warning_counts", {})
+            codes: dict[str, int] = {}
+            for w in payload.get("warnings", []):
+                key = f"{w.get('stage')}:{w.get('code')}"
+                codes[key] = codes.get(key, 0) + 1
+            record["warning_codes"] = codes
+        except (json.JSONDecodeError, IndexError):
+            record["outcome"] = "crash"
+            record["error_code"] = "ok exit without parseable JSON"
+    return record
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--corpus", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--bin", type=Path, default=Path("target/debug/hwpforge"))
+    ap.add_argument("--timeout", type=float, default=60.0)
+    ap.add_argument("--sample", type=int, default=0, help="0 = 전수")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("extra", nargs="*", help="추가 to-pdf 인자 (-- 뒤)")
+    args = ap.parse_args()
+
+    docs = sorted(args.corpus.rglob("*.hwp"))
+    if not docs:
+        print(f"no .hwp under {args.corpus}", file=sys.stderr)
+        return 2
+    total_manifested = len(docs)
+    if args.sample and args.sample < len(docs):
+        # 층화: 크기 상위 10% 는 반드시 포함 + 나머지는 고정 seed 무작위.
+        by_size = sorted(docs, key=lambda p: p.stat().st_size, reverse=True)
+        top = by_size[: max(1, args.sample // 10)]
+        rest_pool = [d for d in docs if d not in set(top)]
+        rng = random.Random(args.seed)
+        rest = rng.sample(rest_pool, min(args.sample - len(top), len(rest_pool)))
+        docs = sorted(set(top) | set(rest))
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    pdf_dir = args.out / "pdf"
+    pdf_dir.mkdir(exist_ok=True)
+    manifest_path = args.out / "manifest.jsonl"
+
+    records = []
+    with open(manifest_path, "w", encoding="utf-8") as mf:
+        for i, doc in enumerate(docs, 1):
+            out_pdf = pdf_dir / f"{doc.stem}-{sha256_head(doc)[:8]}.pdf"
+            rec = run_one(args.bin, doc, out_pdf, args.timeout, args.extra)
+            records.append(rec)
+            mf.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            if i % 50 == 0 or i == len(docs):
+                print(f"[{i}/{len(docs)}] ok={sum(r['outcome'] == 'ok' for r in records)}", flush=True)
+
+    outcomes: dict[str, int] = {}
+    error_codes: dict[str, int] = {}
+    warning_codes: dict[str, int] = {}
+    for r in records:
+        outcomes[r["outcome"]] = outcomes.get(r["outcome"], 0) + 1
+        if r["error_code"]:
+            error_codes[r["error_code"]] = error_codes.get(r["error_code"], 0) + 1
+        for k, v in r.get("warning_codes", {}).items():
+            warning_codes[k] = warning_codes.get(k, 0) + v
+
+    summary = {
+        "commit": git_commit(Path(__file__).resolve().parent.parent),
+        "os": platform.platform(),
+        "bin": str(args.bin),
+        "extra_args": args.extra,
+        "timeout_s": args.timeout,
+        "corpus": str(args.corpus),
+        "total_manifested": total_manifested,
+        "executed": len(records),
+        "outcomes": outcomes,
+        "gate_violations": outcomes.get("crash", 0) + outcomes.get("timeout", 0),
+        "success_rate": round(outcomes.get("ok", 0) / len(records), 4) if records else 0.0,
+        "error_codes": dict(sorted(error_codes.items(), key=lambda kv: -kv[1])),
+        "warning_codes": dict(sorted(warning_codes.items(), key=lambda kv: -kv[1])),
+    }
+    summary_path = args.out / "summary.json"
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 1 if summary["gate_violations"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pdf_overlay_diff.py
+++ b/scripts/pdf_overlay_diff.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""PDF 오버레이 비교기 (에픽 §7 상설 회귀 검출기 — W5 시각 게이트에서 승격).
+
+두 PDF 를 래스터화해 잉크를 겹친다: **빨강 = ours, 파랑 = reference(한컴),
+일치 = 검정**. 어긋난 잉크는 색 번짐으로 즉시 드러난다.
+
+주의: y 축 비교에 pdftotext em-box 를 쓰지 말 것 — FontDescriptor ascent
+기재 차이(krilla=typo vs Quartz=hhea)로 추출 박스만 다르게 나온다 (실측
+2026-08-10). 잉크 수준 비교는 이 래스터 오버레이 또는 콘텐트 스트림 Tm
+해석으로 한다.
+
+의존: ghostscript(`gs`) + Pillow. 사용:
+  python3 scripts/pdf_overlay_diff.py ours.pdf hancom.pdf -o out_dir [--dpi 150] [--pages 1 2]
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageChops
+except ImportError:  # pragma: no cover
+    print("Pillow 필요: pip install Pillow", file=sys.stderr)
+    sys.exit(2)
+
+
+def rasterize(pdf: Path, out_dir: Path, tag: str, dpi: int) -> list[Path]:
+    subprocess.run(
+        [
+            "gs", "-dNOPAUSE", "-dBATCH", "-dQUIET", "-sDEVICE=pnggray", f"-r{dpi}",
+            f"-sOutputFile={out_dir}/{tag}-%d.png", str(pdf),
+        ],
+        check=True,
+    )
+    return sorted(out_dir.glob(f"{tag}-*.png"), key=lambda p: int(p.stem.rsplit("-", 1)[1]))
+
+
+def overlay(ours: Path, reference: Path, out: Path) -> float:
+    """겹침 PNG 를 쓰고, 불일치 잉크 비율(0.0=완전 일치)을 반환한다."""
+    o = Image.open(ours).convert("L")
+    h = Image.open(reference).convert("L")
+    w, ht = min(o.width, h.width), min(o.height, h.height)
+    o, h = o.crop((0, 0, w, ht)), h.crop((0, 0, w, ht))
+    oi, hi = ImageChops.invert(o), ImageChops.invert(h)  # 잉크 = 밝음
+    r = ImageChops.invert(hi)
+    g = ImageChops.invert(ImageChops.lighter(oi, hi))
+    b = ImageChops.invert(oi)
+    Image.merge("RGB", (r, g, b)).save(out)
+    # 불일치 지표: 한쪽에만 있는 잉크 픽셀 / 전체 잉크 픽셀 (임계 128).
+    diff = ImageChops.difference(oi, hi).point(lambda v: 255 if v >= 128 else 0)
+    union = ImageChops.lighter(oi, hi).point(lambda v: 255 if v >= 128 else 0)
+    diff_px = sum(1 for v in diff.getdata() if v)
+    union_px = sum(1 for v in union.getdata() if v)
+    return diff_px / union_px if union_px else 0.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("ours", type=Path)
+    ap.add_argument("reference", type=Path)
+    ap.add_argument("-o", "--out", type=Path, required=True)
+    ap.add_argument("--dpi", type=int, default=150)
+    ap.add_argument("--pages", type=int, nargs="*", help="1-기반 쪽 번호 (기본 전체)")
+    ap.add_argument("--max-diff", type=float, default=1.0, help="불일치 비율 상한 (초과 시 exit 1)")
+    args = ap.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    worst = 0.0
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        ours_pages = rasterize(args.ours, tdp, "ours", args.dpi)
+        ref_pages = rasterize(args.reference, tdp, "ref", args.dpi)
+        n = min(len(ours_pages), len(ref_pages))
+        if len(ours_pages) != len(ref_pages):
+            print(f"쪽수 불일치: ours {len(ours_pages)} vs reference {len(ref_pages)}")
+            worst = 1.0
+        pages = args.pages or range(1, n + 1)
+        for p in pages:
+            if p < 1 or p > n:
+                continue
+            out_png = args.out / f"p{p}-overlay.png"
+            ratio = overlay(ours_pages[p - 1], ref_pages[p - 1], out_png)
+            worst = max(worst, ratio)
+            print(f"p{p}: 불일치 잉크 {ratio:.4f} → {out_png}")
+    print(f"worst = {worst:.4f} (상한 {args.max_diff})")
+    return 0 if worst <= args.max_diff else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pdf_overlay_diff.py
+++ b/scripts/pdf_overlay_diff.py
@@ -29,13 +29,17 @@ except ImportError:  # pragma: no cover
 
 
 def rasterize(pdf: Path, out_dir: Path, tag: str, dpi: int) -> list[Path]:
-    subprocess.run(
-        [
-            "gs", "-dNOPAUSE", "-dBATCH", "-dQUIET", "-sDEVICE=pnggray", f"-r{dpi}",
-            f"-sOutputFile={out_dir}/{tag}-%d.png", str(pdf),
-        ],
-        check=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "gs", "-dNOPAUSE", "-dBATCH", "-dQUIET", "-sDEVICE=pnggray", f"-r{dpi}",
+                f"-sOutputFile={out_dir}/{tag}-%d.png", str(pdf),
+            ],
+            check=True,
+        )
+    except FileNotFoundError:
+        print("ghostscript(`gs`) 필요: brew install ghostscript", file=sys.stderr)
+        sys.exit(2)
     return sorted(out_dir.glob(f"{tag}-*.png"), key=lambda p: int(p.stem.rsplit("-", 1)[1]))
 
 
@@ -70,14 +74,16 @@ def main() -> int:
 
     args.out.mkdir(parents=True, exist_ok=True)
     worst = 0.0
+    page_mismatch = False
     with tempfile.TemporaryDirectory() as td:
         tdp = Path(td)
         ours_pages = rasterize(args.ours, tdp, "ours", args.dpi)
         ref_pages = rasterize(args.reference, tdp, "ref", args.dpi)
         n = min(len(ours_pages), len(ref_pages))
         if len(ours_pages) != len(ref_pages):
+            # 쪽수 = 유일한 구조 신호 — 잉크 비율/임계와 무관하게 무조건 실패.
             print(f"쪽수 불일치: ours {len(ours_pages)} vs reference {len(ref_pages)}")
-            worst = 1.0
+            page_mismatch = True
         pages = args.pages or range(1, n + 1)
         for p in pages:
             if p < 1 or p > n:
@@ -86,8 +92,8 @@ def main() -> int:
             ratio = overlay(ours_pages[p - 1], ref_pages[p - 1], out_png)
             worst = max(worst, ratio)
             print(f"p{p}: 불일치 잉크 {ratio:.4f} → {out_png}")
-    print(f"worst = {worst:.4f} (상한 {args.max_diff})")
-    return 0 if worst <= args.max_diff else 1
+    print(f"worst = {worst:.4f} (상한 {args.max_diff})" + (" · 쪽수 불일치" if page_mismatch else ""))
+    return 1 if page_mismatch or worst > args.max_diff else 0
 
 
 if __name__ == "__main__":

--- a/scripts/skill-smoke.sh
+++ b/scripts/skill-smoke.sh
@@ -151,6 +151,21 @@ else
   echo "  (skipped — no .hwp fixture found)"
 fi
 
+echo "== to-pdf (W6a — 콘텐츠 스니핑 / fail-closed / 렌더는 폰트 있을 때만) =="
+printf 'not a container' > garbage.hwpx
+assert_fail_grep "$BIN" to-pdf garbage.hwpx -- "UNRECOGNIZED_FORMAT"
+PDF_FIXTURE="$ROOT/tests/fixtures/pdf-rules/rules-headerfooter.hwpx"
+HANCOM_TTF="/Applications/Hancom Office HWP.app/Contents/Resources/Hnc/Shared/TTF"
+if [[ -f "$PDF_FIXTURE" && -d "$HANCOM_TTF" ]]; then
+  assert_ok "$BIN" to-pdf "$PDF_FIXTURE" -o smoke.pdf --discovery hancom
+  assert_file smoke.pdf
+  "$BIN" --json to-pdf "$PDF_FIXTURE" -o smoke2.pdf --discovery hancom > topdf.json 2>/dev/null
+  assert_grep topdf.json '"detected_format":"hwpx"'
+  assert_grep topdf.json '"warning_counts"'
+else
+  echo "  (렌더 검사 skipped — 한컴 폰트 번들 또는 fixture 없음)"
+fi
+
 echo ""
 echo "== Skill smoke summary: $PASS passed, $FAIL failed =="
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## 구현 기능

**CLI `to-pdf`** — HWPX/HWP5 문서를 조판 캐시 재생으로 PDF 렌더:
- 포맷은 확장자가 아니라 **콘텐츠 스니핑**(CFB/ZIP)으로 판별 — 확장자 불일치는 경고로 표면화
- HWP5 는 convert(조판 캐시 carry) 경유, HWPX 는 직접 디코드
- 경고를 `input/convert/decode/render` 단계별 구조화 DTO 로 보존 (`--json`) — 변환 손실이 렌더 성공 뒤에 숨지 않음
- `--font-dir`·`--discovery {explicit|hancom|platform}`·`--degraded`·`--partial-cache-reject` 옵션, 원자적 쓰기
- MSRV: smithy-pdf(krilla) 의존으로 CLI `rust-version = 1.92` — CI MSRV 레인 분리(1.88 레인 제외 + 1.92 검사 신설)

**corpus 검증 러너** (`scripts/pdf_corpus_run.py`, 커밋) — 프로세스 격리·per-doc 타임아웃·RSS 고수위·경고 버킷·폰트 인벤토리를 manifest(JSONL)로 기록, 층화 샘플 지원. 정부문서 corpus 전수(N=2,247) 실행: **crash/timeout 0** (전 실패 = 구조화 fail-closed).

**스킬·검증 도구** — SKILL.md 에 to-pdf 사용법 추가, `make skill-test` 에 커버리지 편입, 오버레이 비교기(`scripts/pdf_overlay_diff.py` — 빨강/파랑 잉크 겹침 + 쪽수 게이트)를 상설 도구로 승격.

**렌더러 정합** (smithy-pdf):
- **표 흐름 앵커 이중 모델**: 글자취급(인라인) 표는 host lineseg 캐시가 흐름의 진실, 앵커형 표는 계산치(outMargin+Σ행높이) — 판별식 도입으로 실문서에서 표 뒤 문단이 새 쪽으로 밀리던 **쪽 over-split 해소** (실측: corpus 문서 쪽수 15=15·13=13 수렴)
- 폰트에 없는 글리프(tofu)는 기본 **에러**, `--degraded` 는 경고 후 렌더 — 조용한 □ 출력 금지
- 줄 자연폭이 캐시 줄 상자를 넘으면 `LINE_OVERFLOW` 경고 (자간/장평 미carry 갭 표면화)
- 프로덕션 `.expect()` 10곳을 구조화 에러로 전환 (corpus 대량 실행 안전망)

## 검증

워크스페이스 3,174 tests 그린 (`make ci`) · corpus N=2,247 crash-free · 독립 리뷰 조건부 승인 → 전항 상환.

## semver

비파괴 feat/fix — publish 크레이트는 additive 변경 없음 (smithy-pdf·bindings-cli 는 publish=false).