### PR TITLE
feat!: 이미지 에픽 W1a+W1b — HxRun 순서 보존과 줄 캐시 좌표계 통일 (wire↔Core ledger)

### DIFF
--- a/.audit/hwp5_baseline.json
+++ b/.audit/hwp5_baseline.json
@@ -3,12 +3,18 @@
   "fixtures_scanned": 138,
   "fixtures_decoded": 138,
   "fixtures_failed": 0,
-  "total_warnings": 1,
+  "total_warnings": 2,
   "categories": {
     "DroppedControl:unknown_control": {
       "count": 1,
       "fixtures": {
         "tests/fixtures/tables/table_20_real_world_ministry_stress.hwp": 1
+      }
+    },
+    "LayoutCacheDropped:lineseg textpos ##: wire ## inside a non-#:# span interior": {
+      "count": 1,
+      "fixtures": {
+        "tests/fixtures/hwp5/sample-field-docsummary.hwp": 1
       }
     }
   },

--- a/crates/hwpforge-bindings-cli/src/commands/convert_hwp5.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/convert_hwp5.rs
@@ -59,10 +59,13 @@ pub fn run(input: &Path, output: &Path, carry_layout_cache: bool, json_mode: boo
 
     // 집계 드롭 경고(unknown_control)를 우선 배치 — 선행 decode 경고가
     // 상한을 다 먹어 집계가 가려지는 일 방지 (독립 리뷰 Medium #6).
-    let is_aggregate = |w: &&hwpforge_smithy_hwp5::Hwp5Warning| {
+    let is_aggregate = |w: &&hwpforge_convert::ConvertWarning| {
         matches!(
-            w,
-            hwpforge_smithy_hwp5::Hwp5Warning::DroppedControl { control: "unknown_control", .. }
+            w.as_hwp5(),
+            Some(hwpforge_smithy_hwp5::Hwp5Warning::DroppedControl {
+                control: "unknown_control",
+                ..
+            })
         )
     };
     let warning_details: Vec<String> = warnings

--- a/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/to_pdf.rs
@@ -67,7 +67,29 @@ fn detect_format(bytes: &[u8]) -> Option<&'static str> {
     None
 }
 
-fn convert_warning_dto(w: &Hwp5Warning) -> WarningDto {
+fn convert_warning_dto(w: &hwpforge_convert::ConvertWarning) -> WarningDto {
+    let w = match w {
+        hwpforge_convert::ConvertWarning::Hwp5(w) => w,
+        // W1b: 인코드 캐시 드롭 — 문단 경로+사유를 그대로 표면화.
+        hwpforge_convert::ConvertWarning::HwpxEncode(
+            hwpforge_smithy_hwpx::EncodeWarning::LayoutCacheDropped { path, reason },
+        ) => {
+            return WarningDto {
+                stage: "convert",
+                code: "LAYOUT_CACHE_DROPPED",
+                message: reason.clone(),
+                location: Some(path.to_string()),
+            };
+        }
+        other => {
+            return WarningDto {
+                stage: "convert",
+                code: "OTHER",
+                message: format!("{other:?}"),
+                location: None,
+            };
+        }
+    };
     let (code, message, location) = match w {
         Hwp5Warning::UnsupportedTag { tag_id, offset } => (
             "UNSUPPORTED_TAG",
@@ -85,6 +107,9 @@ fn convert_warning_dto(w: &Hwp5Warning) -> WarningDto {
         }
         Hwp5Warning::ParserFallback { subject, reason } => {
             ("PARSER_FALLBACK", format!("{subject}: {reason}"), None)
+        }
+        Hwp5Warning::LayoutCacheDropped { reason } => {
+            ("LAYOUT_CACHE_DROPPED", reason.clone(), None)
         }
         other => ("OTHER", format!("{other:?}"), None),
     };
@@ -389,7 +414,7 @@ mod tests {
             (Hwp5Warning::ParserFallback { subject: "s", reason: "r".into() }, "PARSER_FALLBACK"),
         ];
         for (w, code) in cases {
-            let dto = convert_warning_dto(&w);
+            let dto = convert_warning_dto(&hwpforge_convert::ConvertWarning::Hwp5(w));
             assert_eq!(dto.stage, "convert");
             assert_eq!(dto.code, code);
         }

--- a/crates/hwpforge-bindings-cli/src/main.rs
+++ b/crates/hwpforge-bindings-cli/src/main.rs
@@ -71,9 +71,10 @@ enum Commands {
         /// Carry the HWP5 layout cache (PARA_LINE_SEG) into HWPX
         /// `<hp:linesegarray>` so the output can be rendered with `to-pdf`.
         /// PDF replay/comparison pipelines only — the carried cache is NOT
-        /// for Hancom re-open (multi-line overlap risk), and HWP5-side
-        /// textpos normalization is incomplete so `to-pdf` may still reject
-        /// the cache on complex documents.
+        /// for Hancom re-open (multi-line overlap risk). Paragraphs whose
+        /// coordinates cannot be normalized (charts, unknown controls,
+        /// ambiguous marker boundaries) drop their cache with a
+        /// LAYOUT_CACHE_DROPPED warning instead of carrying bad data.
         #[arg(long)]
         carry_layout_cache: bool,
     },

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -1666,11 +1666,13 @@ fn audit_hwp5_rect_fixture_now_matches_after_carry() {
     let warnings =
         hwpforge_convert::hwp5_to_hwpx(&source, &out).expect("convert hwp5 rect fixture");
     assert!(
-        !warnings.iter().any(|warning| matches!(
-            warning,
-            hwpforge_smithy_hwp5::Hwp5Warning::DroppedControl { control, .. }
-                if *control == "rect"
-        )),
+        !warnings.iter().filter_map(hwpforge_convert::ConvertWarning::as_hwp5).any(|warning| {
+            matches!(
+                warning,
+                hwpforge_smithy_hwp5::Hwp5Warning::DroppedControl { control, .. }
+                    if *control == "rect"
+            )
+        }),
         "Wave 4a Rect carry should suppress the DroppedControl{{\"rect\", ..}} warning"
     );
 
@@ -3308,7 +3310,11 @@ fn diff_verifies_fill_delta_end_to_end() {
     assert_eq!(semantic["field_values"][0]["name"], "user_email");
     assert_eq!(semantic["field_values"][0]["after"], "diff@cli.io");
     assert!(semantic["paragraphs"].as_array().unwrap().is_empty());
-    assert!(semantic["raw"].as_array().unwrap().is_empty());
+    // W1b: fill 은 stale linesegarray 도 제거 — raw 축에 `$.layout_cache`
+    // 변경 하나가 정직하게 보고된다.
+    let raw = semantic["raw"].as_array().unwrap();
+    assert_eq!(raw.len(), 1, "raw: {raw:?}");
+    assert_eq!(raw[0]["detail"], "$.layout_cache");
     // Full report file written alongside inline output.
     let report_value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&report).unwrap()).unwrap();

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -3915,10 +3915,13 @@ fn fill_unknown_name_reports_available_fields() {
 }
 
 #[test]
-fn fill_merged_run_field_rejected_as_not_fillable() {
+fn fill_merged_run_field_succeeds_with_exact_attribution() {
+    // W1a (이미지/글상자 에픽): HxRun 자식 순서 보존으로 병합-run 본문
+    // 귀속이 무모호해져 채움이 성공한다 (종전 FIELD_NOT_FILLABLE 거부 →
+    // gotcha #30 철폐).
     let f = fixture("clickhere_filled.hwpx");
     let tmp = test_tmp();
-    let out = tmp.join("never2.hwpx");
+    let out = tmp.join("merged_filled.hwpx");
     let (value, _, code) = run_json(&[
         "fill",
         f.to_str().unwrap(),
@@ -3927,9 +3930,13 @@ fn fill_merged_run_field_rejected_as_not_fillable() {
         "-o",
         out.to_str().unwrap(),
     ]);
-    assert_eq!(code, 1);
-    assert_eq!(value["code"], "FIELD_NOT_FILLABLE");
-    assert!(!out.exists());
+    assert_eq!(code, 0, "{value}");
+    assert!(out.exists());
+    let (fields, _, code) = run_json(&["fields", out.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let list = fields["fields"].as_array().expect("fields array");
+    let f = list.iter().find(|f| f["name"] == "user_email").expect("user_email field");
+    assert_eq!(f["current"], "x@y.z");
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/crates/hwpforge-convert/examples/audit_batch.rs
+++ b/crates/hwpforge-convert/examples/audit_batch.rs
@@ -135,7 +135,20 @@ fn collect_hwp_files(root: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-fn category_key(warning: &Hwp5Warning) -> String {
+fn category_key(warning: &hwpforge_convert::ConvertWarning) -> String {
+    let warning = match warning {
+        hwpforge_convert::ConvertWarning::Hwp5(w) => w,
+        // W1b: HWPX 인코드 경고 (캐시 드롭 등) — 자체 카테고리.
+        hwpforge_convert::ConvertWarning::HwpxEncode(w) => {
+            return format!("HwpxEncode:{w:?}")
+                .split('{')
+                .next()
+                .unwrap_or("HwpxEncode")
+                .trim()
+                .to_string();
+        }
+        _ => return "Other".to_string(),
+    };
     match warning {
         Hwp5Warning::UnsupportedTag { tag_id, .. } => {
             format!("UnsupportedTag:0x{tag_id:04X}")

--- a/crates/hwpforge-convert/examples/audit_batch.rs
+++ b/crates/hwpforge-convert/examples/audit_batch.rs
@@ -165,6 +165,13 @@ fn category_key(warning: &hwpforge_convert::ConvertWarning) -> String {
         Hwp5Warning::ParserFallback { subject, .. } => {
             format!("ParserFallback:{subject}")
         }
+        // W1b: 캐시 fail-closed 드롭 — 사유의 가변부(좌표 숫자)는 제거해
+        // baseline 카테고리를 안정화한다.
+        Hwp5Warning::LayoutCacheDropped { reason } => {
+            let stable: String =
+                reason.chars().map(|c| if c.is_ascii_digit() { '#' } else { c }).collect();
+            format!("LayoutCacheDropped:{stable}")
+        }
         _ => "Other:unknown".to_string(),
     }
 }

--- a/crates/hwpforge-convert/examples/census_layout_carry.rs
+++ b/crates/hwpforge-convert/examples/census_layout_carry.rs
@@ -1,0 +1,89 @@
+//! W1b corpus 센서스: `--carry-layout-cache` 변환에서 문단 캐시 드롭률과
+//! 사유 분포를 전수 측정한다 (§1g v5 R3#3 — "구현된 Rust ledger 가 곧
+//! 측정기"; 파이썬 근사는 오차 위험으로 기각된 그 게이트).
+//!
+//! ```bash
+//! cargo run --release -p hwpforge-convert --example census_layout_carry -- <corpus-dir>
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use hwpforge_convert::{hwp5_to_hwpx_bytes_with_options, ConvertOptions, ConvertWarning};
+use hwpforge_smithy_hwpx::EncodeWarning;
+
+fn main() {
+    let root = std::env::args().nth(1).expect("usage: census_layout_carry <corpus-dir>");
+    let mut files: Vec<PathBuf> = Vec::new();
+    collect_hwp(&PathBuf::from(&root), &mut files);
+    files.sort();
+
+    let mut converted = 0usize;
+    let mut convert_failed = 0usize;
+    let mut files_with_drops = 0usize;
+    let mut total_drops = 0usize;
+    let mut reasons: BTreeMap<String, usize> = BTreeMap::new();
+    let options = ConvertOptions::default().with_carry_layout_cache(true);
+
+    for (i, f) in files.iter().enumerate() {
+        if i % 200 == 0 {
+            eprintln!("[{i}/{}]", files.len());
+        }
+        let Ok(bytes) = std::fs::read(f) else {
+            convert_failed += 1;
+            continue;
+        };
+        match hwp5_to_hwpx_bytes_with_options(&bytes, options) {
+            Ok((_out, warnings)) => {
+                converted += 1;
+                let mut drops_here = 0usize;
+                for w in &warnings {
+                    if let ConvertWarning::HwpxEncode(EncodeWarning::LayoutCacheDropped {
+                        reason,
+                        ..
+                    }) = w
+                    {
+                        drops_here += 1;
+                        // 카테고리화: 가변 숫자는 지우되 오류 종류는 보존.
+                        let key = if let Some((_, kind)) = reason.split_once(": ") {
+                            let kind: String = kind
+                                .chars()
+                                .map(|c| if c.is_ascii_digit() { '#' } else { c })
+                                .collect();
+                            format!(
+                                "to_wire {}",
+                                kind.split_whitespace().collect::<Vec<_>>().join(" ")
+                            )
+                        } else {
+                            reason.split('(').next().unwrap_or(reason).trim().to_string()
+                        };
+                        *reasons.entry(key).or_default() += 1;
+                    }
+                }
+                if drops_here > 0 {
+                    files_with_drops += 1;
+                    total_drops += drops_here;
+                }
+            }
+            Err(_) => convert_failed += 1,
+        }
+    }
+
+    println!("files={} converted={converted} convert_failed={convert_failed}", files.len());
+    println!("files_with_cache_drops={files_with_drops} total_dropped_paragraphs={total_drops}");
+    for (reason, count) in &reasons {
+        println!("  {count:>6}  {reason}");
+    }
+}
+
+fn collect_hwp(dir: &PathBuf, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_hwp(&path, out);
+        } else if path.extension().is_some_and(|e| e.eq_ignore_ascii_case("hwp")) {
+            out.push(path);
+        }
+    }
+}

--- a/crates/hwpforge-convert/src/lib.rs
+++ b/crates/hwpforge-convert/src/lib.rs
@@ -27,6 +27,40 @@ use crate::style_store_convert::{
     push_fonts, resolved_font_group_counts,
 };
 use crate::warning_utils::push_projection_fallback;
+use hwpforge_smithy_hwpx::EncodeWarning;
+
+/// 변환 전 단계의 typed 경고 합성 (W1b — §1g v5 변경 2).
+///
+/// convert 는 HWP5 디코드/projection/스타일 경고와 HWPX 인코드 경고를
+/// **타입 그대로** 전달한다 (`Hwp5Warning` 으로 강제 변환하지 않음 —
+/// smithy peer 의미의 계층 누수 방지). 순서 = HWP5 경고 전체 → HWPX
+/// 인코드 경고.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum ConvertWarning {
+    /// HWP5 디코드/projection/스타일 매핑 경고.
+    Hwp5(Hwp5Warning),
+    /// HWPX 인코드 경고 (캐시 드롭 등).
+    HwpxEncode(EncodeWarning),
+}
+
+impl ConvertWarning {
+    /// HWP5 경고면 참조를 돌려준다 (테스트/집계 편의).
+    pub fn as_hwp5(&self) -> Option<&Hwp5Warning> {
+        match self {
+            Self::Hwp5(w) => Some(w),
+            Self::HwpxEncode(_) => None,
+        }
+    }
+
+    /// HWPX 인코드 경고면 참조를 돌려준다.
+    pub fn as_hwpx_encode(&self) -> Option<&EncodeWarning> {
+        match self {
+            Self::Hwp5(_) => None,
+            Self::HwpxEncode(w) => Some(w),
+        }
+    }
+}
 
 /// Converts an HWP5 file to HWPX format.
 ///
@@ -51,7 +85,7 @@ use crate::warning_utils::push_projection_fallback;
 pub fn hwp5_to_hwpx(
     input: impl AsRef<Path>,
     output: impl AsRef<Path>,
-) -> Hwp5Result<Vec<Hwp5Warning>> {
+) -> Hwp5Result<Vec<ConvertWarning>> {
     hwp5_to_hwpx_with_options(input, output, ConvertOptions::default())
 }
 
@@ -65,7 +99,7 @@ pub fn hwp5_to_hwpx_with_options(
     input: impl AsRef<Path>,
     output: impl AsRef<Path>,
     options: ConvertOptions,
-) -> Hwp5Result<Vec<Hwp5Warning>> {
+) -> Hwp5Result<Vec<ConvertWarning>> {
     let bytes = std::fs::read(input.as_ref()).map_err(Hwp5Error::Io)?;
     let (hwpx_bytes, warnings) = hwp5_to_hwpx_bytes_with_options(&bytes, options)?;
     std::fs::write(output.as_ref(), hwpx_bytes).map_err(Hwp5Error::Io)?;
@@ -94,7 +128,7 @@ pub fn hwp5_to_hwpx_with_options(
 ///
 /// Returns [`Hwp5Error`] if the bytes cannot be decoded, the document fails
 /// validation, or HWPX encoding fails.
-pub fn hwp5_to_hwpx_bytes(bytes: &[u8]) -> Hwp5Result<(Vec<u8>, Vec<Hwp5Warning>)> {
+pub fn hwp5_to_hwpx_bytes(bytes: &[u8]) -> Hwp5Result<(Vec<u8>, Vec<ConvertWarning>)> {
     hwp5_to_hwpx_bytes_with_options(bytes, ConvertOptions::default())
 }
 
@@ -110,11 +144,12 @@ pub struct ConvertOptions {
     /// (`layout_hint_patch` 는 표 높이만 재생) — 이 opt-in 산출물은 한컴
     /// 재개봉 용도가 아니다.
     ///
-    /// ⚠️ 미완 (W2 독립 리뷰 기록): HWP5 승격 경로는 아직 textpos
-    /// 보이는-텍스트 정규화를 하지 않는다 (HWPX 디코더만 정규화) —
-    /// carry 산출물의 캐시는 현재 smithy-pdf 의 textpos 정합 검사를
-    /// 통과하지 못할 수 있다. HWP5 쪽 정규화 = 후속 TODO
-    /// (규칙 문서 §1 · W2 계획 §8).
+    /// W1b (이미지 에픽): HWP5 승격 경로가 wire→Core 좌표 ledger 로
+    /// textpos 를 가시 좌표로 정규화하고, 인코더가 방출-통합 역변환으로
+    /// wire 좌표로 되돌린다. 정규화/역변환이 불가능한 문단(차트 재배치·
+    /// 미지 컨트롤·축약점 모호 등)은 캐시를 **드롭**하고
+    /// [`ConvertWarning::HwpxEncode`] 로 경고한다 (부분 carry — 무음
+    /// 손실 없음).
     pub carry_layout_cache: bool,
 }
 
@@ -135,7 +170,7 @@ impl ConvertOptions {
 pub fn hwp5_to_hwpx_bytes_with_options(
     bytes: &[u8],
     options: ConvertOptions,
-) -> Hwp5Result<(Vec<u8>, Vec<Hwp5Warning>)> {
+) -> Hwp5Result<(Vec<u8>, Vec<ConvertWarning>)> {
     let decoded = decode_hwp5_to_core(bytes)?;
     let (hwpx_style_store, style_warnings) = hwp5_style_store_to_hwpx(&decoded.style_store);
     // Warning order: decode-phase warnings (intermediate + projection +
@@ -150,7 +185,10 @@ pub fn hwp5_to_hwpx_bytes_with_options(
     let validated = decoded.document.validate().map_err(Hwp5Error::Core)?;
     let encode_options =
         EncodeOptions::default().with_emit_layout_cache(options.carry_layout_cache);
-    let hwpx_bytes = HwpxEncoder::encode_with_options(
+    // W1b: 진단 보존 경로 — 캐시 드롭이 있어도 변환은 성공하되 경고를
+    // `ConvertWarning::HwpxEncode` 로 전파한다 (legacy strict 진입점의
+    // LayoutCacheDropped 에러와 달리 carry 파이프라인은 부분 carry 허용).
+    let outcome = HwpxEncoder::encode_with_diagnostics(
         &validated,
         &hwpx_style_store,
         &decoded.image_store,
@@ -158,9 +196,11 @@ pub fn hwp5_to_hwpx_bytes_with_options(
     )
     .map_err(|e| Hwp5Error::Cfb { detail: format!("HWPX encoding failed: {e}") })?;
     let hwpx_bytes =
-        layout_hint_patch::patch_hwpx_layout_hints(&hwpx_bytes, &decoded.layout_hints)?;
+        layout_hint_patch::patch_hwpx_layout_hints(&outcome.bytes, &decoded.layout_hints)?;
 
-    Ok((hwpx_bytes, warnings))
+    let mut all: Vec<ConvertWarning> = warnings.into_iter().map(ConvertWarning::Hwp5).collect();
+    all.extend(outcome.warnings.into_iter().map(ConvertWarning::HwpxEncode));
+    Ok((hwpx_bytes, all))
 }
 
 /// Maps a format-neutral [`Hwp5StyleStore`] onto an [`HwpxStyleStore`].

--- a/crates/hwpforge-convert/src/tests.rs
+++ b/crates/hwpforge-convert/src/tests.rs
@@ -2,6 +2,7 @@
 //! (`hwp5_to_hwpx`, `hwp5_to_hwpx_bytes`, image/OLE asset conversion, ...).
 //! Migrated from `hwpforge-smithy-hwp5` as part of the E5 executor task.
 
+use crate::ConvertWarning;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -432,7 +433,7 @@ fn hwp5_to_hwpx_full_report_keeps_leading_image_non_zero() {
     let out = unique_temp_path("full_report.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("full_report conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|warning| matches!(
             warning,
             Hwp5Warning::DroppedControl { control, .. } if *control == "image"
         )),
@@ -686,7 +687,7 @@ fn hwp5_to_hwpx_rect_fixture_carries_rect_without_warning() {
     let out = unique_temp_path("rect_simple.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("fixture conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|warning| matches!(
             warning,
             Hwp5Warning::DroppedControl { control, .. } if *control == "rect"
         )),
@@ -718,7 +719,10 @@ fn hwp5_to_hwpx_user_sample_gso_ellipse_carries_ellipse() {
     let out = unique_temp_path("user-sample-gso-ellipse.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("ellipse conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "gso ellipse must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -752,7 +756,10 @@ fn hwp5_to_hwpx_user_sample_gso_arc_carries_arc() {
     let out = unique_temp_path("user-sample-gso-arc.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("arc conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "gso arc must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -785,7 +792,10 @@ fn hwp5_to_hwpx_user_sample_gso_curve_carries_curve() {
     let out = unique_temp_path("user-sample-gso-curve.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("curve conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "gso curve must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -816,7 +826,10 @@ fn hwp5_to_hwpx_user_sample_gso_connectline_carries_connect_line() {
     let out = unique_temp_path("user-sample-gso-connectline-native.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("connect-line conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "connect line must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -849,7 +862,10 @@ fn hwp5_to_hwpx_user_sample_equation_carries_script() {
     let out = unique_temp_path("user-sample-equation-basic.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("equation conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "equation must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -883,7 +899,7 @@ fn hwp5_to_hwpx_user_sample_memo_basic_preserves_body_and_carries_memo() {
     let out = unique_temp_path("user-sample-memo-basic.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("memo conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|warning| matches!(
             warning,
             Hwp5Warning::DroppedControl { control: "memo" | "memo_content_cluster", .. }
         )),
@@ -965,7 +981,7 @@ fn hwp5_to_hwpx_user_sample_memo_multiple_matches_clusters_by_id() {
     let out = unique_temp_path("user-sample-memo-multiple.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("multi-memo conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|warning| matches!(
             warning,
             Hwp5Warning::DroppedControl { control: "memo" | "memo_content_cluster", .. }
         )),
@@ -1035,7 +1051,10 @@ fn hwp5_to_hwpx_user_sample_dutmal_basic_carries_option_and_preserves_spacing() 
     let out = unique_temp_path("user-sample-dutmal-basic.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("dutmal conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "dutmal must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -1109,7 +1128,7 @@ fn hwp5_to_hwpx_user_sample_dutmal_variants_carries_sz_ratio_and_align() {
     let out = unique_temp_path("user-sample-dutmal-variants.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("dutmal variants conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|warning| matches!(
             warning,
             Hwp5Warning::DroppedControl { .. } | Hwp5Warning::ProjectionFallback { .. }
         )),
@@ -1169,7 +1188,10 @@ fn hwp5_to_hwpx_user_sample_compose_basic_carries_composetext_and_char_pr_overri
     let out = unique_temp_path("user-sample-compose-basic.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("compose conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "compose must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -1239,7 +1261,10 @@ fn hwp5_to_hwpx_user_sample_compose_all_shapes_handles_packed_wire_variant() {
     let warnings =
         hwp5_to_hwpx(&source, &out).expect("all-shapes compose conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "no compose variant must drop: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -1337,7 +1362,10 @@ fn hwp5_to_hwpx_user_sample_indexmark_basic_carries_primary_only_entries() {
     let out = unique_temp_path("user-sample-indexmark-basic.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("indexmark conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "indexmark must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -1384,7 +1412,10 @@ fn hwp5_to_hwpx_user_sample_indexmark_multi_preserves_order_and_secondary_keys()
     let out = unique_temp_path("user-sample-indexmark-multi.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("multi indexmark conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "no indexmark variant must drop: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -1462,7 +1493,10 @@ fn hwp5_to_hwpx_user_sample_indexmark_surrogate_reassembles_split_pairs() {
     let warnings =
         hwp5_to_hwpx(&source, &out).expect("surrogate indexmark conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "no surrogate variant must drop: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -1502,7 +1536,10 @@ fn hwp5_to_hwpx_user_sample_equation_native_carries_complex_scripts() {
     let out = unique_temp_path("user-sample-equation-native.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("native equation conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
+        !warnings
+            .iter()
+            .filter_map(ConvertWarning::as_hwp5)
+            .any(|warning| matches!(warning, Hwp5Warning::DroppedControl { .. })),
         "native equations must not drop any control: {warnings:?}"
     );
     assert_valid_hwpx(&out);
@@ -2751,7 +2788,7 @@ fn hwp5_to_hwpx_user_sample_underline_variants_preserves_all_shapes() {
 
     // After Wave 1b the underline_shape warning is replaced by actual carry.
     assert!(
-        !warnings.iter().any(|w| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|w| matches!(
             w,
             Hwp5Warning::ProjectionFallback { subject, .. }
                 if *subject == "style.char_shape.underline_shape"
@@ -2809,7 +2846,7 @@ fn hwp5_to_hwpx_user_sample_strike_variants_preserves_line_family() {
     // Wave 1c: the strike line family is now carried, so the projection
     // fallback warning for strike_shape must not fire.
     assert!(
-        !warnings.iter().any(|w| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|w| matches!(
             w,
             Hwp5Warning::ProjectionFallback { subject, .. }
                 if *subject == "style.char_shape.strike_shape"
@@ -2866,7 +2903,7 @@ fn hwp5_to_hwpx_user_sample_breakwordlatin_variants_preserves_hyphenation() {
     // After Wave 1d carry, the break_latin_word projection warning is gone
     // for the raw=1 (HYPHENATION) and raw=2 (BREAK_WORD) cases.
     assert!(
-        !warnings.iter().any(|w| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|w| matches!(
             w,
             Hwp5Warning::ProjectionFallback { subject, .. }
                 if *subject == "style.para_shape.break_latin_word"
@@ -2911,7 +2948,7 @@ fn hwp5_to_hwpx_user_sample_line_spacing_preserves_all_modes() {
     // Wave 2a: AtLeast is now a first-class variant, so the
     // ProjectionFallback warning for raw=3 must no longer fire.
     assert!(
-        !warnings.iter().any(|w| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|w| matches!(
             w,
             Hwp5Warning::ProjectionFallback { subject, .. }
                 if *subject == "style.para_shape.line_spacing"
@@ -3196,7 +3233,7 @@ fn hwp5_to_hwpx_chart_fixture_emits_embedded_chart_switch_block() {
     let out = unique_temp_path("chart_01_single_column.hwpx");
     let warnings = hwp5_to_hwpx(&source, &out).expect("chart fixture conversion should succeed");
     assert!(
-        !warnings.iter().any(|warning| matches!(
+        !warnings.iter().filter_map(ConvertWarning::as_hwp5).any(|warning| matches!(
             warning,
             Hwp5Warning::DroppedControl { control, .. } if *control == "ole_object"
         )),

--- a/crates/hwpforge-smithy-hwp5/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwp5/src/decoder/mod.rs
@@ -86,6 +86,13 @@ pub enum Hwp5Warning {
         /// Concrete fallback detail.
         reason: String,
     },
+    /// A paragraph's line-layout cache was not promoted to Core because the
+    /// wire→Core coordinate ledger could not be built or a lineseg `textpos`
+    /// could not be normalized (W1b fail-closed — no guessed coordinates).
+    LayoutCacheDropped {
+        /// Concrete drop reason (ledger failure or offending textpos).
+        reason: String,
+    },
 }
 
 /// Shared parser output before Core projection or semantic adaptation.

--- a/crates/hwpforge-smithy-hwp5/src/decoder/section/mod.rs
+++ b/crates/hwpforge-smithy-hwp5/src/decoder/section/mod.rs
@@ -122,10 +122,13 @@ impl ParaBuf {
 
     /// Build the final `Hwp5Paragraph`, consuming this buffer.
     fn finish(self) -> Hwp5Paragraph {
-        let text_segments =
-            self.text.map_or_else(Vec::new, |paragraph_text| paragraph_text.segments);
+        let (text_segments, silent_wires) = self.text.map_or_else(
+            || (Vec::new(), Vec::new()),
+            |paragraph_text| (paragraph_text.segments, paragraph_text.silent_wires),
+        );
         let text = segments_to_string(&text_segments);
         Hwp5Paragraph {
+            silent_wires,
             text,
             text_segments,
             para_shape_id: self.header.para_shape_id,

--- a/crates/hwpforge-smithy-hwp5/src/decoder/section/model.rs
+++ b/crates/hwpforge-smithy-hwp5/src/decoder/section/model.rs
@@ -19,6 +19,9 @@ pub(crate) struct Hwp5Paragraph {
     pub text: String,
     /// The raw decoded text segments in paragraph order before flattening.
     pub text_segments: Vec<TextSegment>,
+    /// segment 없이 무음 소비된 wire 구간들 (W1b ledger — 좌표 정규화 시
+    /// 이 구간들을 빼놓으면 그만큼 어긋난다).
+    pub silent_wires: Vec<crate::schema::section::SilentWire>,
     /// Paragraph shape ID (index into DocInfo para_shapes).
     pub para_shape_id: u16,
     /// Style ID (index into DocInfo styles).

--- a/crates/hwpforge-smithy-hwp5/src/layout_hint_patch.rs
+++ b/crates/hwpforge-smithy-hwp5/src/layout_hint_patch.rs
@@ -266,6 +266,7 @@ mod tests {
         controls: Vec<Hwp5Control>,
     ) -> Hwp5Paragraph {
         Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: text.into(),
@@ -322,6 +323,7 @@ mod tests {
                 is_header: false,
                 border_fill_id: None,
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: "cell".into(),

--- a/crates/hwpforge-smithy-hwp5/src/lib.rs
+++ b/crates/hwpforge-smithy-hwp5/src/lib.rs
@@ -53,6 +53,7 @@ mod table_page_break;
 /// Test-only helpers for resolving shared workspace fixtures.
 pub(crate) mod test_support;
 mod warning_utils;
+mod wire_text_map;
 
 use std::collections::BTreeMap;
 use std::path::Path;

--- a/crates/hwpforge-smithy-hwp5/src/projection/mod.rs
+++ b/crates/hwpforge-smithy-hwp5/src/projection/mod.rs
@@ -42,7 +42,9 @@ use crate::decoder::Hwp5Warning;
 use crate::error::Hwp5Result;
 use crate::numeric::positive_i32_from_u32;
 use crate::schema::section::Hwp5DutmalControl;
-use crate::schema::section::{Hwp5CharShapeRun, Hwp5PageDef, Hwp5ShapeComponentGeometry};
+use crate::schema::section::{
+    Hwp5CharShapeRun, Hwp5PageDef, Hwp5ShapeComponentGeometry, SilentWire,
+};
 use crate::table_cell_vertical_align::{
     core_table_cell_vertical_align, unknown_hwp5_table_cell_vertical_align_raw,
 };
@@ -868,7 +870,11 @@ fn project_paragraph_with_images_flat(
     if hwp_para.style_id > 0 {
         paragraph = paragraph.with_style(StyleIndex::new(hwp_para.style_id as usize));
     }
-    paragraph.layout_cache = promote_line_segments(&hwp_para.line_segments);
+    paragraph.layout_cache = promote_line_segments(
+        &hwp_para.line_segments,
+        check_ledger_against_emission(build_flat_ledger(hwp_para), &paragraph.runs),
+        &mut projection_images.warnings,
+    );
     // W3: ParaHeader divide_sort 쪽/단 나누기 carry (F2 실측 — 한컴은 쪽나눔
     // 문단의 lineseg v 를 리셋하지 않아 이 플래그가 유일한 쪽분할 신호).
     paragraph.page_break = hwp_para.page_break;
@@ -884,25 +890,298 @@ fn project_paragraph_with_images_flat(
 /// 없음 = 캐시 부재 의미).
 fn promote_line_segments(
     segs: &[crate::schema::section::Hwp5ParaLineSeg],
+    ledger: Result<crate::wire_text_map::WireTextMap, &'static str>,
+    warnings: &mut Vec<crate::decoder::Hwp5Warning>,
 ) -> Option<hwpforge_core::layout::LayoutCache> {
     if segs.is_empty() {
         return None;
     }
-    Some(hwpforge_core::layout::LayoutCache::new(
-        segs.iter()
-            .map(|s| hwpforge_core::layout::LineSeg {
-                textpos: s.text_start_position,
-                vertpos: s.vertical_position,
-                vertsize: s.line_height,
-                textheight: s.text_height,
-                baseline: s.baseline_distance,
-                spacing: s.line_spacing,
-                horzpos: s.column_start_position,
-                horzsize: s.segment_width,
-                flags: s.tag,
-            })
-            .collect(),
-    ))
+    // W1b: raw wire textpos → Core 가시(text_content) 좌표 정규화.
+    // ledger 구축 실패·좌표 변환 실패 = fail-closed (캐시 미승격 + 경고) —
+    // 추측 좌표를 Core 에 싣지 않는다 (§1g v5).
+    let map = match ledger {
+        Ok(map) => map,
+        Err(reason) => {
+            warnings.push(crate::decoder::Hwp5Warning::LayoutCacheDropped {
+                reason: reason.to_string(),
+            });
+            return None;
+        }
+    };
+    let mut lines = Vec::with_capacity(segs.len());
+    for s in segs {
+        let textpos = match map.to_core(s.text_start_position) {
+            Ok(core) => core,
+            Err(e) => {
+                warnings.push(crate::decoder::Hwp5Warning::LayoutCacheDropped {
+                    reason: format!("lineseg textpos {}: {e}", s.text_start_position),
+                });
+                return None;
+            }
+        };
+        lines.push(hwpforge_core::layout::LineSeg {
+            textpos,
+            vertpos: s.vertical_position,
+            vertsize: s.line_height,
+            textheight: s.text_height,
+            baseline: s.baseline_distance,
+            spacing: s.line_spacing,
+            horzpos: s.column_start_position,
+            horzsize: s.segment_width,
+            flags: s.tag,
+        });
+    }
+    Some(hwpforge_core::layout::LayoutCache::new(lines))
+}
+
+/// ledger 가 예측한 Core 총길이와 실제 방출된 run 들의 텍스트 총길이를
+/// 대조한다 — 불일치 = ledger/방출 분기 (fail-closed, §1g v5 choke).
+fn check_ledger_against_emission(
+    ledger_result: Result<crate::wire_text_map::WireTextMap, &'static str>,
+    runs: &[Run],
+) -> Result<crate::wire_text_map::WireTextMap, &'static str> {
+    let map = ledger_result?;
+    let emitted_core: u32 = runs
+        .iter()
+        .filter_map(|r| r.content.plain_text())
+        .map(|t| t.encode_utf16().count() as u32)
+        .sum();
+    if map.core_end() != emitted_core {
+        return Err("ledger/emission core length mismatch");
+    }
+    Ok(map)
+}
+
+/// FieldBegin~FieldEnd 방출 결과 — ledger 의 field 구간 core 폭을
+/// 방출부가 결정한다 (단일 진실원, §1g v5 R3#1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldEmissionOutcome {
+    /// 본문이 Control 내부로 접힘 (ClickHere/Hyperlink/CrossRef/Memo/
+    /// 자동필드 display) — 전체 구간이 Core 텍스트 0 유닛.
+    Folded,
+    /// 본문이 가시 텍스트 슬라이스로 재방출됨 (BookmarkSpan/
+    /// PlainTextFallback/빈 display CrossRef) — begin/end 만 (8,0),
+    /// 본문은 가시 축 그대로 (내부 marker 는 U+FFFC 로 1유닛 재방출).
+    ReEmitted,
+}
+
+/// 문단 하나의 wire→Core 좌표 ledger 를 방출과 나란히 구축한다 (W1b).
+///
+/// wire 소비는 세그먼트 종류에서 유도하고 (Text=UTF-16 len ·
+/// Tab/컨트롤=8 · 단일 제어=1), segment 없는 무음 소비는
+/// [`SilentWire`] 목록을 wire 순서로 합류시킨다. FieldBegin~FieldEnd
+/// 는 pending 버퍼로 모아 방출 결과([`FieldEmissionOutcome`])가
+/// 확정된 뒤 commit 한다. 어떤 단계든 실패하면 문단 전체가
+/// fail-closed (캐시 미승격).
+struct ParaLedger<'a> {
+    builder: crate::wire_text_map::WireMapBuilder,
+    silent: &'a [SilentWire],
+    silent_idx: usize,
+    /// ledger 자체 wire 커서 — pending 동안 builder 커서와 분리.
+    wire_cursor: u32,
+    /// FieldBegin 이후 버퍼된 body 조각 `(wire, 재방출 시 core)`.
+    pending: Option<Vec<(u32, u32)>>,
+    failed: Option<&'static str>,
+}
+
+impl<'a> ParaLedger<'a> {
+    fn new(silent: &'a [SilentWire]) -> Self {
+        Self {
+            builder: crate::wire_text_map::WireMapBuilder::new(),
+            silent,
+            silent_idx: 0,
+            wire_cursor: 0,
+            pending: None,
+            failed: None,
+        }
+    }
+
+    fn fail(&mut self, why: &'static str) {
+        if self.failed.is_none() {
+            self.failed = Some(why);
+        }
+    }
+
+    /// 현재 커서 위치에 도달한 무음 소비 구간을 합류시킨다.
+    fn drain_silent(&mut self) {
+        while let Some(s) = self.silent.get(self.silent_idx) {
+            if s.start > self.wire_cursor {
+                break;
+            }
+            if s.start < self.wire_cursor {
+                // parse 기록과 유도 소비폭이 어긋남 — 좌표를 믿을 수 없다.
+                self.fail("silent-wire accounting mismatch");
+                self.silent_idx += 1;
+                continue;
+            }
+            self.silent_idx += 1;
+            self.consume(s.len, 0, 0);
+        }
+    }
+
+    /// 소비 하나를 기록한다. `core_folded`/`core_reemitted` 는 각각
+    /// field 밖(즉시 반영)·재방출 body 조각일 때의 Core 폭.
+    fn consume(&mut self, wire: u32, core_outside: u32, core_reemitted: u32) {
+        match self.wire_cursor.checked_add(wire) {
+            Some(w) => self.wire_cursor = w,
+            None => {
+                self.fail("wire cursor overflow");
+                return;
+            }
+        }
+        if let Some(pieces) = self.pending.as_mut() {
+            pieces.push((wire, core_reemitted));
+        } else if core_outside == wire {
+            self.builder.advance_identity(wire);
+        } else {
+            self.builder.push_span(wire, core_outside);
+        }
+    }
+
+    /// 일반 텍스트 (field 밖 1:1 · 재방출 body 도 1:1).
+    fn observe_text(&mut self, utf16_len: u32) {
+        self.drain_silent();
+        self.consume(utf16_len, utf16_len, utf16_len);
+    }
+
+    /// Tab — wire 8 · Core `\t` 1 (양쪽 동일).
+    fn observe_tab(&mut self) {
+        self.drain_silent();
+        self.consume(8, 1, 1);
+    }
+
+    /// 단일 유닛 제어 (`\n`·nbSp·fwSp) — 1:1.
+    fn observe_unit(&mut self) {
+        self.drain_silent();
+        self.consume(1, 1, 1);
+    }
+
+    /// ParaBreak — wire 1 · Core 0.
+    fn observe_para_break(&mut self) {
+        self.drain_silent();
+        self.consume(1, 0, 0);
+    }
+
+    /// ControlRef/ExtendedControlRef marker — field 밖 (8,0) (U+FFFC
+    /// 미방출), 재방출 body 안 (8,1) (U+FFFC 가 텍스트로 살아남음).
+    fn observe_marker(&mut self) {
+        self.drain_silent();
+        self.consume(8, 0, 1);
+    }
+
+    /// SectionColumnDef — wire 8 · Core 0 (양쪽 동일).
+    fn observe_section_ctrl(&mut self) {
+        self.drain_silent();
+        self.consume(8, 0, 0);
+    }
+
+    /// FieldBegin — pending 개시 (begin 자체 8유닛 소비).
+    fn begin_field(&mut self) {
+        self.drain_silent();
+        if self.pending.is_some() {
+            self.fail("nested field begin");
+        }
+        match self.wire_cursor.checked_add(8) {
+            Some(w) => self.wire_cursor = w,
+            None => {
+                self.fail("wire cursor overflow");
+                return;
+            }
+        }
+        if self.failed.is_none() {
+            self.pending = Some(Vec::new());
+        }
+    }
+
+    /// FieldEnd — 방출 결과에 따라 pending 을 commit 한다.
+    fn commit_field(&mut self, outcome: FieldEmissionOutcome) {
+        self.drain_silent();
+        match self.wire_cursor.checked_add(8) {
+            Some(w) => self.wire_cursor = w,
+            None => {
+                self.fail("wire cursor overflow");
+                return;
+            }
+        }
+        let Some(pieces) = self.pending.take() else {
+            self.fail("unpaired field end");
+            return;
+        };
+        match outcome {
+            FieldEmissionOutcome::Folded => {
+                let mut total: u32 = 16; // begin + end
+                for (wire, _) in &pieces {
+                    match total.checked_add(*wire) {
+                        Some(t) => total = t,
+                        None => {
+                            self.fail("wire cursor overflow");
+                            return;
+                        }
+                    }
+                }
+                self.builder.push_span(total, 0);
+            }
+            FieldEmissionOutcome::ReEmitted => {
+                self.builder.push_span(8, 0);
+                for (wire, core) in pieces {
+                    if wire == core {
+                        self.builder.advance_identity(wire);
+                    } else {
+                        self.builder.push_span(wire, core);
+                    }
+                }
+                self.builder.push_span(8, 0);
+            }
+        }
+    }
+
+    /// 문단 종료 — 잔여 무음 구간 합류 후 seal.
+    fn finish(mut self) -> Result<crate::wire_text_map::WireTextMap, &'static str> {
+        if self.pending.is_some() {
+            self.fail("dangling field begin");
+        }
+        self.drain_silent();
+        if self.silent_idx < self.silent.len() {
+            self.fail("silent-wire accounting mismatch");
+        }
+        if let Some(why) = self.failed {
+            return Err(why);
+        }
+        self.builder.finish().map_err(|_| "wire map invariant violation")
+    }
+}
+
+/// field 없는(flat) 문단의 ledger — 세그먼트 종류만으로 구축한다.
+fn build_flat_ledger(
+    hwp_para: &Hwp5Paragraph,
+) -> Result<crate::wire_text_map::WireTextMap, &'static str> {
+    let mut ledger = ParaLedger::new(&hwp_para.silent_wires);
+    for segment in &hwp_para.text_segments {
+        match segment {
+            crate::schema::section::TextSegment::Text(text) => {
+                ledger.observe_text(text.encode_utf16().count() as u32);
+            }
+            crate::schema::section::TextSegment::Tab { .. } => ledger.observe_tab(),
+            crate::schema::section::TextSegment::LineBreak
+            | crate::schema::section::TextSegment::NonBreakingSpace
+            | crate::schema::section::TextSegment::FwSpace => ledger.observe_unit(),
+            crate::schema::section::TextSegment::ParaBreak => ledger.observe_para_break(),
+            crate::schema::section::TextSegment::ControlRef { .. }
+            | crate::schema::section::TextSegment::ExtendedControlRef { .. } => {
+                ledger.observe_marker();
+            }
+            crate::schema::section::TextSegment::SectionColumnDef { .. } => {
+                ledger.observe_section_ctrl();
+            }
+            crate::schema::section::TextSegment::FieldBegin { .. }
+            | crate::schema::section::TextSegment::FieldEnd => {
+                // flat 분기는 field 문단을 받지 않는다
+                // (`paragraph_needs_structural_projection`) — 방어적 실패.
+                ledger.fail("field segment in flat projection");
+            }
+        }
+    }
+    ledger.finish()
 }
 
 fn project_paragraph_with_images_structural(
@@ -916,10 +1195,12 @@ fn project_paragraph_with_images_structural(
     let mut runs: Vec<Run> = Vec::new();
     let mut visible_utf16: u32 = 0;
     let mut active_field: Option<ActiveField> = None;
+    let mut ledger = ParaLedger::new(&hwp_para.silent_wires);
 
     for segment in &hwp_para.text_segments {
         match segment {
             crate::schema::section::TextSegment::Text(text) => {
+                ledger.observe_text(text.encode_utf16().count() as u32);
                 project_visible_text_segment(
                     text,
                     hwp_para,
@@ -933,6 +1214,7 @@ fn project_paragraph_with_images_structural(
                 // attribute carry is tracked separately by
                 // `warn_on_inline_tab_attributes` to cover both the
                 // flat and structural projection branches uniformly.
+                ledger.observe_tab();
                 append_visible_unit(
                     hwp_para,
                     &mut runs,
@@ -942,6 +1224,7 @@ fn project_paragraph_with_images_structural(
                 );
             }
             crate::schema::section::TextSegment::LineBreak => {
+                ledger.observe_unit();
                 append_visible_unit(
                     hwp_para,
                     &mut runs,
@@ -951,6 +1234,7 @@ fn project_paragraph_with_images_structural(
                 );
             }
             crate::schema::section::TextSegment::NonBreakingSpace => {
+                ledger.observe_unit();
                 // Sentinel: U+00A0 is the canonical NBSP code-point and is
                 // what `inline_text::encode_inline_text_xml` translates back
                 // into `<hp:nbSpace/>` on HWPX emit.
@@ -963,6 +1247,7 @@ fn project_paragraph_with_images_structural(
                 );
             }
             crate::schema::section::TextSegment::FwSpace => {
+                ledger.observe_unit();
                 // Sentinel: U+001F mirrors the HWP5 wire control byte for
                 // fixed-width space and is what `inline_text` translates back
                 // into `<hp:fwSpace/>` on HWPX emit.
@@ -976,6 +1261,7 @@ fn project_paragraph_with_images_structural(
             }
             crate::schema::section::TextSegment::ControlRef { .. }
             | crate::schema::section::TextSegment::ExtendedControlRef { .. } => {
+                ledger.observe_marker();
                 if active_field.is_none() {
                     if let Some(control) = queues.object_controls.pop_front() {
                         if let Some(run) = project_control_run(
@@ -991,10 +1277,17 @@ fn project_paragraph_with_images_structural(
                 visible_utf16 += 1;
             }
             crate::schema::section::TextSegment::SectionColumnDef { extra } => {
+                ledger.observe_section_ctrl();
                 let ctrl_id = ctrl_id_from_inline_extra(extra);
                 let _ = consume_marker_header(&mut queues.marker_headers, ctrl_id);
             }
             crate::schema::section::TextSegment::FieldBegin { extra } => {
+                ledger.begin_field();
+                if active_field.is_some() {
+                    // 기존 동작(교체)은 유지하되 ledger 는 nested 로 실패
+                    // 처리됨 — 좌표를 추측하지 않는다.
+                    ledger.fail("nested field begin");
+                }
                 active_field = Some(start_field_from_marker(
                     extra,
                     &mut queues,
@@ -1005,21 +1298,28 @@ fn project_paragraph_with_images_structural(
             }
             crate::schema::section::TextSegment::FieldEnd => {
                 if let Some(field) = active_field.take() {
-                    finish_active_field(
+                    let outcome = finish_active_field(
                         field,
                         hwp_para,
                         visible_utf16,
                         &mut runs,
                         projection_images,
                     );
+                    ledger.commit_field(outcome);
+                } else {
+                    ledger.commit_field(FieldEmissionOutcome::Folded);
                 }
             }
-            crate::schema::section::TextSegment::ParaBreak => {}
+            crate::schema::section::TextSegment::ParaBreak => {
+                ledger.observe_para_break();
+            }
         }
     }
 
     if let Some(field) = active_field.take() {
-        finish_active_field(field, hwp_para, visible_utf16, &mut runs, projection_images);
+        // 방출은 기존 동작대로 완료하되, 좌표는 신뢰 불가 (v5 fail-closed).
+        let _ = finish_active_field(field, hwp_para, visible_utf16, &mut runs, projection_images);
+        ledger.fail("dangling field begin");
     }
 
     drain_unconsumed_paragraph_queues(
@@ -1040,7 +1340,11 @@ fn project_paragraph_with_images_structural(
     if hwp_para.style_id > 0 {
         paragraph = paragraph.with_style(StyleIndex::new(hwp_para.style_id as usize));
     }
-    paragraph.layout_cache = promote_line_segments(&hwp_para.line_segments);
+    paragraph.layout_cache = promote_line_segments(
+        &hwp_para.line_segments,
+        check_ledger_against_emission(ledger.finish(), &paragraph.runs),
+        &mut projection_images.warnings,
+    );
     // W3: ParaHeader divide_sort 쪽/단 나누기 carry (F2 실측 — 한컴은 쪽나눔
     // 문단의 lineseg v 를 리셋하지 않아 이 플래그가 유일한 쪽분할 신호).
     paragraph.page_break = hwp_para.page_break;
@@ -1561,17 +1865,18 @@ fn finish_active_field(
     end_utf16: u32,
     runs: &mut Vec<Run>,
     projection_images: &mut ProjectionImageState<'_>,
-) {
+) -> FieldEmissionOutcome {
     match field {
         ActiveField::Hyperlink { url, start_utf16, display_text } => {
             if display_text.is_empty() {
-                return;
+                return FieldEmissionOutcome::Folded;
             }
             let char_shape_id = CharShapeIndex::new(char_shape_id_for_visible_position(
                 &hwp_para.char_shape_runs,
                 start_utf16,
             ) as usize);
             runs.push(Run::control(Control::Hyperlink { text: display_text, url }, char_shape_id));
+            FieldEmissionOutcome::Folded
         }
         ActiveField::BookmarkSpan { name, start_utf16 } => {
             let char_shape_id = CharShapeIndex::new(char_shape_id_for_visible_position(
@@ -1592,6 +1897,7 @@ fn finish_active_field(
                 Control::Bookmark { name, bookmark_type: BookmarkType::SpanEnd },
                 char_shape_id,
             ));
+            FieldEmissionOutcome::ReEmitted
         }
         ActiveField::CrossRef { control, start_utf16, display_text } => {
             // Wave 12m Phase 2 Step 4: emit native `Control::CrossRef`.
@@ -1612,7 +1918,7 @@ fn finish_active_field(
                     start_utf16,
                     end_utf16,
                 ));
-                return;
+                return FieldEmissionOutcome::ReEmitted;
             }
             let ref_type = decode_hwp5_crossref_ref_type(control.ref_type_code);
             let content_type =
@@ -1623,6 +1929,7 @@ fn finish_active_field(
                 Control::CrossRef { target, ref_type, content_type, as_hyperlink, display_text },
                 char_shape_id,
             ));
+            FieldEmissionOutcome::Folded
         }
         ActiveField::PlainTextFallback { start_utf16 } => {
             runs.extend(project_text_segment(
@@ -1631,6 +1938,7 @@ fn finish_active_field(
                 start_utf16,
                 end_utf16,
             ));
+            FieldEmissionOutcome::ReEmitted
         }
         ActiveField::MemoAnchor { start_utf16, memo } => {
             // Capture the FieldBegin..FieldEnd span as `anchor_runs` *inside*
@@ -1652,6 +1960,7 @@ fn finish_active_field(
                 start_utf16,
             ) as usize);
             runs.push(project_memo_run(&memo, projection_images, char_shape_id, anchor_runs));
+            FieldEmissionOutcome::Folded
         }
         ActiveField::ClickHere { start_utf16, hint_text, help_text, name } => {
             // Emit a single Control::Field Run at the span start. The
@@ -1677,6 +1986,7 @@ fn finish_active_field(
                 },
                 char_shape_id,
             ));
+            FieldEmissionOutcome::Folded
         }
         ActiveField::SummaryField { start_utf16, command_token, display_text } => {
             // Emit a single Run carrying either typed `Control::Field`
@@ -1701,6 +2011,7 @@ fn finish_active_field(
                 None => Control::UnknownSummary { token: command_token, display_text },
             };
             runs.push(Run::control(control, char_shape_id));
+            FieldEmissionOutcome::Folded
         }
         ActiveField::DateCodeField { start_utf16, raw_command, display_text } => {
             // Emit Control::DateCodeField with `is_time_mode` derived
@@ -1717,6 +2028,7 @@ fn finish_active_field(
                 Control::DateCodeField { is_time_mode, display_text },
                 char_shape_id,
             ));
+            FieldEmissionOutcome::Folded
         }
         ActiveField::PathField { start_utf16, raw_command, display_text } => {
             // Map raw `$P`/`$F`/`$P$F` to a typed PathFieldCommand
@@ -1730,6 +2042,7 @@ fn finish_active_field(
             use hwpforge_core::control::PathFieldCommand;
             let command = PathFieldCommand::from_wire(&raw_command);
             runs.push(Run::control(Control::PathField { command, display_text }, char_shape_id));
+            FieldEmissionOutcome::Folded
         }
     }
 }
@@ -3342,6 +3655,7 @@ mod tests {
 
     fn make_paragraph(text: &str, para_shape_id: u16, style_id: u8) -> Hwp5Paragraph {
         Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: text.to_string(),
@@ -3356,6 +3670,7 @@ mod tests {
 
     fn _make_paragraph_with_runs(text: &str, runs: Vec<Hwp5CharShapeRun>) -> Hwp5Paragraph {
         Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: text.to_string(),
@@ -3395,7 +3710,14 @@ mod tests {
                 tag: 0x0016_0000,
             },
         ];
-        let cache = promote_line_segments(&segs).expect("promoted");
+        let mut warnings = Vec::new();
+        let identity = {
+            let mut b = crate::wire_text_map::WireMapBuilder::new();
+            b.advance_identity(64);
+            b.finish().expect("identity map")
+        };
+        let cache = promote_line_segments(&segs, Ok(identity), &mut warnings).expect("promoted");
+        assert!(warnings.is_empty(), "identity promote must not warn: {warnings:?}");
         assert_eq!(cache.line_count(), 2);
         // 필드 대응: 이름만 다르고 wire 의미 동일 (textpos/vertpos/vertsize/…)
         assert_eq!(cache.lines[0].horzpos, 10);
@@ -3406,8 +3728,10 @@ mod tests {
         assert_eq!(cache.lines[1].baseline, 850);
         assert_eq!(cache.lines[1].spacing, 600);
         assert_eq!(cache.lines[1].flags, 0x0016_0000);
-        // 세그먼트 없음 = 캐시 부재
-        assert!(promote_line_segments(&[]).is_none());
+        // 세그먼트 없음 = 캐시 부재 (경고도 없음)
+        let empty_map = crate::wire_text_map::WireMapBuilder::new().finish().expect("empty");
+        assert!(promote_line_segments(&[], Ok(empty_map), &mut warnings).is_none());
+        assert!(warnings.is_empty());
     }
 
     fn make_section(
@@ -3573,6 +3897,7 @@ mod tests {
             segments.push(crate::schema::section::TextSegment::ControlRef { extra: [0u8; 14] });
         }
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             text: String::new(),
             text_segments: segments,
             para_shape_id: 0,
@@ -3608,6 +3933,7 @@ mod tests {
         let form_id = u32::from_be_bytes(*b"form"); // 기지 deferred ctrl
         let mk = || Hwp5Control::Unknown { ctrl_id: form_id, header_data: vec![] };
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             text: String::new(),
             text_segments: vec![
                 crate::schema::section::TextSegment::ControlRef { extra: [0u8; 14] },
@@ -3697,6 +4023,7 @@ mod tests {
         });
         let section = make_section(
             vec![Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "앞\u{fffc}뒤".to_string(),
@@ -3755,6 +4082,7 @@ mod tests {
         });
         let section = make_section(
             vec![Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "\u{fffc}\u{fffc}".to_string(),
@@ -3769,6 +4097,7 @@ mod tests {
                         properties_raw: 0,
                         instance_id: 0,
                         paragraphs: vec![Hwp5Paragraph {
+                            silent_wires: Vec::new(),
                             page_break: false,
                             column_break: false,
                             text: "\u{fffc}".to_string(),
@@ -3830,6 +4159,7 @@ mod tests {
             },
             list_header_properties: None,
             paragraphs: vec![Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "앞\u{fffc}뒤".to_string(),
@@ -3843,6 +4173,7 @@ mod tests {
         });
         let section = make_section(
             vec![Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "\u{fffc}".to_string(),
@@ -3908,6 +4239,7 @@ mod tests {
         });
         let section = make_section(
             vec![Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "\u{fffc}".to_string(),
@@ -3949,6 +4281,7 @@ mod tests {
         });
         let section = make_section(
             vec![Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "\u{fffc}".to_string(),
@@ -3996,6 +4329,7 @@ mod tests {
         });
         let section = make_section(
             vec![Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "\u{fffc}".to_string(),
@@ -4096,6 +4430,7 @@ mod tests {
     #[test]
     fn table_control_becomes_run_table() {
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: String::new(),
@@ -4147,6 +4482,7 @@ mod tests {
             vertical_align: crate::decoder::section::Hwp5TableCellVerticalAlign::Center,
             border_fill_id: None,
             paragraphs: vec![Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "셀".to_string(),
@@ -4162,6 +4498,7 @@ mod tests {
 
     fn grid_test_table_paragraph(rows: u16, cols: u16, cells: Vec<Hwp5TableCell>) -> Hwp5Paragraph {
         Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4238,6 +4575,7 @@ mod tests {
     #[test]
     fn table_cell_text_is_projected() {
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4270,6 +4608,7 @@ mod tests {
                     vertical_align: crate::decoder::section::Hwp5TableCellVerticalAlign::Center,
                     border_fill_id: Some(3),
                     paragraphs: vec![Hwp5Paragraph {
+                        silent_wires: Vec::new(),
                         page_break: false,
                         column_break: false,
                         text: "셀".to_string(),
@@ -4313,6 +4652,7 @@ mod tests {
     #[test]
     fn unknown_table_cell_vertical_align_emits_projection_fallback_warning() {
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4345,6 +4685,7 @@ mod tests {
                     vertical_align: crate::decoder::section::Hwp5TableCellVerticalAlign::Unknown(3),
                     border_fill_id: Some(3),
                     paragraphs: vec![Hwp5Paragraph {
+                        silent_wires: Vec::new(),
                         page_break: false,
                         column_break: false,
                         text: "셀".to_string(),
@@ -4387,6 +4728,7 @@ mod tests {
     #[test]
     fn mixed_table_header_cells_emit_warning_and_do_not_promote_header_row() {
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4420,6 +4762,7 @@ mod tests {
                         vertical_align: crate::decoder::section::Hwp5TableCellVerticalAlign::Center,
                         border_fill_id: Some(3),
                         paragraphs: vec![Hwp5Paragraph {
+                            silent_wires: Vec::new(),
                             page_break: false,
                             column_break: false,
                             text: "head".to_string(),
@@ -4448,6 +4791,7 @@ mod tests {
                         vertical_align: crate::decoder::section::Hwp5TableCellVerticalAlign::Center,
                         border_fill_id: Some(3),
                         paragraphs: vec![Hwp5Paragraph {
+                            silent_wires: Vec::new(),
                             page_break: false,
                             column_break: false,
                             text: "body".to_string(),
@@ -4504,6 +4848,7 @@ mod tests {
                 vertical_align: crate::decoder::section::Hwp5TableCellVerticalAlign::Center,
                 border_fill_id: Some(3),
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: text.to_string(),
@@ -4518,6 +4863,7 @@ mod tests {
         }
 
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4588,6 +4934,7 @@ mod tests {
                 vertical_align: crate::decoder::section::Hwp5TableCellVerticalAlign::Center,
                 border_fill_id: None,
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: String::new(),
@@ -4606,6 +4953,7 @@ mod tests {
         }
 
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4643,6 +4991,7 @@ mod tests {
         // body-only scan would have returned the later top-level control).
         fn pgnp_para(pos_byte: u8) -> Hwp5Paragraph {
             Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "\u{FFFC}".to_string(),
@@ -4677,6 +5026,7 @@ mod tests {
                 paragraphs: vec![pgnp_para(pos_byte)],
             };
             Hwp5Paragraph {
+                silent_wires: Vec::new(),
                 page_break: false,
                 column_break: false,
                 text: "\u{FFFC}".to_string(),
@@ -4719,6 +5069,7 @@ mod tests {
         // surrounding text runs, inside a single Core paragraph — never on
         // its own line / paragraph, and never drained to the paragraph tail.
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "앞\u{FFFC}뒤".to_string(),
@@ -4732,6 +5083,7 @@ mod tests {
                 properties_raw: 0,
                 instance_id: 7,
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: "각주 본문".to_string(),
@@ -4781,6 +5133,7 @@ mod tests {
     #[test]
     fn line_control_becomes_visible_core_line() {
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4821,6 +5174,7 @@ mod tests {
     #[test]
     fn polygon_control_becomes_visible_core_polygon() {
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4877,6 +5231,7 @@ mod tests {
     #[test]
     fn rect_control_carries_into_core_rect_without_warning() {
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "\u{FFFC}".to_string(),
@@ -4920,6 +5275,7 @@ mod tests {
     #[test]
     fn unknown_control_is_ignored() {
         let para = Hwp5Paragraph {
+            silent_wires: Vec::new(),
             page_break: false,
             column_break: false,
             text: "text".to_string(),

--- a/crates/hwpforge-smithy-hwp5/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwp5/src/schema/section.rs
@@ -199,6 +199,21 @@ pub(crate) enum TextSegment {
     FwSpace,
 }
 
+/// segment 를 방출하지 않고 무음 소비된 wire 구간 (문단 시작 기준 u16 단위).
+///
+/// W1b ledger 의 유일한 추가 진실원 — segment 가 있는 소비는 종류에서
+/// wire 길이가 유도되지만 (Text=UTF-16 len · Tab/컨트롤=8 · 단일=1),
+/// 무음 소비 (`0x00`·`0x01`·`0x05~0x08`·`0x13/0x14`·비승격
+/// `0x11/0x12/0x15/0x16`·`0x0E~0x10`·`0x1E`) 는 여기 기록하지 않으면
+/// 좌표 정규화가 그만큼 어긋난다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SilentWire {
+    /// wire 시작 위치 (문단 시작 기준 u16 단위).
+    pub start: u32,
+    /// wire 소비 유닛 수 (확장/인라인 컨트롤=8, 단일 제어문자=1).
+    pub len: u32,
+}
+
 /// Parsed from a `ParaText` (tag `0x43`) record in a BodyText section.
 ///
 /// Contains the decoded text of one paragraph as a sequence of typed
@@ -208,6 +223,8 @@ pub(crate) enum TextSegment {
 pub(crate) struct Hwp5ParaText {
     /// Decoded text segments in paragraph order.
     pub segments: Vec<TextSegment>,
+    /// segment 없이 무음 소비된 wire 구간들 (start 오름차순 — W1b ledger).
+    pub silent_wires: Vec<SilentWire>,
 }
 
 impl Hwp5ParaText {
@@ -236,6 +253,7 @@ impl Hwp5ParaText {
             data.chunks_exact(2).map(|b| u16::from_le_bytes([b[0], b[1]])).collect();
 
         let mut segments: Vec<TextSegment> = Vec::new();
+        let mut silent_wires: Vec<SilentWire> = Vec::new();
         let mut text_buf: Vec<u16> = Vec::new();
         let mut i = 0usize;
 
@@ -284,14 +302,22 @@ impl Hwp5ParaText {
 
             match cp {
                 // Reserved single-wchar control.
-                0x00 => {}
+                //
+                // W1b: 무음 1유닛 소비 — 텍스트 버퍼를 쪼개 flush 해야
+                // ledger 의 wire 구간이 연속 텍스트와 섞이지 않는다
+                // (segments_to_string 결과는 동일).
+                0x00 => {
+                    flush_text!();
+                    silent_wires.push(SilentWire { start: (i - 1) as u32, len: 1 });
+                }
 
                 // Extended controls: 8 wchars total (1 control + 7 extra u16).
                 // 0x01 = reserved extended control.
                 0x01 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let _extra = read_extra!(i - 1);
-                    // No segment emitted — consumed silently.
+                    silent_wires.push(SilentWire { start: seg_start, len: 8 });
                 }
                 0x02 => {
                     flush_text!();
@@ -315,8 +341,9 @@ impl Hwp5ParaText {
                 }
                 0x13 | 0x14 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let _extra = read_extra!(i - 1);
-                    // Unsupported inline control — consumed silently.
+                    silent_wires.push(SilentWire { start: seg_start, len: 8 });
                 }
                 // 0x17: dutmal (덧말) inline marker.
                 // `extra[0..4]` carries the BE-ascii ctrl_id `tdut` for the
@@ -337,11 +364,13 @@ impl Hwp5ParaText {
                 // family whose CtrlHeader we don't yet decode.
                 0x16 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let extra = read_extra!(i - 1);
                     if ctrl_id_from_inline_extra_bytes(&extra) == CTRL_ID_INDEXMARK {
                         segments.push(TextSegment::ControlRef { extra });
+                    } else {
+                        silent_wires.push(SilentWire { start: seg_start, len: 8 });
                     }
-                    // Else: consumed silently, same as 0x0E..=0x15 below.
                 }
                 // 0x12: extended control — Wave 12n discovered that
                 // `atno` inline page-number markers ride this control
@@ -351,11 +380,13 @@ impl Hwp5ParaText {
                 // accidentally promoting an unknown control family.
                 0x12 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let extra = read_extra!(i - 1);
                     if ctrl_id_from_inline_extra_bytes(&extra) == CTRL_ID_ATNO {
                         segments.push(TextSegment::ControlRef { extra });
+                    } else {
+                        silent_wires.push(SilentWire { start: seg_start, len: 8 });
                     }
-                    // Else: consumed silently, same as 0x0E..=0x10 / 0x13..=0x15 below.
                 }
                 // 0x11: 각주/미주 (footnote/endnote) inline reference marker
                 // (HWP 5.0 spec rev 1.3 표 6 코드 17 — "각주/미주", extended).
@@ -373,14 +404,16 @@ impl Hwp5ParaText {
                 // CtrlHeader we don't decode (mirrors the 0x12/0x16 guards).
                 0x11 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let extra = read_extra!(i - 1);
                     if matches!(
                         ctrl_id_from_inline_extra_bytes(&extra),
                         CTRL_ID_FOOTNOTE | CTRL_ID_ENDNOTE
                     ) {
                         segments.push(TextSegment::ControlRef { extra });
+                    } else {
+                        silent_wires.push(SilentWire { start: seg_start, len: 8 });
                     }
-                    // Else: consumed silently, same as 0x0E..=0x10 below.
                 }
                 // 0x15: page-control marker (새 번호 `nwno`·감추기 `pghd`·
                 // 쪽번호 위치 `pgnp` 공유 — F1/F2 실측 2026-08-12). `nwno`
@@ -391,14 +424,16 @@ impl Hwp5ParaText {
                 // 큐 정렬이 유지된다.
                 0x15 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let extra = read_extra!(i - 1);
                     if matches!(
                         ctrl_id_from_inline_extra_bytes(&extra),
                         CTRL_ID_NEW_NUMBER | CTRL_ID_PAGE_HIDING
                     ) {
                         segments.push(TextSegment::ControlRef { extra });
+                    } else {
+                        silent_wires.push(SilentWire { start: seg_start, len: 8 });
                     }
-                    // Else (pgnp/미지 owner): consumed silently.
                 }
                 // 0x0E-0x10: extended controls (bookmarks, change tracking,
                 // etc. — 0x11/0x12/0x13/0x14/0x15 는 위의 전용 arm). All
@@ -406,8 +441,9 @@ impl Hwp5ParaText {
                 // a future slice promotes them to a typed variant.
                 0x0E..=0x10 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let _extra = read_extra!(i - 1);
-                    // No segment emitted — consumed silently.
+                    silent_wires.push(SilentWire { start: seg_start, len: 8 });
                 }
 
                 // Inline controls: 8 wchars total (1 control + 7 extra u16).
@@ -418,13 +454,16 @@ impl Hwp5ParaText {
                 }
                 0x05..=0x07 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let _extra = read_extra!(i - 1);
-                    // Unsupported inline control — consumed silently.
+                    silent_wires.push(SilentWire { start: seg_start, len: 8 });
                 }
                 0x08 => {
                     flush_text!();
+                    let seg_start = (i - 1) as u32;
                     let _extra = read_extra!(i - 1);
-                    // Title mark is not modeled in Core IR yet.
+                    // Title mark is not modeled in Core IR yet — 무음 8유닛.
+                    silent_wires.push(SilentWire { start: seg_start, len: 8 });
                 }
                 0x09 => {
                     flush_text!();
@@ -457,6 +496,7 @@ impl Hwp5ParaText {
                 0x1E => {
                     flush_text!();
                     // Hard hyphen — not modeled in Core yet; consumed silently.
+                    silent_wires.push(SilentWire { start: (i - 1) as u32, len: 1 });
                 }
 
                 // Everything else: normal character.
@@ -469,7 +509,7 @@ impl Hwp5ParaText {
         // Flush any trailing text.
         flush_text!();
 
-        Ok(Self { segments })
+        Ok(Self { segments, silent_wires })
     }
 }
 

--- a/crates/hwpforge-smithy-hwp5/src/semantic_adapter.rs
+++ b/crates/hwpforge-smithy-hwp5/src/semantic_adapter.rs
@@ -1321,6 +1321,7 @@ mod tests {
             doc_info: empty_doc_info(),
             sections: vec![SectionResult {
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: "\u{fffc}본문".to_string(),
@@ -1354,6 +1355,7 @@ mod tests {
                                 vertical_align: Hwp5TableCellVerticalAlign::Bottom,
                                 border_fill_id: Some(3),
                                 paragraphs: vec![Hwp5Paragraph {
+                                    silent_wires: Vec::new(),
                                     page_break: false,
                                     column_break: false,
                                     text: "cell".to_string(),
@@ -1562,6 +1564,7 @@ mod tests {
             doc_info: empty_doc_info(),
             sections: vec![SectionResult {
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: "앞\u{fffc}뒤".to_string(),
@@ -1608,6 +1611,7 @@ mod tests {
             doc_info: empty_doc_info(),
             sections: vec![SectionResult {
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: "\u{fffc}".to_string(),
@@ -1660,6 +1664,7 @@ mod tests {
             doc_info: empty_doc_info(),
             sections: vec![SectionResult {
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: "앞\u{fffc}뒤".to_string(),
@@ -1745,6 +1750,7 @@ mod tests {
             doc_info: empty_doc_info(),
             sections: vec![SectionResult {
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: "\u{fffc}".to_string(),
@@ -1801,6 +1807,7 @@ mod tests {
             doc_info: empty_doc_info(),
             sections: vec![SectionResult {
                 paragraphs: vec![Hwp5Paragraph {
+                    silent_wires: Vec::new(),
                     page_break: false,
                     column_break: false,
                     text: "\u{fffc}".to_string(),
@@ -1819,6 +1826,7 @@ mod tests {
                         },
                         list_header_properties: None,
                         paragraphs: vec![Hwp5Paragraph {
+                            silent_wires: Vec::new(),
                             page_break: false,
                             column_break: false,
                             text: "글상자 시작.\u{fffc}글상자 끝.".to_string(),

--- a/crates/hwpforge-smithy-hwp5/src/wire_text_map.rs
+++ b/crates/hwpforge-smithy-hwp5/src/wire_text_map.rs
@@ -1,0 +1,358 @@
+//! Wire↔Core 텍스트 좌표 맵 (W1b) — 이 crate 내부 전용.
+//!
+//! wire 좌표(HWP5 raw 스트림 = 한컴 HWPX linesegarray textpos 규약)와
+//! Core 정준 좌표(`Paragraph::text_content()` UTF-16 축) 사이의 변환을
+//! 담당한다. 설계 정본: `.docs/planning/2026-08-13-image-textbox-epic.md`
+//! §1g v5 (Codex 4라운드 확정 수학 법칙).
+//!
+//! ## 모델
+//!
+//! 문단의 wire 스트림은 **비-1:1 span** (marker `(8,0)`, tab `(8,1)`,
+//! 무음 소비 `(1,0)` 등) 과 그 사이의 **1:1 구간** (일반 텍스트) 으로
+//! 구성된다. 맵은 비-1:1 span 만 보유하며 (1:1 span 은 push 시점에
+//! identity 로 흡수), 총길이 `wire_end`/`core_end` 를 seal 시점에 고정한다.
+//!
+//! ## 법칙 (v5 확정 — proptest 로 잠금)
+//!
+//! - 입력 domain = inclusive `[0, wire_end]` / `[0, core_end]`, 밖은 Err.
+//! - `to_core(0) = 0` · `to_wire(0) = 0` 무조건 성립 (canonicalization —
+//!   native 291파일·13,598 linesegarray 전수에서 첫 lineseg textpos=0
+//!   100% 실측).
+//! - 1:1 **열린 구간에서만** 양방향 합성이 identity.
+//! - 비-1:1 span 의 wire strict interior 는 `to_core = Err`.
+//! - 동일 core 좌표에 wire preimage 2개 이상이면 `to_wire = Err`
+//!   (단 core 0 은 canonicalization 으로 항상 wire 0).
+//!
+//! ⚠️ smithy-hwpx 의 동명 모듈과 **to_core 방향 동형** — conformance
+//! vector 테스트를 양쪽에 복제해 drift 를 방지한다 (Core 승격은 계층
+//! 누수라 기각, §1g v2 disposition #2). **`to_wire` 는 이 crate 에
+//! 없다**: HWP5 writer 가 없어 역변환 수요가 없음 (v4 disposition #10
+//! YAGNI — 필요해지는 시점에 hwpx 모듈에서 conformance 와 함께 복제).
+
+use std::fmt;
+
+/// 비-1:1 wire 소비 구간 하나.
+///
+/// `wire_len != core_len` 이 불변식이다 (1:1 은 span 이 아니라 구간).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WireSpan {
+    /// wire 좌표계에서의 시작 위치.
+    pub wire_start: u32,
+    /// wire 유닛 소비량 (≥ 1).
+    pub wire_len: u32,
+    /// Core 축 기여량 (marker=0, tab=1 등).
+    pub core_len: u32,
+}
+
+/// 좌표 변환/맵 구성 실패 사유.
+///
+/// 캐시 fail-closed 경고(`DecodeWarning`/`EncodeWarning`)의 payload 로
+/// 전파된다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CacheMapError {
+    /// 질의 좌표가 `[0, wire_end]` / `[0, core_end]` 밖.
+    OutOfRange {
+        /// 질의 좌표.
+        pos: u32,
+        /// 해당 축의 총길이.
+        end: u32,
+    },
+    /// `to_core` 질의가 비-1:1 span 의 strict interior 에 위치.
+    InsideContraction {
+        /// 질의 wire 좌표.
+        wire: u32,
+    },
+    /// span 정렬/중첩/불변식 위반 또는 checked 산술 overflow.
+    InvalidSpans,
+}
+
+impl fmt::Display for CacheMapError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutOfRange { pos, end } => {
+                write!(f, "coordinate {pos} outside [0, {end}]")
+            }
+            Self::InsideContraction { wire } => {
+                write!(f, "wire {wire} inside a non-1:1 span interior")
+            }
+            Self::InvalidSpans => write!(f, "span set violates map invariants"),
+        }
+    }
+}
+
+/// seal 된 wire↔Core 좌표 맵.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WireTextMap {
+    /// 비-1:1 span 들 (wire_start 오름차순, 비중첩).
+    spans: Vec<WireSpan>,
+    /// wire 축 총길이.
+    wire_end: u32,
+    /// Core 축 총길이.
+    core_end: u32,
+}
+
+impl WireTextMap {
+    /// wire 축 총길이 (현재 테스트 전용 — lib 소비자가 생기면 게이트 해제).
+    #[cfg(test)]
+    pub(crate) fn wire_end(&self) -> u32 {
+        self.wire_end
+    }
+
+    /// Core 축 총길이.
+    pub(crate) fn core_end(&self) -> u32 {
+        self.core_end
+    }
+
+    /// wire 좌표 → Core 좌표.
+    pub(crate) fn to_core(&self, wire: u32) -> Result<u32, CacheMapError> {
+        if wire > self.wire_end {
+            return Err(CacheMapError::OutOfRange { pos: wire, end: self.wire_end });
+        }
+        let mut wire_cursor = 0u32;
+        let mut core_cursor = 0u32;
+        for span in &self.spans {
+            if wire <= span.wire_start {
+                // 1:1 구간 (span 시작점 포함 — 시작점의 core 값은 구간
+                // 공식과 동일).
+                return Ok(core_cursor + (wire - wire_cursor));
+            }
+            let span_end = span.wire_start + span.wire_len;
+            if wire < span_end {
+                return Err(CacheMapError::InsideContraction { wire });
+            }
+            core_cursor += (span.wire_start - wire_cursor) + span.core_len;
+            wire_cursor = span_end;
+        }
+        Ok(core_cursor + (wire - wire_cursor))
+    }
+}
+
+/// [`WireTextMap`] 증분 구성기.
+///
+/// 변환기(디코더/projection/인코더 방출부)가 **wire 순서대로** 소비를
+/// 기록한다: 1:1 텍스트는 [`advance_identity`], 비-1:1 소비는
+/// [`push_span`]. [`finish`] 가 불변식 검증 후 seal 한다.
+///
+/// field pending(begin~end 사이 core 기여 확정 지연)은 변환기 측 책임 —
+/// 이 빌더는 확정된 소비만 순서대로 받는다 (v5 lifecycle: FieldEnd 에서
+/// wire 순서대로 commit).
+///
+/// [`advance_identity`]: WireMapBuilder::advance_identity
+/// [`push_span`]: WireMapBuilder::push_span
+/// [`finish`]: WireMapBuilder::finish
+#[derive(Debug, Default)]
+pub(crate) struct WireMapBuilder {
+    spans: Vec<WireSpan>,
+    wire_cursor: u32,
+    core_cursor: u32,
+    overflowed: bool,
+}
+
+impl WireMapBuilder {
+    /// 새 빌더 (빈 문단 = 그대로 `finish` 하면 `(0,0)` 맵).
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// 1:1 구간 전진 (일반 텍스트 UTF-16 `units`).
+    pub(crate) fn advance_identity(&mut self, units: u32) {
+        match (self.wire_cursor.checked_add(units), self.core_cursor.checked_add(units)) {
+            (Some(w), Some(c)) => {
+                self.wire_cursor = w;
+                self.core_cursor = c;
+            }
+            _ => self.overflowed = true,
+        }
+    }
+
+    /// 비-1:1 소비 기록 (`wire_len != core_len`).
+    ///
+    /// `wire_len == core_len` 이면 identity 로 흡수한다 (span 최소성).
+    pub(crate) fn push_span(&mut self, wire_len: u32, core_len: u32) {
+        if wire_len == core_len {
+            self.advance_identity(wire_len);
+            return;
+        }
+        if wire_len == 0 {
+            // core 만 늘어나는 span 은 존재하지 않음 (markpen 은 (0,0) —
+            // 어느 축도 소비하지 않으므로 기록 자체가 불필요).
+            self.overflowed = true;
+            return;
+        }
+        let span = WireSpan { wire_start: self.wire_cursor, wire_len, core_len };
+        match (self.wire_cursor.checked_add(wire_len), self.core_cursor.checked_add(core_len)) {
+            (Some(w), Some(c)) => {
+                self.wire_cursor = w;
+                self.core_cursor = c;
+                self.spans.push(span);
+            }
+            _ => self.overflowed = true,
+        }
+    }
+
+    /// 불변식 검증 후 seal.
+    ///
+    /// 검증: overflow 부재 · span 정렬/비중첩 · `wire_len != core_len` ·
+    /// 누적 합 == 커서 (구성 오류 방어).
+    pub(crate) fn finish(self) -> Result<WireTextMap, CacheMapError> {
+        if self.overflowed {
+            return Err(CacheMapError::InvalidSpans);
+        }
+        let mut expect_wire = 0u32;
+        let mut expect_core = 0u32;
+        for span in &self.spans {
+            if span.wire_start < expect_wire || span.wire_len == 0 || span.wire_len == span.core_len
+            {
+                return Err(CacheMapError::InvalidSpans);
+            }
+            expect_core = expect_core
+                .checked_add(span.wire_start - expect_wire)
+                .and_then(|c| c.checked_add(span.core_len))
+                .ok_or(CacheMapError::InvalidSpans)?;
+            expect_wire =
+                span.wire_start.checked_add(span.wire_len).ok_or(CacheMapError::InvalidSpans)?;
+        }
+        // trailing 1:1 구간 반영.
+        let tail = self.wire_cursor.checked_sub(expect_wire).ok_or(CacheMapError::InvalidSpans)?;
+        expect_core = expect_core.checked_add(tail).ok_or(CacheMapError::InvalidSpans)?;
+        if expect_core != self.core_cursor {
+            return Err(CacheMapError::InvalidSpans);
+        }
+        Ok(WireTextMap {
+            spans: self.spans,
+            wire_end: self.wire_cursor,
+            core_end: self.core_cursor,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// conformance vector — smithy-hwpx 의 동명 모듈 테스트와 to_core
+    /// 방향에서 동일하게 유지할 것 (동형성 게이트).
+    fn marker_ledger_p1() -> WireTextMap {
+        // rules-marker-ledger p1: 텍스트 17유닛 + nwno(8,0)×2 + 텍스트.
+        // raw lineseg [0, 76, 132] → core [0, 60, 116].
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(17);
+        b.push_span(8, 0);
+        b.push_span(8, 0);
+        b.advance_identity(148 - 33);
+        b.finish().expect("valid map")
+    }
+
+    #[test]
+    fn empty_paragraph_succeeds_only_at_zero() {
+        let map = WireMapBuilder::new().finish().expect("empty map");
+        assert_eq!(map.wire_end(), 0);
+        assert_eq!(map.core_end(), 0);
+        assert_eq!(map.to_core(0), Ok(0));
+        assert_eq!(map.to_core(1), Err(CacheMapError::OutOfRange { pos: 1, end: 0 }));
+    }
+
+    #[test]
+    fn control_only_paragraph_collapses_to_core_zero() {
+        let mut b = WireMapBuilder::new();
+        b.push_span(8, 0);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.wire_end(), 8);
+        assert_eq!(map.core_end(), 0);
+        assert_eq!(map.to_core(0), Ok(0));
+        assert_eq!(map.to_core(8), Ok(0));
+        assert_eq!(map.to_core(3), Err(CacheMapError::InsideContraction { wire: 3 }));
+    }
+
+    #[test]
+    fn leading_marker_prelude_normalizes_to_core_zero() {
+        // HWP5 첫 문단 프렐류드 (secd+cold = 16유닛) 후 텍스트 4유닛.
+        let mut b = WireMapBuilder::new();
+        b.push_span(8, 0);
+        b.push_span(8, 0);
+        b.advance_identity(4);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.to_core(0), Ok(0));
+        assert_eq!(map.to_core(8), Ok(0));
+        assert_eq!(map.to_core(16), Ok(0));
+        assert_eq!(map.to_core(20), Ok(4));
+    }
+
+    #[test]
+    fn golden_marker_ledger_p1_normalization() {
+        let map = marker_ledger_p1();
+        assert_eq!(map.to_core(0), Ok(0));
+        assert_eq!(map.to_core(76), Ok(60));
+        assert_eq!(map.to_core(132), Ok(116));
+    }
+
+    #[test]
+    fn marker_interior_is_error() {
+        let map = marker_ledger_p1();
+        for w in [18u32, 20, 24, 26, 30, 32] {
+            assert_eq!(
+                map.to_core(w),
+                Err(CacheMapError::InsideContraction { wire: w }),
+                "wire {w}"
+            );
+        }
+        assert_eq!(map.to_core(17), Ok(17));
+        assert_eq!(map.to_core(25), Ok(17));
+        assert_eq!(map.to_core(33), Ok(17));
+    }
+
+    #[test]
+    fn tab_span_maps_core_contribution() {
+        // "ab" + tab(8,1) + "cd".
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(2);
+        b.push_span(8, 1);
+        b.advance_identity(2);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.wire_end(), 12);
+        assert_eq!(map.core_end(), 5);
+        assert_eq!(map.to_core(2), Ok(2));
+        assert_eq!(map.to_core(10), Ok(3));
+        assert_eq!(map.to_core(12), Ok(5));
+        assert_eq!(map.to_core(5), Err(CacheMapError::InsideContraction { wire: 5 }));
+    }
+
+    #[test]
+    fn single_unit_silent_consumption() {
+        // "a" + 0x1E(1,0) + "b".
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(1);
+        b.push_span(1, 0);
+        b.advance_identity(1);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.to_core(1), Ok(1));
+        assert_eq!(map.to_core(2), Ok(1));
+        assert_eq!(map.to_core(3), Ok(2));
+    }
+
+    #[test]
+    fn identity_sized_span_is_absorbed() {
+        let mut b = WireMapBuilder::new();
+        b.push_span(1, 1);
+        b.advance_identity(3);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.wire_end(), 4);
+        assert_eq!(map.core_end(), 4);
+        assert_eq!(map.to_core(2), Ok(2));
+    }
+
+    #[test]
+    fn overflow_is_rejected_at_finish() {
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(u32::MAX);
+        b.push_span(8, 0);
+        assert_eq!(b.finish(), Err(CacheMapError::InvalidSpans));
+    }
+
+    #[test]
+    fn zero_wire_span_is_rejected() {
+        let mut b = WireMapBuilder::new();
+        b.push_span(0, 1);
+        assert_eq!(b.finish(), Err(CacheMapError::InvalidSpans));
+    }
+}

--- a/crates/hwpforge-smithy-hwpx/Cargo.toml
+++ b/crates/hwpforge-smithy-hwpx/Cargo.toml
@@ -35,3 +35,4 @@ zip = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+proptest = { workspace = true }

--- a/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/mod.rs
@@ -61,6 +61,87 @@ pub enum DecodeWarning {
         /// 폴백한 값의 wire 표기.
         fallback: &'static str,
     },
+    /// 문단의 linesegarray 캐시가 Core 로 승격되지 않음 — wire→Core
+    /// 좌표 ledger 구축 실패 또는 textpos 정규화 실패 (W1b fail-closed,
+    /// 추측 좌표 승격 금지).
+    LayoutCacheDropped {
+        /// 경고가 난 문단의 중첩 경로.
+        path: ParagraphPath,
+        /// 구체 사유 (ledger 실패 원인 또는 문제 textpos).
+        reason: String,
+    },
+}
+
+/// 디코드 경고가 가리키는 문단의 중첩 경로 (§1g v5 변경 5).
+///
+/// `(section, paragraph)` 튜플로는 셀/머리말/각주 내부 문단을 표현할 수
+/// 없어 ordered segment vector 로 기록한다. `Section` 으로 시작해 최종
+/// 문단 segment 로 끝난다 — sublist 진입 시 인덱스를 리셋하거나 depth
+/// 만 전달하지 않는다.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ParagraphPath(pub Vec<PathSeg>);
+
+/// [`ParagraphPath`] 의 segment 하나.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PathSeg {
+    /// 구역 인덱스.
+    Section(usize),
+    /// 본문 문단 인덱스.
+    BodyParagraph(usize),
+    /// 머리말 인덱스.
+    Header(usize),
+    /// 꼬리말 인덱스.
+    Footer(usize),
+    /// run 인덱스.
+    Run(usize),
+    /// 표 셀 (행, 셀).
+    TableCell {
+        /// 행 인덱스.
+        row: usize,
+        /// 셀 인덱스.
+        cell: usize,
+    },
+    /// 캡션 내부.
+    Caption,
+    /// 각주 내부.
+    Footnote,
+    /// 미주 내부.
+    Endnote,
+    /// 글상자 내부.
+    TextBox,
+    /// 메모 내부.
+    Memo,
+    /// 묶음 객체 자식 인덱스.
+    GroupChild(usize),
+    /// 중첩 sublist 문단 인덱스 (컨테이너 내부 문단).
+    NestedParagraph(usize),
+}
+
+impl std::fmt::Display for ParagraphPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (i, seg) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, ".")?;
+            }
+            match seg {
+                PathSeg::Section(n) => write!(f, "section[{n}]")?,
+                PathSeg::BodyParagraph(n) => write!(f, "para[{n}]")?,
+                PathSeg::Header(n) => write!(f, "header[{n}]")?,
+                PathSeg::Footer(n) => write!(f, "footer[{n}]")?,
+                PathSeg::Run(n) => write!(f, "run[{n}]")?,
+                PathSeg::TableCell { row, cell } => write!(f, "cell[{row}][{cell}]")?,
+                PathSeg::Caption => write!(f, "caption")?,
+                PathSeg::Footnote => write!(f, "footnote")?,
+                PathSeg::Endnote => write!(f, "endnote")?,
+                PathSeg::TextBox => write!(f, "textbox")?,
+                PathSeg::Memo => write!(f, "memo")?,
+                PathSeg::GroupChild(n) => write!(f, "group[{n}]")?,
+                PathSeg::NestedParagraph(n) => write!(f, "npara[{n}]")?,
+            }
+        }
+        Ok(())
+    }
 }
 
 // ── HwpxDecoder ──────────────────────────────────────────────────

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -27,9 +27,9 @@ use quick_xml::de::from_str;
 use crate::color::parse_hex_color_raw;
 use crate::error::{HwpxError, HwpxResult};
 use crate::schema::section::{
-    HxCaption, HxChart, HxCompose, HxCtrl, HxDutmal, HxEquation, HxFieldBegin, HxFootNote,
-    HxHeaderFooter, HxPageNum, HxParagraph, HxPic, HxRun, HxSection, HxSubList, HxTable,
-    HxTableCell, HxTableRow,
+    legacy_child_order, HxCaption, HxChart, HxCompose, HxCtrl, HxDutmal, HxEquation, HxFieldBegin,
+    HxFootNote, HxHeaderFooter, HxPageNum, HxParagraph, HxPic, HxRun, HxRunChildKind, HxSection,
+    HxSubList, HxTable, HxTableCell, HxTableRow,
 };
 
 /// Maximum nesting depth for tables-within-tables.
@@ -398,56 +398,151 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
     let char_shape_id = CharShapeIndex::new(hx.char_pr_id_ref as usize);
     let mut runs = Vec::new();
 
-    // Check if this run has a fieldBegin+fieldEnd pair — if so, the text
-    // is consumed by the field control and should NOT be emitted separately.
-    let has_field_pair = hx.ctrls.iter().any(|c| c.field_begin.is_some())
-        && hx.ctrls.iter().any(|c| c.field_end.is_some());
-
-    // Text runs — skip if consumed by field controls.
+    // W1a (이미지/글상자 에픽): 자식을 **문서 순서**(child_order 사이드카)로
+    // 평탄화한다 — 종전 by-kind 고정 순서는 `<t>a</t><pic/><t>b</t>` 를
+    // Core `[a, b, pic]` 으로 재배열해 인라인 객체의 앵커 위치를 왜곡했다.
+    //
+    // field pairing 도 순서 기반: fieldBegin 과 fieldEnd **사이**의 텍스트
+    // 자식이 곧 필드 본문이다 — 종전의 `texts.len()==1` 모호성 다운그레이드
+    // (gotcha #30)는 순서 보존으로 철폐. begin 앞/end 뒤 텍스트는 정상
+    // 방출된다 (종전엔 pair 존재 시 run 의 전 텍스트가 드롭 — 한컴 병합
+    // run 의 충실도 개선).
     //
     // `HxText::to_run_content` preserves any `<hp:tab>` attribute payload
-    // (`width` / `leader` / `tab_type`) as `RunContent::InlineText`,
-    // falling back to the existing `RunContent::Text(String)` when every
-    // tab is attribute-less. This closes the HWPX-decode side of the
-    // inline tab carry — see
-    // `.docs/debug/2026-05-27_hwpx_decoder_inline_tab_attrs_lost.md`.
-    if !has_field_pair {
-        for text in &hx.texts {
-            let content = text.to_run_content();
-            let keep = match &content {
-                RunContent::Text(s) => !s.is_empty(),
-                RunContent::InlineText(it) => !it.segments.is_empty(),
-                _ => true,
-            };
-            if keep {
-                runs.push(Run { content, char_shape_id });
-            }
-        }
-    }
+    // (`width` / `leader` / `tab_type`) as `RunContent::InlineText` —
+    // see `.docs/debug/2026-05-27_hwpx_decoder_inline_tab_attrs_lost.md`.
+    let order = if hx.child_order.is_empty() {
+        // 수동 생성 HxRun(테스트·내부 도구) 폴백 — 종전 by-kind 순서 재현.
+        legacy_child_order(hx)
+    } else {
+        hx.child_order.clone()
+    };
 
-    // Table runs
-    for table in &hx.tables {
-        let core_table = convert_table(table, depth)?;
-        runs.push(Run { content: RunContent::Table(Box::new(core_table)), char_shape_id });
-    }
-
-    // Image runs
-    for pic in &hx.pictures {
-        if let Some(image) = convert_picture(pic, depth)? {
-            runs.push(Run { content: RunContent::Image(image), char_shape_id });
-        }
-    }
-
-    // Footnote / Endnote / Bookmark / IndexMark / Field runs (from <hp:ctrl>)
-    //
-    // Field controls use fieldBegin/fieldEnd pairs. We collect fieldBegin ctrls
-    // and match them with fieldEnd ctrls to extract the field's text from
-    // intervening <hp:t> elements. The text runs between begin and end are
-    // consumed as the field's display text.
     let mut field_begin: Option<&HxFieldBegin> = None;
     let mut field_begin_char_shape: CharShapeIndex = char_shape_id;
+    let mut field_body = String::new();
 
-    for ctrl in &hx.ctrls {
+    for &(kind, idx) in &order {
+        match kind {
+            HxRunChildKind::Text => {
+                let text = &hx.texts[idx];
+                if field_begin.is_some() {
+                    // 마커 사이 텍스트 = 필드 본문 (문서 순서라 무모호).
+                    field_body.push_str(&text.text());
+                    continue;
+                }
+                let content = text.to_run_content();
+                let keep = match &content {
+                    RunContent::Text(s) => !s.is_empty(),
+                    RunContent::InlineText(it) => !it.segments.is_empty(),
+                    _ => true,
+                };
+                if keep {
+                    runs.push(Run { content, char_shape_id });
+                }
+            }
+            HxRunChildKind::Table => {
+                let core_table = convert_table(&hx.tables[idx], depth)?;
+                runs.push(Run { content: RunContent::Table(Box::new(core_table)), char_shape_id });
+            }
+            HxRunChildKind::Picture => {
+                if let Some(image) = convert_picture(&hx.pictures[idx], depth)? {
+                    runs.push(Run { content: RunContent::Image(image), char_shape_id });
+                }
+            }
+            HxRunChildKind::Ctrl => {
+                convert_ctrl_child(
+                    &hx.ctrls[idx],
+                    char_shape_id,
+                    depth,
+                    &mut runs,
+                    &mut field_begin,
+                    &mut field_begin_char_shape,
+                    &mut field_body,
+                )?;
+            }
+            HxRunChildKind::Rect => {
+                if let Some(run) = decode_textbox(&hx.rects[idx], char_shape_id, depth)? {
+                    runs.push(run);
+                }
+            }
+            HxRunChildKind::Line => {
+                runs.push(decode_line(&hx.lines[idx], char_shape_id, depth)?);
+            }
+            HxRunChildKind::Ellipse => {
+                let ellipse = &hx.ellipses[idx];
+                if ellipse.has_arc_pr == 1 {
+                    runs.push(decode_arc(ellipse, char_shape_id, depth)?);
+                } else {
+                    runs.push(decode_ellipse(ellipse, char_shape_id, depth)?);
+                }
+            }
+            HxRunChildKind::Polygon => {
+                runs.push(decode_polygon(&hx.polygons[idx], char_shape_id, depth)?);
+            }
+            HxRunChildKind::Curve => {
+                runs.push(decode_curve(&hx.curves[idx], char_shape_id, depth)?);
+            }
+            HxRunChildKind::TextArt => {
+                runs.push(decode_textart(&hx.textarts[idx], char_shape_id, depth)?);
+            }
+            HxRunChildKind::ConnectLine => {
+                runs.push(decode_connect_line(&hx.connect_lines[idx], char_shape_id, depth)?);
+            }
+            HxRunChildKind::Container => {
+                if let Some(run) = decode_container(&hx.containers[idx], char_shape_id, depth)? {
+                    runs.push(run);
+                }
+            }
+            HxRunChildKind::Equation => {
+                runs.push(decode_equation(&hx.equations[idx], char_shape_id)?);
+            }
+            HxRunChildKind::Dutmal => {
+                runs.push(decode_dutmal(&hx.dutmals[idx], char_shape_id));
+            }
+            HxRunChildKind::Compose => {
+                runs.push(decode_compose(&hx.composes[idx], char_shape_id));
+            }
+            // secPr/titleMark 는 구역·문단 수준에서 소비, switch 는 차트
+            // 전용 경로 소유, Other 는 미지 요소 자리 — run 방출 없음.
+            HxRunChildKind::SecPr
+            | HxRunChildKind::TitleMark
+            | HxRunChildKind::Switch
+            | HxRunChildKind::Other => {}
+        }
+    }
+
+    // Handle self-closing fieldBegin without a matching fieldEnd (e.g. bookmark span start)
+    if let Some(fb) = field_begin.take() {
+        if fb.field_type == "BOOKMARK" {
+            runs.push(Run {
+                content: RunContent::Control(Box::new(Control::Bookmark {
+                    name: fb.name.clone(),
+                    bookmark_type: hwpforge_foundation::BookmarkType::SpanStart,
+                })),
+                char_shape_id: field_begin_char_shape,
+            });
+        }
+    }
+
+    Ok(runs)
+}
+
+/// `<hp:ctrl>` 자식 하나를 문서 순서 위치에서 변환한다 (W1a 분리 헬퍼).
+///
+/// footnote/endnote/bookmark/indexmark/autoNum/newNum/pageHiding 은 즉시
+/// run 으로, fieldBegin/fieldEnd 는 순서 기반 pairing 상태를 갱신한다.
+#[allow(clippy::too_many_arguments)]
+fn convert_ctrl_child<'a>(
+    ctrl: &'a HxCtrl,
+    char_shape_id: CharShapeIndex,
+    depth: usize,
+    runs: &mut Vec<Run>,
+    field_begin: &mut Option<&'a HxFieldBegin>,
+    field_begin_char_shape: &mut CharShapeIndex,
+    field_body: &mut String,
+) -> HwpxResult<()> {
+    {
         if let Some(run) = decode_footnote(ctrl, char_shape_id, depth)? {
             runs.push(run);
         }
@@ -460,32 +555,24 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
         if let Some(run) = decode_indexmark(ctrl, char_shape_id) {
             runs.push(run);
         }
-        // Field begin: remember for pairing with fieldEnd
+        // Field begin: remember for pairing with fieldEnd — 사이드카 순서
+        // 덕에 이후 마주치는 텍스트는 정확히 마커 사이 본문이다 (W1a).
         if let Some(fb) = &ctrl.field_begin {
-            field_begin = Some(fb);
-            field_begin_char_shape = char_shape_id;
+            *field_begin = Some(fb);
+            *field_begin_char_shape = char_shape_id;
+            field_body.clear();
         }
-        // Field end: pair with remembered fieldBegin and emit control
+        // Field end: pair with remembered fieldBegin and emit control.
+        // 본문 = begin 이후 누적된 field_body — 문서 순서라 무모호하므로
+        // 종전의 `texts.len()==1` 다운그레이드(gotcha #30)는 철폐한다.
         if ctrl.field_end.is_some() {
             if let Some(fb) = field_begin.take() {
-                let field_text = collect_run_text(hx);
-                // `HxRun` 은 자식 순서(texts/ctrls interleaving)를 보존하지
-                // 않으므로, run 에 `<hp:t>` 가 정확히 1개일 때만 그 텍스트가
-                // 마커 사이 본문이라고 무모호하게 귀속할 수 있다. 한컴은
-                // 재저장 시 라벨 run 과 필드 run 을 병합하기도 한다
-                // (fixture `fields/clickhere_filled.hwpx`: t·fieldBegin·
-                // t·fieldEnd·t 한 run) — 그 경우 연결 텍스트를 본문으로
-                // 오귀속하는 대신 미채움으로 다운그레이드한다 (warning-first).
-                let unambiguous_body = hx.texts.len() == 1;
-                if let Some(run) = decode_field_control(
-                    fb,
-                    &field_text,
-                    field_begin_char_shape,
-                    depth,
-                    unambiguous_body,
-                )? {
+                if let Some(run) =
+                    decode_field_control(fb, field_body, *field_begin_char_shape, depth, true)?
+                {
                     runs.push(run);
                 }
+                field_body.clear();
             }
         }
         // AutoNum (inline page number) — Wave 12n: routed to
@@ -540,84 +627,7 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
             });
         }
     }
-
-    // Handle self-closing fieldBegin without a matching fieldEnd (e.g. bookmark span start)
-    if let Some(fb) = field_begin.take() {
-        if fb.field_type == "BOOKMARK" {
-            runs.push(Run {
-                content: RunContent::Control(Box::new(Control::Bookmark {
-                    name: fb.name.clone(),
-                    bookmark_type: hwpforge_foundation::BookmarkType::SpanStart,
-                })),
-                char_shape_id: field_begin_char_shape,
-            });
-        }
-    }
-
-    // Textbox runs (from <hp:rect>)
-    for rect in &hx.rects {
-        if let Some(run) = decode_textbox(rect, char_shape_id, depth)? {
-            runs.push(run);
-        }
-    }
-
-    // Line runs (from <hp:line>)
-    for line in &hx.lines {
-        runs.push(decode_line(line, char_shape_id, depth)?);
-    }
-
-    // Ellipse and Arc runs (from <hp:ellipse>)
-    for ellipse in &hx.ellipses {
-        if ellipse.has_arc_pr == 1 {
-            runs.push(decode_arc(ellipse, char_shape_id, depth)?);
-        } else {
-            runs.push(decode_ellipse(ellipse, char_shape_id, depth)?);
-        }
-    }
-
-    // Polygon runs (from <hp:polygon>)
-    for polygon in &hx.polygons {
-        runs.push(decode_polygon(polygon, char_shape_id, depth)?);
-    }
-
-    // Curve runs (from <hp:curve>)
-    for curve in &hx.curves {
-        runs.push(decode_curve(curve, char_shape_id, depth)?);
-    }
-
-    // TextArt runs (from <hp:textart>)
-    for text_art in &hx.textarts {
-        runs.push(decode_textart(text_art, char_shape_id, depth)?);
-    }
-
-    // ConnectLine runs (from <hp:connectLine>)
-    for connect_line in &hx.connect_lines {
-        runs.push(decode_connect_line(connect_line, char_shape_id, depth)?);
-    }
-
-    // Group runs (from <hp:container>) — Wave A flat children.
-    for container in &hx.containers {
-        if let Some(run) = decode_container(container, char_shape_id, depth)? {
-            runs.push(run);
-        }
-    }
-
-    // Equation runs (from <hp:equation>)
-    for equation in &hx.equations {
-        runs.push(decode_equation(equation, char_shape_id)?);
-    }
-
-    // Dutmal runs (from <hp:dutmal>)
-    for dutmal in &hx.dutmals {
-        runs.push(decode_dutmal(dutmal, char_shape_id));
-    }
-
-    // Compose runs (from <hp:compose>)
-    for compose in &hx.composes {
-        runs.push(decode_compose(compose, char_shape_id));
-    }
-
-    Ok(runs)
+    Ok(())
 }
 
 /// Converts an `HxTable` into a Core `Table`.
@@ -959,14 +969,6 @@ fn decode_indexmark(ctrl: &HxCtrl, char_shape_id: CharShapeIndex) -> Option<Run>
 /// Collects all text content from an `HxRun`'s `<hp:t>` elements.
 ///
 /// Used to extract the display text between a fieldBegin and fieldEnd pair.
-fn collect_run_text(hx: &HxRun) -> String {
-    let mut text = String::new();
-    for t in &hx.texts {
-        text.push_str(&t.text());
-    }
-    text
-}
-
 /// Extracts named parameter values from an `HxFieldBegin`'s parameters.
 fn get_field_param(fb: &HxFieldBegin, name: &str) -> Option<String> {
     let params = fb.parameters.as_ref()?;
@@ -3353,6 +3355,36 @@ mod tests {
             page_num.is_some(),
             "autoNum PAGE must produce InlinePageNumber control (Wave 12n)"
         );
+    }
+
+    #[test]
+    fn interleaved_children_preserve_document_order_in_core() {
+        // W1a 핵심 잠금: `<t>a</t><pic/><t>b</t>` 는 Core `[a, Image, b]` —
+        // 종전 by-kind 평탄화는 `[a, b, Image]` 로 재배열해 인라인 앵커를
+        // 왜곡했다 (이미지/글상자 에픽의 관문 결함).
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0">
+                    <t>a</t>
+                    <pic id="1"><img binaryItemIDRef="image1.png" bright="0" contrast="0"/><curSz width="100" height="100"/></pic>
+                    <t>b</t>
+                </run>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        let kinds: Vec<&str> = result.paragraphs[0]
+            .runs
+            .iter()
+            .map(|r| match &r.content {
+                RunContent::Text(_) | RunContent::InlineText(_) => "text",
+                RunContent::Image(_) => "image",
+                RunContent::Table(_) => "table",
+                RunContent::Control(_) => "control",
+                _ => "other",
+            })
+            .collect();
+        assert_eq!(kinds, vec!["text", "image", "text"], "문서 순서 보존");
+        assert_eq!(result.paragraphs[0].text_content(), "ab");
     }
 
     #[test]

--- a/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/section.rs
@@ -147,7 +147,7 @@ pub fn parse_section(
     let mut page_settings = None;
     let mut headers = Vec::new();
     let mut footers = Vec::new();
-    let mut warnings: Vec<super::DecodeWarning> = Vec::new();
+    let mut ctx = DecodeCtx::new(section_index);
     let mut page_number = None;
     let mut column_settings = None;
     let mut visibility = None;
@@ -161,7 +161,10 @@ pub fn parse_section(
         .iter()
         .enumerate()
         .map(|(para_idx, hx_para)| {
-            let (mut para, ps) = convert_paragraph(hx_para, para_idx == 0, 0)?;
+            ctx.enter(super::PathSeg::BodyParagraph(para_idx));
+            let result = convert_paragraph(hx_para, para_idx == 0, 0, &mut ctx);
+            ctx.leave();
+            let (mut para, ps) = result?;
             if ps.is_some() && page_settings.is_none() {
                 page_settings = ps;
             }
@@ -181,7 +184,7 @@ pub fn parse_section(
                             page_border_fills = extract_page_border_fills(sec_pr);
                         }
                         if begin_num.is_none() {
-                            begin_num = extract_begin_num(sec_pr, &mut warnings);
+                            begin_num = extract_begin_num(sec_pr, &mut ctx.warnings);
                         }
                         text_direction = TextDirection::from_hwpx_str(&sec_pr.text_direction);
                     }
@@ -198,14 +201,20 @@ pub fn parse_section(
                     }
                     // 다중 머리말/꼬리말 = wire 순서대로 전부 수집 (W5-α C1:
                     // first-wins 는 ODD/EVEN 문서에서 무음 데이터 손실).
-                    if let Some(hf) = convert_ctrl_header(ctrl, &mut warnings)? {
+                    ctx.enter(super::PathSeg::Header(headers.len()));
+                    let header_result = convert_ctrl_header(ctrl, &mut ctx);
+                    ctx.leave();
+                    if let Some(hf) = header_result? {
                         headers.push(hf);
                     }
-                    if let Some(hf) = convert_ctrl_footer(ctrl, &mut warnings)? {
+                    ctx.enter(super::PathSeg::Footer(footers.len()));
+                    let footer_result = convert_ctrl_footer(ctrl, &mut ctx);
+                    ctx.leave();
+                    if let Some(hf) = footer_result? {
                         footers.push(hf);
                     }
                     if page_number.is_none() {
-                        if let Some(pn) = convert_ctrl_page_number(ctrl, &mut warnings) {
+                        if let Some(pn) = convert_ctrl_page_number(ctrl, &mut ctx.warnings) {
                             page_number = Some(pn);
                         }
                     }
@@ -250,8 +259,186 @@ pub fn parse_section(
         master_pages: None,
         text_direction,
         begin_num,
-        warnings,
+        warnings: ctx.warnings,
     })
+}
+
+/// 디코드 경고 sink + 현재 문단의 중첩 경로 (W1b — §1g v5 변경 5).
+///
+/// 중첩 컨테이너(셀/각주/글상자/묶음)로 들어갈 때 [`enter`]/[`leave`] 로
+/// 경로를 유지한다. 캐시 드롭 경고는 이 경로를 payload 로 갖는다.
+///
+/// [`enter`]: DecodeCtx::enter
+/// [`leave`]: DecodeCtx::leave
+pub(crate) struct DecodeCtx {
+    /// 수집된 비치명 경고 (SectionParseResult.warnings 로 흘러감).
+    pub(crate) warnings: Vec<super::DecodeWarning>,
+    path: Vec<super::PathSeg>,
+}
+
+impl DecodeCtx {
+    pub(crate) fn new(section_index: usize) -> Self {
+        Self { warnings: Vec::new(), path: vec![super::PathSeg::Section(section_index)] }
+    }
+
+    pub(crate) fn enter(&mut self, seg: super::PathSeg) {
+        self.path.push(seg);
+    }
+
+    pub(crate) fn leave(&mut self) {
+        self.path.pop();
+    }
+
+    fn cache_dropped(&mut self, reason: String) {
+        self.warnings.push(super::DecodeWarning::LayoutCacheDropped {
+            path: super::ParagraphPath(self.path.clone()),
+            reason,
+        });
+    }
+}
+
+/// 문단 전체 자식을 문서 순서로 걷어 wire→Core 좌표 맵을 구축한다 (W1b).
+///
+/// 소비폭은 **디코더가 실제 방출하는 것**에서 유도한다 (§1g v5 R3#1):
+/// run-내 field 접힘(begin..end 같은 run — `convert_run` pairing 미러)은
+/// 사이 텍스트가 (n,0), cross-run field 는 begin/end 만 (8,0) 이고 사이
+/// 텍스트는 일반 방출이라 1:1. 소비량을 알 수 없는 자식(미지 Switch·
+/// Other·StrayText·`<hp:t>` 내 미지 요소·다중 payload ctrl)은 `Err` —
+/// 캐시 fail-closed (문서 디코드는 계속된다).
+fn build_paragraph_wire_map(hx: &HxParagraph) -> Result<crate::wire_text_map::WireTextMap, String> {
+    build_wire_map_over_runs(&hx.runs, 0)
+}
+
+/// [`build_paragraph_wire_map`] 의 본체 — 인코더도 **방출한 run 트리**에
+/// 동일 맵을 적용해 왕복 대칭을 구성적으로 보장한다 (§1g v5 변경 4:
+/// 방출-통합). `injected_leading_ctrls` = 인코더가 직렬화 후 문자열로
+/// 주입하는 선행 ctrl 수 (colPr/머리말/꼬리말/쪽번호 — 트리에 없어
+/// 맵이 못 보는 (8,0) 유닛; 전부 영-core 라 상호 순서는 무관).
+pub(crate) fn build_wire_map_over_runs(
+    runs: &[crate::schema::section::HxRun],
+    injected_leading_ctrls: usize,
+) -> Result<crate::wire_text_map::WireTextMap, String> {
+    use crate::schema::section::{HxRunChildKind as K, HxTextPart};
+    let mut b = crate::wire_text_map::WireMapBuilder::new();
+    for _ in 0..injected_leading_ctrls {
+        b.push_span(8, 0);
+    }
+    for hx_run in runs {
+        let order = if hx_run.child_order.is_empty() {
+            legacy_child_order(hx_run)
+        } else {
+            hx_run.child_order.clone()
+        };
+        // convert_run 의 run-local field 접힘 상태 미러.
+        let mut in_field = false;
+        for &(kind, idx) in &order {
+            match kind {
+                K::Text => {
+                    for part in &hx_run.texts[idx].parts {
+                        match part {
+                            HxTextPart::Text(s) => {
+                                let n = s.encode_utf16().count() as u32;
+                                if n == 0 {
+                                    continue;
+                                }
+                                if in_field {
+                                    b.push_span(n, 0);
+                                } else {
+                                    b.advance_identity(n);
+                                }
+                            }
+                            HxTextPart::Tab { .. } => {
+                                if in_field {
+                                    b.push_span(8, 0);
+                                } else {
+                                    b.push_span(8, 1);
+                                }
+                            }
+                            HxTextPart::LineBreak {}
+                            | HxTextPart::NbSpace {}
+                            | HxTextPart::FwSpace {} => {
+                                if in_field {
+                                    b.push_span(1, 0);
+                                } else {
+                                    b.advance_identity(1);
+                                }
+                            }
+                            // 한컴 titleMark 는 `<t>` 내부 — HWP5 0x08
+                            // 미러 = wire 8·가시 0.
+                            HxTextPart::TitleMark { .. } => b.push_span(8, 0),
+                            // markpen 은 HWP5 range-tag (스트림 유닛 0) —
+                            // corpus 프로브: native 327본 중 markpen 1본,
+                            // 전부 한 줄 (§1g v3).
+                            HxTextPart::MarkpenBegin {} | HxTextPart::MarkpenEnd {} => {}
+                            HxTextPart::Other => {
+                                return Err("unknown inline element in <hp:t>".into());
+                            }
+                        }
+                    }
+                }
+                K::Ctrl => {
+                    let ctrl = &hx_run.ctrls[idx];
+                    let payloads = usize::from(ctrl.col_pr.is_some())
+                        + usize::from(ctrl.header.is_some())
+                        + usize::from(ctrl.footer.is_some())
+                        + usize::from(ctrl.page_num.is_some())
+                        + usize::from(ctrl.foot_note.is_some())
+                        + usize::from(ctrl.end_note.is_some())
+                        + usize::from(ctrl.bookmark.is_some())
+                        + usize::from(ctrl.indexmark.is_some())
+                        + usize::from(ctrl.field_begin.is_some())
+                        + usize::from(ctrl.field_end.is_some())
+                        + usize::from(ctrl.auto_num.is_some())
+                        + usize::from(ctrl.new_num.is_some())
+                        + usize::from(ctrl.page_hiding.is_some());
+                    if payloads != 1 {
+                        return Err(format!(
+                            "<hp:ctrl> wrapper with {payloads} payloads (expected exactly 1)"
+                        ));
+                    }
+                    b.push_span(8, 0);
+                    if ctrl.field_begin.is_some() {
+                        in_field = true;
+                    }
+                    if ctrl.field_end.is_some() {
+                        in_field = false;
+                    }
+                }
+                K::SecPr
+                | K::Table
+                | K::Picture
+                | K::Rect
+                | K::Line
+                | K::Ellipse
+                | K::Polygon
+                | K::Curve
+                | K::ConnectLine
+                | K::Container
+                | K::TextArt
+                | K::Equation
+                | K::Dutmal
+                | K::Compose
+                | K::TitleMark => b.push_span(8, 0),
+                K::Switch => {
+                    // 알려진 chart 캐리어만 (8,0) — 미지 switch 내용은
+                    // 소비량 미상 (v4 R3#6: 차트 일괄 드롭은 퇴행).
+                    let is_chart = hx_run
+                        .switches
+                        .get(idx)
+                        .and_then(|sw| sw.case.as_ref())
+                        .is_some_and(|case| case.chart.is_some());
+                    if is_chart {
+                        b.push_span(8, 0);
+                    } else {
+                        return Err("unknown <hp:switch> content".into());
+                    }
+                }
+                K::Other => return Err("unknown run child element".into()),
+                K::StrayText => return Err("stray run-level text".into()),
+            }
+        }
+    }
+    b.finish().map_err(|e| e.to_string())
 }
 
 /// Converts an `HxParagraph` to a Core `Paragraph`.
@@ -262,6 +449,7 @@ fn convert_paragraph(
     hx: &HxParagraph,
     is_first: bool,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<(Paragraph, Option<PageSettings>)> {
     const MAX_STYLE_INDEX: u32 = 100_000;
     if hx.para_pr_id_ref > MAX_STYLE_INDEX {
@@ -277,7 +465,7 @@ fn convert_paragraph(
 
     let mut runs = Vec::new();
     let mut has_title_mark = false;
-    for hx_run in &hx.runs {
+    for (run_idx, hx_run) in hx.runs.iter().enumerate() {
         // Extract page settings from secPr in first paragraph
         if is_first && page_settings.is_none() {
             if let Some(sec_pr) = &hx_run.sec_pr {
@@ -292,7 +480,10 @@ fn convert_paragraph(
             }
         }
 
-        let mut converted_runs = convert_run(hx_run, depth)?;
+        ctx.enter(super::PathSeg::Run(run_idx));
+        let result = convert_run(hx_run, depth, ctx);
+        ctx.leave();
+        let mut converted_runs = result?;
         runs.append(&mut converted_runs);
     }
 
@@ -323,38 +514,38 @@ fn convert_paragraph(
 
     // 줄 조판 캐시 승격 (decode-only). 인코더는 기본적으로 재방출하지 않는다.
     //
-    // ⚠️ textpos 좌표 정규화: 한컴의 textpos 는 내부 텍스트 스트림 기준이라
-    // 확장 컨트롤(HWP5 secd/cold/head... 의 미러)이 **각 8 유닛**을 차지한다.
-    // Core 캐시는 보이는-텍스트(UTF-16) 좌표를 계약하므로, 텍스트 시작 전에
-    // 스트림을 차지하고 **디코더가 소비해 Core run 에서 사라지는** 요소만
-    // 차감한다: secPr + 섹션-수준 ctrl(colPr/header/footer/pageNum).
-    // 실측: rules-justify 첫 문단 secPr+colPr = 16 = 70−54 (규칙 문서 §1).
-    // 첫 텍스트 run 까지 포함해 센다 (한컴이 secPr 를 텍스트와 같은 run 에
-    // 쓰는 형태도 스트림상 텍스트보다 앞선다). Core run 으로 남는 인라인
-    // 컨트롤(각주·수식·그림 등)이 텍스트보다 앞서는 경우는 여기서 차감하지
-    // 않는다 — 소비자(smithy-pdf)의 선행 비텍스트 run 가드가 fail-closed
-    // 로 거부한다.
-    let leading_ctrl_units: u32 = {
-        let is_section_level = |c: &crate::schema::section::HxCtrl| {
-            c.col_pr.is_some() || c.header.is_some() || c.footer.is_some() || c.page_num.is_some()
-        };
-        let mut units = 0u32;
-        for run in &hx.runs {
-            units += 8 * u32::from(run.sec_pr.is_some());
-            units += 8 * run.ctrls.iter().filter(|c| is_section_level(c)).count() as u32;
-            if !run.texts.is_empty() {
-                break;
+    // W1b: 한컴 textpos = HWP5 raw 스트림 좌표 (확장 marker 종류 무관
+    // 8유닛 — §1f 보편 규칙). 문단 전체 자식을 걷는 wire ledger 로 Core
+    // `text_content()` 가시 좌표로 정규화한다 (종전 선두-균일 차감은 중간
+    // marker 문단을 무음 오절단 — 철폐). 실패 = fail-closed: 캐시 미승격
+    // + `DecodeWarning::LayoutCacheDropped` (추측 좌표 승격 금지).
+    let layout_cache = hx.linesegarray.as_ref().and_then(|array| {
+        let map = match build_paragraph_wire_map(hx) {
+            Ok(map) => map,
+            Err(reason) => {
+                ctx.cache_dropped(reason);
+                return None;
             }
+        };
+        // ledger↔방출 정합 자가검증: 예측 Core 총길이 == 실제 방출 텍스트
+        // 총길이 (불일치 = ledger/방출 분기 — choke, §1g v5 변경 4).
+        let emitted_core: u32 = runs
+            .iter()
+            .filter_map(|r| r.content.plain_text())
+            .map(|t| t.encode_utf16().count() as u32)
+            .sum();
+        if map.core_end() != emitted_core {
+            ctx.cache_dropped(format!(
+                "ledger/emission core length mismatch (map {} vs emitted {emitted_core})",
+                map.core_end()
+            ));
+            return None;
         }
-        units
-    };
-    let layout_cache = hx.linesegarray.as_ref().map(|array| {
-        hwpforge_core::layout::LayoutCache::new(
-            array
-                .items
-                .iter()
-                .map(|s| hwpforge_core::layout::LineSeg {
-                    textpos: s.textpos.saturating_sub(leading_ctrl_units),
+        let mut lines = Vec::with_capacity(array.items.len());
+        for s in &array.items {
+            match map.to_core(s.textpos) {
+                Ok(textpos) => lines.push(hwpforge_core::layout::LineSeg {
+                    textpos,
                     vertpos: s.vertpos,
                     vertsize: s.vertsize,
                     textheight: s.textheight,
@@ -363,9 +554,14 @@ fn convert_paragraph(
                     horzpos: s.horzpos,
                     horzsize: s.horzsize,
                     flags: s.flags,
-                })
-                .collect(),
-        )
+                }),
+                Err(e) => {
+                    ctx.cache_dropped(format!("lineseg textpos {}: {e}", s.textpos));
+                    return None;
+                }
+            }
+        }
+        Some(hwpforge_core::layout::LayoutCache::new(lines))
     });
 
     let paragraph = Paragraph {
@@ -385,7 +581,7 @@ fn convert_paragraph(
 /// A single HxRun can contain multiple `<hp:t>`, `<hp:tbl>`, `<hp:pic>`,
 /// `<hp:ctrl>` (footnote/endnote), and `<hp:rect>` (textbox) elements.
 /// Each is converted to a separate Run with the same charPrIDRef.
-fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
+fn convert_run(hx: &HxRun, depth: usize, ctx: &mut DecodeCtx) -> HwpxResult<Vec<Run>> {
     const MAX_STYLE_INDEX: u32 = 100_000;
     if hx.char_pr_id_ref > MAX_STYLE_INDEX {
         return Err(crate::error::HwpxError::InvalidStructure {
@@ -442,11 +638,11 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
                 }
             }
             HxRunChildKind::Table => {
-                let core_table = convert_table(&hx.tables[idx], depth)?;
+                let core_table = convert_table(&hx.tables[idx], depth, ctx)?;
                 runs.push(Run { content: RunContent::Table(Box::new(core_table)), char_shape_id });
             }
             HxRunChildKind::Picture => {
-                if let Some(image) = convert_picture(&hx.pictures[idx], depth)? {
+                if let Some(image) = convert_picture(&hx.pictures[idx], depth, ctx)? {
                     runs.push(Run { content: RunContent::Image(image), char_shape_id });
                 }
             }
@@ -459,38 +655,40 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
                     &mut field_begin,
                     &mut field_begin_char_shape,
                     &mut field_body,
+                    ctx,
                 )?;
             }
             HxRunChildKind::Rect => {
-                if let Some(run) = decode_textbox(&hx.rects[idx], char_shape_id, depth)? {
+                if let Some(run) = decode_textbox(&hx.rects[idx], char_shape_id, depth, ctx)? {
                     runs.push(run);
                 }
             }
             HxRunChildKind::Line => {
-                runs.push(decode_line(&hx.lines[idx], char_shape_id, depth)?);
+                runs.push(decode_line(&hx.lines[idx], char_shape_id, depth, ctx)?);
             }
             HxRunChildKind::Ellipse => {
                 let ellipse = &hx.ellipses[idx];
                 if ellipse.has_arc_pr == 1 {
-                    runs.push(decode_arc(ellipse, char_shape_id, depth)?);
+                    runs.push(decode_arc(ellipse, char_shape_id, depth, ctx)?);
                 } else {
-                    runs.push(decode_ellipse(ellipse, char_shape_id, depth)?);
+                    runs.push(decode_ellipse(ellipse, char_shape_id, depth, ctx)?);
                 }
             }
             HxRunChildKind::Polygon => {
-                runs.push(decode_polygon(&hx.polygons[idx], char_shape_id, depth)?);
+                runs.push(decode_polygon(&hx.polygons[idx], char_shape_id, depth, ctx)?);
             }
             HxRunChildKind::Curve => {
-                runs.push(decode_curve(&hx.curves[idx], char_shape_id, depth)?);
+                runs.push(decode_curve(&hx.curves[idx], char_shape_id, depth, ctx)?);
             }
             HxRunChildKind::TextArt => {
                 runs.push(decode_textart(&hx.textarts[idx], char_shape_id, depth)?);
             }
             HxRunChildKind::ConnectLine => {
-                runs.push(decode_connect_line(&hx.connect_lines[idx], char_shape_id, depth)?);
+                runs.push(decode_connect_line(&hx.connect_lines[idx], char_shape_id, depth, ctx)?);
             }
             HxRunChildKind::Container => {
-                if let Some(run) = decode_container(&hx.containers[idx], char_shape_id, depth)? {
+                if let Some(run) = decode_container(&hx.containers[idx], char_shape_id, depth, ctx)?
+                {
                     runs.push(run);
                 }
             }
@@ -504,11 +702,13 @@ fn convert_run(hx: &HxRun, depth: usize) -> HwpxResult<Vec<Run>> {
                 runs.push(decode_compose(&hx.composes[idx], char_shape_id));
             }
             // secPr/titleMark 는 구역·문단 수준에서 소비, switch 는 차트
-            // 전용 경로 소유, Other 는 미지 요소 자리 — run 방출 없음.
+            // 전용 경로 소유, Other/StrayText 는 미지 요소 자리 — run
+            // 방출 없음 (ledger 가 fail-closed 신호로 소비).
             HxRunChildKind::SecPr
             | HxRunChildKind::TitleMark
             | HxRunChildKind::Switch
-            | HxRunChildKind::Other => {}
+            | HxRunChildKind::Other
+            | HxRunChildKind::StrayText => {}
         }
     }
 
@@ -541,12 +741,13 @@ fn convert_ctrl_child<'a>(
     field_begin: &mut Option<&'a HxFieldBegin>,
     field_begin_char_shape: &mut CharShapeIndex,
     field_body: &mut String,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<()> {
     {
-        if let Some(run) = decode_footnote(ctrl, char_shape_id, depth)? {
+        if let Some(run) = decode_footnote(ctrl, char_shape_id, depth, ctx)? {
             runs.push(run);
         }
-        if let Some(run) = decode_endnote(ctrl, char_shape_id, depth)? {
+        if let Some(run) = decode_endnote(ctrl, char_shape_id, depth, ctx)? {
             runs.push(run);
         }
         if let Some(run) = decode_bookmark(ctrl, char_shape_id) {
@@ -568,7 +769,7 @@ fn convert_ctrl_child<'a>(
         if ctrl.field_end.is_some() {
             if let Some(fb) = field_begin.take() {
                 if let Some(run) =
-                    decode_field_control(fb, field_body, *field_begin_char_shape, depth, true)?
+                    decode_field_control(fb, field_body, *field_begin_char_shape, depth, true, ctx)?
                 {
                     runs.push(run);
                 }
@@ -631,31 +832,30 @@ fn convert_ctrl_child<'a>(
 }
 
 /// Converts an `HxTable` into a Core `Table`.
-fn convert_table(hx: &HxTable, depth: usize) -> HwpxResult<Table> {
+fn convert_table(hx: &HxTable, depth: usize, ctx: &mut DecodeCtx) -> HwpxResult<Table> {
     if depth >= MAX_NESTING_DEPTH {
         return Err(HwpxError::InvalidStructure {
             detail: format!("table nesting depth {} exceeds limit of {}", depth, MAX_NESTING_DEPTH,),
         });
     }
 
-    let rows = hx
-        .rows
-        .iter()
-        .map(|hx_row| {
-            let cells = hx_row
-                .cells
-                .iter()
-                .map(|cell| convert_table_cell(cell, depth))
-                .collect::<HwpxResult<Vec<_>>>()?;
-            let height: Option<HwpUnit> = cells.iter().filter_map(|cell| cell.height).max();
-            let row: TableRow = match height {
-                Some(value) => TableRow::with_height(cells, value),
-                None => TableRow::new(cells),
-            };
-            let is_header: bool = decode_table_row_header(hx_row)?;
-            Ok(row.with_header(is_header))
-        })
-        .collect::<HwpxResult<Vec<_>>>()?;
+    let mut rows: Vec<TableRow> = Vec::with_capacity(hx.rows.len());
+    for (row_idx, hx_row) in hx.rows.iter().enumerate() {
+        let mut cells: Vec<TableCell> = Vec::with_capacity(hx_row.cells.len());
+        for (cell_idx, cell) in hx_row.cells.iter().enumerate() {
+            ctx.enter(super::PathSeg::TableCell { row: row_idx, cell: cell_idx });
+            let result = convert_table_cell(cell, depth, ctx);
+            ctx.leave();
+            cells.push(result?);
+        }
+        let height: Option<HwpUnit> = cells.iter().filter_map(|cell| cell.height).max();
+        let row: TableRow = match height {
+            Some(value) => TableRow::with_height(cells, value),
+            None => TableRow::new(cells),
+        };
+        let is_header: bool = decode_table_row_header(hx_row)?;
+        rows.push(row.with_header(is_header));
+    }
     validate_leading_header_rows(&rows)?;
 
     // Validate declared row count matches actual row count
@@ -669,7 +869,7 @@ fn convert_table(hx: &HxTable, depth: usize) -> HwpxResult<Table> {
         });
     }
 
-    let caption = hx.caption.as_ref().map(|c| convert_hx_caption(c, depth)).transpose()?;
+    let caption = hx.caption.as_ref().map(|c| convert_hx_caption(c, depth, ctx)).transpose()?;
 
     let page_break: TablePageBreak = decode_table_page_break(&hx.page_break)?;
     let width: Option<HwpUnit> = match hx.sz.as_ref() {
@@ -740,16 +940,21 @@ fn table_pos_is_default_flow(pos: Option<&crate::schema::section::HxTablePos>) -
 }
 
 /// Converts an `HxTableCell` into a Core `TableCell`.
-fn convert_table_cell(hx: &HxTableCell, depth: usize) -> HwpxResult<TableCell> {
+fn convert_table_cell(
+    hx: &HxTableCell,
+    depth: usize,
+    ctx: &mut DecodeCtx,
+) -> HwpxResult<TableCell> {
     let paragraphs = if let Some(sub_list) = &hx.sub_list {
-        sub_list
-            .paragraphs
-            .iter()
-            .map(|hx_para| {
-                let (para, _) = convert_paragraph(hx_para, false, depth + 1)?;
-                Ok(para)
-            })
-            .collect::<HwpxResult<Vec<_>>>()?
+        let mut out = Vec::with_capacity(sub_list.paragraphs.len());
+        for (i, hx_para) in sub_list.paragraphs.iter().enumerate() {
+            ctx.enter(super::PathSeg::NestedParagraph(i));
+            let result = convert_paragraph(hx_para, false, depth + 1, ctx);
+            ctx.leave();
+            let (para, _) = result?;
+            out.push(para);
+        }
+        out
     } else {
         vec![Paragraph::new(ParaShapeIndex::new(0))]
     };
@@ -829,7 +1034,7 @@ fn validate_leading_header_rows(rows: &[TableRow]) -> HwpxResult<()> {
 }
 
 /// Converts an `HxPic` into a Core `Image`, if it has a valid image reference.
-fn convert_picture(hx: &HxPic, depth: usize) -> HwpxResult<Option<Image>> {
+fn convert_picture(hx: &HxPic, depth: usize, ctx: &mut DecodeCtx) -> HwpxResult<Option<Image>> {
     let img = match hx.img.as_ref() {
         Some(img) if !img.binary_item_id_ref.is_empty() => img,
         _ => return Ok(None),
@@ -850,7 +1055,7 @@ fn convert_picture(hx: &HxPic, depth: usize) -> HwpxResult<Option<Image>> {
         })
         .unwrap_or((HwpUnit::ZERO, HwpUnit::ZERO));
 
-    let caption = hx.caption.as_ref().map(|c| convert_hx_caption(c, depth)).transpose()?;
+    let caption = hx.caption.as_ref().map(|c| convert_hx_caption(c, depth, ctx)).transpose()?;
     let placement = decode_image_placement(hx);
 
     let mut image: Image = Image::new(path, width, height, format);
@@ -902,12 +1107,16 @@ fn decode_footnote(
     ctrl: &HxCtrl,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Option<Run>> {
     let hx = match &ctrl.foot_note {
         Some(note) => note,
         None => return Ok(None),
     };
-    let paragraphs = decode_note_paragraphs(hx, depth)?;
+    ctx.enter(super::PathSeg::Footnote);
+    let result = decode_note_paragraphs(hx, depth, ctx);
+    ctx.leave();
+    let paragraphs = result?;
     Ok(Some(Run {
         content: RunContent::Control(Box::new(Control::Footnote {
             inst_id: hx.inst_id.map(hwpforge_core::ObjectId::new),
@@ -922,12 +1131,16 @@ fn decode_endnote(
     ctrl: &HxCtrl,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Option<Run>> {
     let hx = match &ctrl.end_note {
         Some(note) => note,
         None => return Ok(None),
     };
-    let paragraphs = decode_note_paragraphs(hx, depth)?;
+    ctx.enter(super::PathSeg::Endnote);
+    let result = decode_note_paragraphs(hx, depth, ctx);
+    ctx.leave();
+    let paragraphs = result?;
     Ok(Some(Run {
         content: RunContent::Control(Box::new(Control::Endnote {
             inst_id: hx.inst_id.map(hwpforge_core::ObjectId::new),
@@ -938,8 +1151,12 @@ fn decode_endnote(
 }
 
 /// Decodes an `HxFootNote` (or `HxEndNote`, same type) sub-list into paragraphs.
-fn decode_note_paragraphs(hx: &HxFootNote, depth: usize) -> HwpxResult<Vec<Paragraph>> {
-    decode_sublist_paragraphs(&hx.sub_list, depth)
+fn decode_note_paragraphs(
+    hx: &HxFootNote,
+    depth: usize,
+    ctx: &mut DecodeCtx,
+) -> HwpxResult<Vec<Paragraph>> {
+    decode_sublist_paragraphs(&hx.sub_list, depth, ctx)
 }
 
 /// Decodes an `HxCtrl`'s bookmark into a Core `Run`, if present.
@@ -999,6 +1216,7 @@ fn decode_field_control(
     char_shape_id: CharShapeIndex,
     depth: usize,
     unambiguous_body: bool,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Option<Run>> {
     let control = match fb.field_type.as_str() {
         "HYPERLINK" => {
@@ -1132,7 +1350,10 @@ fn decode_field_control(
         "MEMO" => {
             // Memo body is in subList inside fieldBegin
             let content = if let Some(sub_list) = &fb.sub_list {
-                decode_sublist_paragraphs(sub_list, depth)?
+                ctx.enter(super::PathSeg::Memo);
+                let result = decode_sublist_paragraphs(sub_list, depth, ctx);
+                ctx.leave();
+                result?
             } else {
                 Vec::new()
             };
@@ -1295,6 +1516,7 @@ pub(crate) fn parse_hex_color(s: &str) -> Option<Color> {
 pub(crate) fn decode_sublist_paragraphs(
     sub_list: &HxSubList,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Vec<Paragraph>> {
     if depth >= MAX_NESTING_DEPTH {
         return Err(HwpxError::InvalidStructure {
@@ -1304,20 +1526,25 @@ pub(crate) fn decode_sublist_paragraphs(
             ),
         });
     }
-    sub_list
-        .paragraphs
-        .iter()
-        .map(|hx_para| {
-            let (para, _) = convert_paragraph(hx_para, false, depth + 1)?;
-            Ok(para)
-        })
-        .collect()
+    let mut out = Vec::with_capacity(sub_list.paragraphs.len());
+    for (i, hx_para) in sub_list.paragraphs.iter().enumerate() {
+        ctx.enter(super::PathSeg::NestedParagraph(i));
+        let result = convert_paragraph(hx_para, false, depth + 1, ctx);
+        ctx.leave();
+        let (para, _) = result?;
+        out.push(para);
+    }
+    Ok(out)
 }
 
 /// Converts an `HxCaption` into a Core `Caption`.
 ///
 /// Parses side, gap, optional width, and paragraph content from the schema type.
-pub(crate) fn convert_hx_caption(hx: &HxCaption, depth: usize) -> HwpxResult<Caption> {
+pub(crate) fn convert_hx_caption(
+    hx: &HxCaption,
+    depth: usize,
+    ctx: &mut DecodeCtx,
+) -> HwpxResult<Caption> {
     let side = match hx.side.as_str() {
         "RIGHT" => CaptionSide::Right,
         "TOP" => CaptionSide::Top,
@@ -1331,7 +1558,10 @@ pub(crate) fn convert_hx_caption(hx: &HxCaption, depth: usize) -> HwpxResult<Cap
 
     let gap = HwpUnit::new(hx.gap).unwrap_or(HwpUnit::new(850).unwrap());
 
-    let paragraphs = decode_sublist_paragraphs(&hx.sub_list, depth)?;
+    ctx.enter(super::PathSeg::Caption);
+    let result = decode_sublist_paragraphs(&hx.sub_list, depth, ctx);
+    ctx.leave();
+    let paragraphs = result?;
 
     Ok(Caption { side, width, gap, paragraphs })
 }
@@ -1631,13 +1861,10 @@ fn parse_mm_width(s: &str) -> HwpUnit {
 ///
 /// 머리말 내부 문단 변환 실패를 전파한다 (W5-α C1 — `filter_map` 무음
 /// 삼킴은 캐시·본문 소실을 숨겼다).
-fn convert_ctrl_header(
-    ctrl: &HxCtrl,
-    warnings: &mut Vec<super::DecodeWarning>,
-) -> HwpxResult<Option<HeaderFooter>> {
+fn convert_ctrl_header(ctrl: &HxCtrl, ctx: &mut DecodeCtx) -> HwpxResult<Option<HeaderFooter>> {
     ctrl.header
         .as_ref()
-        .map(|hx| convert_header_footer(hx, "hp:header@applyPageType", warnings))
+        .map(|hx| convert_header_footer(hx, "hp:header@applyPageType", ctx))
         .transpose()
 }
 
@@ -1646,13 +1873,10 @@ fn convert_ctrl_header(
 /// # Errors
 ///
 /// 꼬리말 내부 문단 변환 실패를 전파한다 (`convert_ctrl_header` 참조).
-fn convert_ctrl_footer(
-    ctrl: &HxCtrl,
-    warnings: &mut Vec<super::DecodeWarning>,
-) -> HwpxResult<Option<HeaderFooter>> {
+fn convert_ctrl_footer(ctrl: &HxCtrl, ctx: &mut DecodeCtx) -> HwpxResult<Option<HeaderFooter>> {
     ctrl.footer
         .as_ref()
-        .map(|hx| convert_header_footer(hx, "hp:footer@applyPageType", warnings))
+        .map(|hx| convert_header_footer(hx, "hp:footer@applyPageType", ctx))
         .transpose()
 }
 
@@ -1665,19 +1889,22 @@ fn convert_ctrl_footer(
 fn convert_header_footer(
     hx: &HxHeaderFooter,
     attribute: &'static str,
-    warnings: &mut Vec<super::DecodeWarning>,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<HeaderFooter> {
-    let apply_page_type = parse_apply_page_type(&hx.apply_page_type, attribute, warnings);
+    let apply_page_type = parse_apply_page_type(&hx.apply_page_type, attribute, &mut ctx.warnings);
 
     let hf = if let Some(sub_list) = &hx.sub_list {
-        let paragraphs = sub_list
-            .paragraphs
-            .iter()
-            .map(|hx_para| convert_paragraph(hx_para, false, 0).map(|(para, _)| para))
-            .collect::<HwpxResult<Vec<_>>>()?;
+        let mut paragraphs = Vec::with_capacity(sub_list.paragraphs.len());
+        for (i, hx_para) in sub_list.paragraphs.iter().enumerate() {
+            ctx.enter(super::PathSeg::NestedParagraph(i));
+            let result = convert_paragraph(hx_para, false, 0, ctx);
+            ctx.leave();
+            let (para, _) = result?;
+            paragraphs.push(para);
+        }
         let mut hf = HeaderFooter::new(paragraphs, apply_page_type);
         // W5-α H1: 컨테이너 기하 승격 — 밴드 재생(R6)의 필수 입력.
-        hf.vert_align = parse_vert_align(&sub_list.vert_align, warnings);
+        hf.vert_align = parse_vert_align(&sub_list.vert_align, &mut ctx.warnings);
         hf.text_width =
             HwpUnit::new(i32::try_from(sub_list.text_width).unwrap_or(0)).unwrap_or(HwpUnit::ZERO);
         hf.text_height =
@@ -1918,14 +2145,16 @@ mod tests {
 
     #[test]
     fn linesegarray_is_promoted_to_layout_cache() {
+        // W1b: textpos 는 wire 스트림 좌표 — 텍스트 총길이(8유닛)를 넘지
+        // 않는 정합 fixture 여야 승격된다 (범위 밖 = fail-closed 거부).
         let xml = r#"<sec>
             <p paraPrIDRef="0">
-                <run charPrIDRef="0"><t>본문</t></run>
+                <run charPrIDRef="0"><t>본문 줄나눔 예시</t></run>
                 <linesegarray>
                     <lineseg textpos="0" vertpos="0" vertsize="1000" textheight="1000"
                              baseline="850" spacing="600" horzpos="0" horzsize="48188"
                              flags="393216"/>
-                    <lineseg textpos="70" vertpos="1600" vertsize="1000" textheight="1000"
+                    <lineseg textpos="6" vertpos="1600" vertsize="1000" textheight="1000"
                              baseline="850" spacing="600" horzpos="0" horzsize="48188"
                              flags="1441792"/>
                 </linesegarray>
@@ -1935,9 +2164,77 @@ mod tests {
         let cache = result.paragraphs[0].layout_cache.as_ref().expect("cache promoted");
         assert_eq!(cache.line_count(), 2);
         assert_eq!(cache.lines[0].vertsize, 1000);
-        assert_eq!(cache.lines[1].textpos, 70);
+        assert_eq!(cache.lines[1].textpos, 6);
         assert_eq!(cache.lines[1].vertpos, 1600);
         assert_eq!(cache.lines[1].flags, 1_441_792);
+        assert!(result.warnings.is_empty(), "no drop warning: {:?}", result.warnings);
+    }
+
+    #[test]
+    fn out_of_range_textpos_drops_cache_with_warning() {
+        // 텍스트 2유닛인데 textpos=70 — wire 총길이와 모순되는 조작 캐시는
+        // 승격하지 않고 경고한다 (W1b fail-closed).
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0"><t>본문</t></run>
+                <linesegarray>
+                    <lineseg textpos="0" vertpos="0" vertsize="1000"/>
+                    <lineseg textpos="70" vertpos="1600" vertsize="1000"/>
+                </linesegarray>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        assert!(result.paragraphs[0].layout_cache.is_none());
+        assert!(
+            result.warnings.iter().any(|w| matches!(
+                w,
+                super::super::DecodeWarning::LayoutCacheDropped { path, reason }
+                    if path.to_string() == "section[0].para[0]" && reason.contains("70")
+            )),
+            "expected LayoutCacheDropped with path, got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn mid_paragraph_marker_normalizes_following_lines() {
+        // 중간 각주 marker(8유닛) 뒤 줄 시작 — 종전 선두-균일 차감은 이
+        // 문단을 무음 오절단했다 (§1f 따름정리). wire: 가나다=0..3,
+        // ctrl=3..11, 라마바=11..14 → 줄2 시작 raw 12 = Core 4.
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0"><t>가나다</t><ctrl><footNote number="1"><subList><p paraPrIDRef="0"><run charPrIDRef="0"><t>각주</t></run></p></subList></footNote></ctrl><t>라마바</t></run>
+                <linesegarray>
+                    <lineseg textpos="0" vertpos="0" vertsize="1000"/>
+                    <lineseg textpos="12" vertpos="1600" vertsize="1000"/>
+                </linesegarray>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        let cache = result.paragraphs[0].layout_cache.as_ref().expect("promoted");
+        assert_eq!(cache.lines[0].textpos, 0);
+        assert_eq!(cache.lines[1].textpos, 4, "raw 12 − marker 8 = core 4");
+    }
+
+    #[test]
+    fn marker_interior_textpos_drops_cache_with_warning() {
+        // 줄 시작이 marker 내부(raw 5 ∈ ctrl 3..11)면 좌표를 신뢰할 수
+        // 없다 — 캐시 드롭 + 경고.
+        let xml = r#"<sec>
+            <p paraPrIDRef="0">
+                <run charPrIDRef="0"><t>가나다</t><ctrl><autoNum num="1" numType="PAGE"/></ctrl><t>라마바</t></run>
+                <linesegarray>
+                    <lineseg textpos="0" vertpos="0" vertsize="1000"/>
+                    <lineseg textpos="5" vertpos="1600" vertsize="1000"/>
+                </linesegarray>
+            </p>
+        </sec>"#;
+        let result = parse_section(xml, 0, &HashMap::new()).unwrap();
+        assert!(result.paragraphs[0].layout_cache.is_none());
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| matches!(w, super::super::DecodeWarning::LayoutCacheDropped { .. })));
     }
 
     #[test]
@@ -1965,14 +2262,14 @@ mod tests {
                 <run charPrIDRef="0"><t>본문 텍스트</t></run>
                 <linesegarray>
                     <lineseg textpos="16" vertpos="0" vertsize="1000"/>
-                    <lineseg textpos="70" vertpos="1600" vertsize="1000"/>
+                    <lineseg textpos="20" vertpos="1600" vertsize="1000"/>
                 </linesegarray>
             </p>
         </sec>"#;
         let result = parse_section(xml, 0, &HashMap::new()).unwrap();
         let cache = result.paragraphs[0].layout_cache.as_ref().expect("promoted");
         assert_eq!(cache.lines[0].textpos, 0, "16 − 16");
-        assert_eq!(cache.lines[1].textpos, 54, "70 − 16");
+        assert_eq!(cache.lines[1].textpos, 4, "20 − 16");
     }
 
     #[test]
@@ -2362,7 +2659,7 @@ mod tests {
         use crate::schema::section::HxTable;
         // Directly call convert_table at max depth to trigger the limit
         let hx = HxTable { row_cnt: 0, col_cnt: 0, rows: vec![], ..Default::default() };
-        let err = convert_table(&hx, MAX_NESTING_DEPTH).unwrap_err();
+        let err = convert_table(&hx, MAX_NESTING_DEPTH, &mut DecodeCtx::new(0)).unwrap_err();
         match &err {
             HwpxError::InvalidStructure { detail } => {
                 assert!(detail.contains("nesting depth"));
@@ -2381,7 +2678,7 @@ mod tests {
             rows: vec![HxTableRow { cells: vec![] }],
             ..Default::default()
         };
-        let err = convert_table(&hx, 0).unwrap_err();
+        let err = convert_table(&hx, 0, &mut DecodeCtx::new(0)).unwrap_err();
         match &err {
             HwpxError::InvalidStructure { detail } => {
                 assert!(detail.contains("rowCnt=2"));
@@ -4043,7 +4340,10 @@ mod tests {
         // 알 수 있게 경고를 표면화한다 (디코더의 증거 세탁 금지).
         assert_eq!(result.headers[0].apply_page_type, ApplyPageType::Both);
         assert_eq!(result.warnings.len(), 1, "{:?}", result.warnings);
-        let DecodeWarning::UnknownEnumValue { attribute, raw, fallback } = &result.warnings[0];
+        let DecodeWarning::UnknownEnumValue { attribute, raw, fallback } = &result.warnings[0]
+        else {
+            panic!("expected UnknownEnumValue, got: {:?}", result.warnings[0]);
+        };
         assert_eq!(*attribute, "hp:header@applyPageType");
         assert_eq!(raw, "WEIRD_VALUE");
         assert_eq!(*fallback, "BOTH");
@@ -4104,7 +4404,9 @@ mod tests {
             .warnings
             .iter()
             .map(|w| {
-                let DecodeWarning::UnknownEnumValue { attribute, .. } = w;
+                let DecodeWarning::UnknownEnumValue { attribute, .. } = w else {
+                    panic!("expected UnknownEnumValue, got: {w:?}");
+                };
                 *attribute
             })
             .collect();
@@ -4368,7 +4670,8 @@ mod tests {
             has_num_ref: 0,
             paragraphs: vec![HxParagraph::default()],
         };
-        let err = decode_sublist_paragraphs(&sub_list, MAX_NESTING_DEPTH).unwrap_err();
+        let err = decode_sublist_paragraphs(&sub_list, MAX_NESTING_DEPTH, &mut DecodeCtx::new(0))
+            .unwrap_err();
         match &err {
             crate::error::HwpxError::InvalidStructure { detail } => {
                 assert!(detail.contains("nesting depth"), "error must mention nesting depth");
@@ -4489,7 +4792,7 @@ mod tests {
                 paragraphs: vec![],
             },
         };
-        let caption = convert_hx_caption(&hx, 0).unwrap();
+        let caption = convert_hx_caption(&hx, 0, &mut DecodeCtx::new(0)).unwrap();
         use hwpforge_core::caption::CaptionSide;
         assert_eq!(caption.side, CaptionSide::Left);
         assert_eq!(caption.width.unwrap().as_i32(), 5000);
@@ -4519,7 +4822,7 @@ mod tests {
                 paragraphs: vec![],
             },
         };
-        let caption = convert_hx_caption(&hx, 0).unwrap();
+        let caption = convert_hx_caption(&hx, 0, &mut DecodeCtx::new(0)).unwrap();
         use hwpforge_core::caption::CaptionSide;
         assert_eq!(caption.side, CaptionSide::Right);
         assert!(caption.width.is_none(), "zero width must decode as None");
@@ -4551,10 +4854,11 @@ mod tests {
             },
         };
 
-        let top = convert_hx_caption(&make_caption("TOP"), 0).unwrap();
+        let top = convert_hx_caption(&make_caption("TOP"), 0, &mut DecodeCtx::new(0)).unwrap();
         assert_eq!(top.side, CaptionSide::Top);
 
-        let bottom = convert_hx_caption(&make_caption("BOTTOM"), 0).unwrap();
+        let bottom =
+            convert_hx_caption(&make_caption("BOTTOM"), 0, &mut DecodeCtx::new(0)).unwrap();
         assert_eq!(bottom.side, CaptionSide::Bottom);
     }
 

--- a/crates/hwpforge-smithy-hwpx/src/decoder/shapes.rs
+++ b/crates/hwpforge-smithy-hwpx/src/decoder/shapes.rs
@@ -17,7 +17,7 @@ use crate::schema::section::{
     HxTextArt,
 };
 
-use super::section::{convert_hx_caption, decode_sublist_paragraphs, parse_hex_color};
+use super::section::{convert_hx_caption, decode_sublist_paragraphs, parse_hex_color, DecodeCtx};
 
 /// Parses an `<hp:subList vertAlign="...">` token into a Core [`VerticalAlign`].
 ///
@@ -37,6 +37,7 @@ pub(crate) fn decode_textbox(
     rect: &HxRect,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Option<Run>> {
     // Extract width/height from sz, falling back to zero
     let (width, height) = rect
@@ -54,7 +55,7 @@ pub(crate) fn decode_textbox(
     let (horz_offset, vert_offset) =
         rect.pos.as_ref().map(|p| (p.horz_offset, p.vert_offset)).unwrap_or((0, 0));
 
-    let caption = rect.caption.as_ref().map(|c| convert_hx_caption(c, depth)).transpose()?;
+    let caption = rect.caption.as_ref().map(|c| convert_hx_caption(c, depth, ctx)).transpose()?;
 
     let style = decode_shape_style_full(
         &rect.line_shape,
@@ -66,7 +67,10 @@ pub(crate) fn decode_textbox(
 
     let control = match &rect.draw_text {
         Some(draw_text) => {
-            let paragraphs = decode_sublist_paragraphs(&draw_text.sub_list, depth)?;
+            ctx.enter(super::PathSeg::TextBox);
+            let result = decode_sublist_paragraphs(&draw_text.sub_list, depth, ctx);
+            ctx.leave();
+            let paragraphs = result?;
             let text_vertical_align = decode_shape_vert_align(&draw_text.sub_list.vert_align);
             Control::TextBox {
                 paragraphs,
@@ -90,6 +94,7 @@ pub(crate) fn decode_line(
     line: &HxLine,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Run> {
     use hwpforge_core::control::ShapePoint;
 
@@ -115,7 +120,7 @@ pub(crate) fn decode_line(
         })
         .unwrap_or((HwpUnit::ZERO, HwpUnit::ZERO));
 
-    let caption = line.caption.as_ref().map(|c| convert_hx_caption(c, depth)).transpose()?;
+    let caption = line.caption.as_ref().map(|c| convert_hx_caption(c, depth, ctx)).transpose()?;
 
     let (horz_offset, vert_offset) =
         line.pos.as_ref().map(|p| (p.horz_offset, p.vert_offset)).unwrap_or((0, 0));
@@ -146,6 +151,7 @@ pub(crate) fn decode_ellipse(
     ellipse: &HxEllipse,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Run> {
     use hwpforge_core::control::ShapePoint;
 
@@ -177,14 +183,17 @@ pub(crate) fn decode_ellipse(
         .unwrap_or((HwpUnit::ZERO, HwpUnit::ZERO));
 
     let (paragraphs, text_vertical_align) = match &ellipse.draw_text {
-        Some(dt) => (
-            decode_sublist_paragraphs(&dt.sub_list, depth)?,
-            decode_shape_vert_align(&dt.sub_list.vert_align),
-        ),
+        Some(dt) => {
+            ctx.enter(super::PathSeg::TextBox);
+            let result = decode_sublist_paragraphs(&dt.sub_list, depth, ctx);
+            ctx.leave();
+            (result?, decode_shape_vert_align(&dt.sub_list.vert_align))
+        }
         None => (Vec::new(), VerticalAlign::Top),
     };
 
-    let caption = ellipse.caption.as_ref().map(|c| convert_hx_caption(c, depth)).transpose()?;
+    let caption =
+        ellipse.caption.as_ref().map(|c| convert_hx_caption(c, depth, ctx)).transpose()?;
 
     let (horz_offset, vert_offset) =
         ellipse.pos.as_ref().map(|p| (p.horz_offset, p.vert_offset)).unwrap_or((0, 0));
@@ -218,6 +227,7 @@ pub(crate) fn decode_polygon(
     polygon: &HxPolygon,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Run> {
     use hwpforge_core::control::ShapePoint;
 
@@ -236,14 +246,17 @@ pub(crate) fn decode_polygon(
         .unwrap_or((HwpUnit::ZERO, HwpUnit::ZERO));
 
     let (paragraphs, text_vertical_align) = match &polygon.draw_text {
-        Some(dt) => (
-            decode_sublist_paragraphs(&dt.sub_list, depth)?,
-            decode_shape_vert_align(&dt.sub_list.vert_align),
-        ),
+        Some(dt) => {
+            ctx.enter(super::PathSeg::TextBox);
+            let result = decode_sublist_paragraphs(&dt.sub_list, depth, ctx);
+            ctx.leave();
+            (result?, decode_shape_vert_align(&dt.sub_list.vert_align))
+        }
         None => (Vec::new(), VerticalAlign::Top),
     };
 
-    let caption = polygon.caption.as_ref().map(|c| convert_hx_caption(c, depth)).transpose()?;
+    let caption =
+        polygon.caption.as_ref().map(|c| convert_hx_caption(c, depth, ctx)).transpose()?;
 
     let (horz_offset, vert_offset) =
         polygon.pos.as_ref().map(|p| (p.horz_offset, p.vert_offset)).unwrap_or((0, 0));
@@ -411,6 +424,7 @@ pub(crate) fn decode_arc(
     ellipse: &HxEllipse,
     char_shape_id: CharShapeIndex,
     _depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Run> {
     use hwpforge_core::control::ShapePoint;
 
@@ -444,7 +458,8 @@ pub(crate) fn decode_arc(
 
     let (horz_offset, vert_offset) =
         ellipse.pos.as_ref().map(|p| (p.horz_offset, p.vert_offset)).unwrap_or((0, 0));
-    let caption = ellipse.caption.as_ref().map(|c| convert_hx_caption(c, _depth)).transpose()?;
+    let caption =
+        ellipse.caption.as_ref().map(|c| convert_hx_caption(c, _depth, ctx)).transpose()?;
 
     Ok(Run {
         content: RunContent::Control(Box::new(Control::Arc {
@@ -478,6 +493,7 @@ pub(crate) fn decode_curve(
     curve: &HxCurve,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Run> {
     use hwpforge_core::control::ShapePoint;
 
@@ -515,7 +531,7 @@ pub(crate) fn decode_curve(
 
     let (horz_offset, vert_offset) =
         curve.pos.as_ref().map(|p| (p.horz_offset, p.vert_offset)).unwrap_or((0, 0));
-    let caption = curve.caption.as_ref().map(|c| convert_hx_caption(c, depth)).transpose()?;
+    let caption = curve.caption.as_ref().map(|c| convert_hx_caption(c, depth, ctx)).transpose()?;
 
     Ok(Run {
         content: RunContent::Control(Box::new(Control::Curve {
@@ -590,6 +606,7 @@ pub(crate) fn decode_connect_line(
     cl: &HxConnectLine,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Run> {
     use hwpforge_core::control::ShapePoint;
 
@@ -625,7 +642,7 @@ pub(crate) fn decode_connect_line(
 
     let (horz_offset, vert_offset) =
         cl.pos.as_ref().map(|p| (p.horz_offset, p.vert_offset)).unwrap_or((0, 0));
-    let caption = cl.caption.as_ref().map(|c| convert_hx_caption(c, depth)).transpose()?;
+    let caption = cl.caption.as_ref().map(|c| convert_hx_caption(c, depth, ctx)).transpose()?;
 
     Ok(Run {
         content: RunContent::Control(Box::new(Control::ConnectLine {
@@ -661,6 +678,7 @@ pub(crate) fn decode_container(
     container: &crate::schema::section::HxContainer,
     char_shape_id: CharShapeIndex,
     depth: usize,
+    ctx: &mut DecodeCtx,
 ) -> HwpxResult<Option<Run>> {
     // Bound nested-container recursion (group-in-group) against pathological
     // depth — same cap and pattern as table nesting (`convert_table`).
@@ -669,42 +687,64 @@ pub(crate) fn decode_container(
     }
 
     let mut children: Vec<Control> = Vec::new();
+    let mut child_idx: usize = 0;
 
-    let push_run = |run: Run, out: &mut Vec<Control>| {
+    let push_run = |run: Run, out: &mut Vec<Control>, child_idx: &mut usize| {
         if let RunContent::Control(boxed) = run.content {
             out.push(*boxed);
+            *child_idx += 1;
         }
     };
 
     for rect in &container.rects {
-        if let Some(run) = decode_textbox(rect, char_shape_id, depth)? {
-            push_run(run, &mut children);
+        ctx.enter(super::PathSeg::GroupChild(child_idx));
+        let result = decode_textbox(rect, char_shape_id, depth, ctx);
+        ctx.leave();
+        if let Some(run) = result? {
+            push_run(run, &mut children, &mut child_idx);
         }
     }
     for line in &container.lines {
-        push_run(decode_line(line, char_shape_id, depth)?, &mut children);
+        ctx.enter(super::PathSeg::GroupChild(child_idx));
+        let result = decode_line(line, char_shape_id, depth, ctx);
+        ctx.leave();
+        push_run(result?, &mut children, &mut child_idx);
     }
     for ellipse in &container.ellipses {
-        let run = if ellipse.has_arc_pr == 1 {
-            decode_arc(ellipse, char_shape_id, depth)?
+        ctx.enter(super::PathSeg::GroupChild(child_idx));
+        let result = if ellipse.has_arc_pr == 1 {
+            decode_arc(ellipse, char_shape_id, depth, ctx)
         } else {
-            decode_ellipse(ellipse, char_shape_id, depth)?
+            decode_ellipse(ellipse, char_shape_id, depth, ctx)
         };
-        push_run(run, &mut children);
+        ctx.leave();
+        push_run(result?, &mut children, &mut child_idx);
     }
     for polygon in &container.polygons {
-        push_run(decode_polygon(polygon, char_shape_id, depth)?, &mut children);
+        ctx.enter(super::PathSeg::GroupChild(child_idx));
+        let result = decode_polygon(polygon, char_shape_id, depth, ctx);
+        ctx.leave();
+        push_run(result?, &mut children, &mut child_idx);
     }
     for curve in &container.curves {
-        push_run(decode_curve(curve, char_shape_id, depth)?, &mut children);
+        ctx.enter(super::PathSeg::GroupChild(child_idx));
+        let result = decode_curve(curve, char_shape_id, depth, ctx);
+        ctx.leave();
+        push_run(result?, &mut children, &mut child_idx);
     }
     for connect_line in &container.connect_lines {
-        push_run(decode_connect_line(connect_line, char_shape_id, depth)?, &mut children);
+        ctx.enter(super::PathSeg::GroupChild(child_idx));
+        let result = decode_connect_line(connect_line, char_shape_id, depth, ctx);
+        ctx.leave();
+        push_run(result?, &mut children, &mut child_idx);
     }
     // Nested `<hp:container>` children recurse (Wave B); depth+1 bounds it.
     for nested in &container.containers {
-        if let Some(run) = decode_container(nested, char_shape_id, depth + 1)? {
-            push_run(run, &mut children);
+        ctx.enter(super::PathSeg::GroupChild(child_idx));
+        let result = decode_container(nested, char_shape_id, depth + 1, ctx);
+        ctx.leave();
+        if let Some(run) = result? {
+            push_run(run, &mut children, &mut child_idx);
         }
     }
 
@@ -1274,7 +1314,7 @@ mod tests {
     fn decode_arc_default_fields_normal_type() {
         let ellipse = default_ellipse();
         let cs = CharShapeIndex::new(0);
-        let run = decode_arc(&ellipse, cs, 0).unwrap();
+        let run = decode_arc(&ellipse, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Arc { arc_type, center, axis1, axis2, width, height, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1294,7 +1334,7 @@ mod tests {
         let mut ellipse = default_ellipse();
         ellipse.arc_type = "PIE".to_string();
         let cs = CharShapeIndex::new(0);
-        let run = decode_arc(&ellipse, cs, 0).unwrap();
+        let run = decode_arc(&ellipse, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Arc { arc_type, .. } = run.content.as_control().unwrap().clone() {
             assert_eq!(arc_type, ArcType::Pie);
         } else {
@@ -1307,7 +1347,7 @@ mod tests {
         let mut ellipse = default_ellipse();
         ellipse.arc_type = "CHORD".to_string();
         let cs = CharShapeIndex::new(0);
-        let run = decode_arc(&ellipse, cs, 0).unwrap();
+        let run = decode_arc(&ellipse, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Arc { arc_type, .. } = run.content.as_control().unwrap().clone() {
             assert_eq!(arc_type, ArcType::Chord);
         } else {
@@ -1324,7 +1364,7 @@ mod tests {
         ellipse.start1 = Some(HxPoint { x: 50, y: 100 });
         ellipse.end1 = Some(HxPoint { x: 150, y: 100 });
         let cs = CharShapeIndex::new(2);
-        let run = decode_arc(&ellipse, cs, 0).unwrap();
+        let run = decode_arc(&ellipse, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         assert_eq!(run.char_shape_id, cs);
         if let Control::Arc { center, axis1, axis2, start1, end1, .. } =
             run.content.as_control().unwrap().clone()
@@ -1345,7 +1385,7 @@ mod tests {
         ellipse.sz = Some(make_sz(5000, 3000));
         ellipse.pos = Some(make_pos(100, 200));
         let cs = CharShapeIndex::new(0);
-        let run = decode_arc(&ellipse, cs, 0).unwrap();
+        let run = decode_arc(&ellipse, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Arc { width, height, horz_offset, vert_offset, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1364,7 +1404,7 @@ mod tests {
         ellipse.rotation_info =
             Some(HxRotationInfo { angle: 45, center_x: 50, center_y: 50, rotate_image: 1 });
         let cs = CharShapeIndex::new(0);
-        let run = decode_arc(&ellipse, cs, 0).unwrap();
+        let run = decode_arc(&ellipse, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Arc { style, .. } = run.content.as_control().unwrap().clone() {
             let s = style.unwrap();
             let rot = s.rotation.unwrap();
@@ -1379,7 +1419,7 @@ mod tests {
         let mut ellipse = default_ellipse();
         ellipse.arc_type = "BOGUS".to_string();
         let cs = CharShapeIndex::new(0);
-        let run = decode_arc(&ellipse, cs, 0).unwrap();
+        let run = decode_arc(&ellipse, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Arc { arc_type, .. } = run.content.as_control().unwrap().clone() {
             assert_eq!(arc_type, ArcType::Normal);
         } else {
@@ -1393,7 +1433,7 @@ mod tests {
     fn decode_curve_empty_returns_no_points() {
         let curve = default_curve();
         let cs = CharShapeIndex::new(0);
-        let run = decode_curve(&curve, cs, 0).unwrap();
+        let run = decode_curve(&curve, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Curve { points, segment_types, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1412,7 +1452,7 @@ mod tests {
             HxCurveSegment { seg_type: "LINE".to_string(), x1: 100, y1: 50, x2: 200, y2: 100 },
         ];
         let cs = CharShapeIndex::new(0);
-        let run = decode_curve(&curve, cs, 0).unwrap();
+        let run = decode_curve(&curve, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Curve { points, segment_types, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1436,7 +1476,7 @@ mod tests {
         curve.segments =
             vec![HxCurveSegment { seg_type: "LINE".to_string(), x1: 0, y1: 0, x2: 999, y2: 999 }];
         let cs = CharShapeIndex::new(0);
-        let run = decode_curve(&curve, cs, 0).unwrap();
+        let run = decode_curve(&curve, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Curve { points, .. } = run.content.as_control().unwrap().clone() {
             assert_eq!(points.len(), 2);
             assert_eq!(points[0], ShapePoint::new(10, 20));
@@ -1452,7 +1492,7 @@ mod tests {
         curve.segments =
             vec![HxCurveSegment { seg_type: "BOGUS".to_string(), x1: 0, y1: 0, x2: 100, y2: 100 }];
         let cs = CharShapeIndex::new(0);
-        let run = decode_curve(&curve, cs, 0).unwrap();
+        let run = decode_curve(&curve, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Curve { segment_types, .. } = run.content.as_control().unwrap().clone() {
             assert_eq!(segment_types[0], CurveSegmentType::Curve);
         } else {
@@ -1466,7 +1506,7 @@ mod tests {
         curve.sz = Some(make_sz(8000, 4000));
         curve.pos = Some(make_pos(50, 75));
         let cs = CharShapeIndex::new(1);
-        let run = decode_curve(&curve, cs, 0).unwrap();
+        let run = decode_curve(&curve, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         assert_eq!(run.char_shape_id, cs);
         if let Control::Curve { width, height, horz_offset, vert_offset, .. } =
             run.content.as_control().unwrap().clone()
@@ -1486,7 +1526,7 @@ mod tests {
     fn decode_connect_line_defaults() {
         let cl = default_connect_line();
         let cs = CharShapeIndex::new(0);
-        let run = decode_connect_line(&cl, cs, 0).unwrap();
+        let run = decode_connect_line(&cl, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::ConnectLine { start, end, control_points, connect_type, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1515,7 +1555,7 @@ mod tests {
             subject_idx: "0".to_string(),
         });
         let cs = CharShapeIndex::new(0);
-        let run = decode_connect_line(&cl, cs, 0).unwrap();
+        let run = decode_connect_line(&cl, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::ConnectLine { start, end, .. } = run.content.as_control().unwrap().clone() {
             assert_eq!(start, ShapePoint::new(100, 200));
             assert_eq!(end, ShapePoint::new(500, 600));
@@ -1536,7 +1576,7 @@ mod tests {
             ],
         });
         let cs = CharShapeIndex::new(0);
-        let run = decode_connect_line(&cl, cs, 0).unwrap();
+        let run = decode_connect_line(&cl, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::ConnectLine { control_points, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1558,7 +1598,7 @@ mod tests {
             ],
         });
         let cs = CharShapeIndex::new(0);
-        let run = decode_connect_line(&cl, cs, 0).unwrap();
+        let run = decode_connect_line(&cl, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::ConnectLine { control_points, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1573,7 +1613,7 @@ mod tests {
         let mut cl = default_connect_line();
         cl.connect_type = "BENT".to_string();
         let cs = CharShapeIndex::new(0);
-        let run = decode_connect_line(&cl, cs, 0).unwrap();
+        let run = decode_connect_line(&cl, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::ConnectLine { connect_type, .. } = run.content.as_control().unwrap().clone()
         {
             assert_eq!(connect_type, "BENT");
@@ -1588,7 +1628,7 @@ mod tests {
         cl.sz = Some(make_sz(10000, 5000));
         cl.pos = Some(make_pos(150, 250));
         let cs = CharShapeIndex::new(3);
-        let run = decode_connect_line(&cl, cs, 0).unwrap();
+        let run = decode_connect_line(&cl, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         assert_eq!(run.char_shape_id, cs);
         if let Control::ConnectLine { width, height, horz_offset, vert_offset, .. } =
             run.content.as_control().unwrap().clone()
@@ -1636,7 +1676,7 @@ mod tests {
             end_pt: None,
         };
         let cs = CharShapeIndex::new(0);
-        let run = decode_line(&line, cs, 0).unwrap();
+        let run = decode_line(&line, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Line { start, end, width, height, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1694,7 +1734,9 @@ mod tests {
     fn decode_rect_without_draw_text_produces_control_rect() {
         let rect = default_rect(8000, 4000);
         let cs = CharShapeIndex::new(0);
-        let run = decode_textbox(&rect, cs, 0).unwrap().expect("pure rect must decode to a Run");
+        let run = decode_textbox(&rect, cs, 0, &mut DecodeCtx::new(0))
+            .unwrap()
+            .expect("pure rect must decode to a Run");
         match run.content.as_control().unwrap().clone() {
             Control::Rect { width, height, horz_offset, vert_offset, .. } => {
                 assert_eq!(width, hwpforge_foundation::HwpUnit::new(8000).unwrap());
@@ -1710,7 +1752,7 @@ mod tests {
     fn decode_ellipse_defaults_all_zero() {
         let ellipse = default_ellipse();
         let cs = CharShapeIndex::new(0);
-        let run = decode_ellipse(&ellipse, cs, 0).unwrap();
+        let run = decode_ellipse(&ellipse, cs, 0, &mut DecodeCtx::new(0)).unwrap();
         if let Control::Ellipse { center, axis1, axis2, width, height, paragraphs, .. } =
             run.content.as_control().unwrap().clone()
         {
@@ -1746,7 +1788,8 @@ mod tests {
     #[test]
     fn decode_ellipse_reads_center_vert_align_from_sublist() {
         let ellipse = ellipse_with_draw_text_align("CENTER");
-        let run = decode_ellipse(&ellipse, CharShapeIndex::new(0), 0).unwrap();
+        let run =
+            decode_ellipse(&ellipse, CharShapeIndex::new(0), 0, &mut DecodeCtx::new(0)).unwrap();
         match run.content.as_control().unwrap().clone() {
             Control::Ellipse { text_vertical_align, .. } => {
                 assert_eq!(text_vertical_align, hwpforge_foundation::VerticalAlign::Center);
@@ -1760,7 +1803,8 @@ mod tests {
         // 한컴 omits vertAlign for the default; empty must decode as Top so
         // default shapes round-trip unchanged.
         let ellipse = ellipse_with_draw_text_align("");
-        let run = decode_ellipse(&ellipse, CharShapeIndex::new(0), 0).unwrap();
+        let run =
+            decode_ellipse(&ellipse, CharShapeIndex::new(0), 0, &mut DecodeCtx::new(0)).unwrap();
         match run.content.as_control().unwrap().clone() {
             Control::Ellipse { text_vertical_align, .. } => {
                 assert_eq!(text_vertical_align, hwpforge_foundation::VerticalAlign::Top);
@@ -1795,6 +1839,7 @@ mod tests {
             0,
             &mut hl,
             crate::encoder::EncodeOptions::default(),
+            &mut crate::encoder::section::EncodeSink::new(0),
         )
         .unwrap();
         assert_eq!(
@@ -1802,7 +1847,7 @@ mod tests {
             "CENTER",
             "encoder must emit CENTER"
         );
-        let run = decode_ellipse(&hx, CharShapeIndex::new(0), 0).unwrap();
+        let run = decode_ellipse(&hx, CharShapeIndex::new(0), 0, &mut DecodeCtx::new(0)).unwrap();
         match run.content.as_control().unwrap().clone() {
             Control::Ellipse { text_vertical_align, .. } => {
                 assert_eq!(

--- a/crates/hwpforge-smithy-hwpx/src/diff.rs
+++ b/crates/hwpforge-smithy-hwpx/src/diff.rs
@@ -700,11 +700,14 @@ mod tests {
         assert_eq!(change.name, "user_email");
         assert_eq!(change.kind, FieldChangeKind::ValueChanged);
         assert_eq!(change.after.as_deref(), Some("diff@gate.io"));
-        // The field axis owns the change: nothing may leak elsewhere.
+        // The field axis owns the value change; W1b 이후 fill 은 해당
+        // 문단의 stale linesegarray 도 제거하므로 raw 축에 `$.layout_cache`
+        // 변경 하나가 **정직하게** 함께 보고된다 (§1g v5 변경 5).
         assert!(diff.semantic.cells.is_empty(), "cells: {:?}", diff.semantic.cells);
         assert!(diff.semantic.paragraphs.is_empty(), "paras: {:?}", diff.semantic.paragraphs);
         assert!(diff.semantic.structure.is_empty());
-        assert!(diff.semantic.raw.is_empty(), "raw: {:?}", diff.semantic.raw);
+        assert_eq!(diff.semantic.raw.len(), 1, "raw: {:?}", diff.semantic.raw);
+        assert_eq!(diff.semantic.raw[0].detail, "$.layout_cache");
         assert!(diff.package.changed.iter().any(|p| p.contains("section")));
     }
 

--- a/crates/hwpforge-smithy-hwpx/src/encoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/mod.rs
@@ -475,6 +475,30 @@ use self::package::PackageWriter;
 use self::section::encode_section;
 
 // ── HwpxEncoder ─────────────────────────────────────────────────
+/// 인코드 중 표면화된 비치명 경고 (W1b — §1g v5 변경 2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EncodeWarning {
+    /// 문단 캐시가 방출되지 않음 — 방출 wire map 구축 실패, 좌표
+    /// 역변환 실패(축약점 모호 등), 또는 cache-inadmissible 방출
+    /// (차트 재배치·스킵된 컨트롤 등).
+    LayoutCacheDropped {
+        /// 해당 문단의 중첩 경로.
+        path: crate::decoder::ParagraphPath,
+        /// 드롭 사유.
+        reason: String,
+    },
+}
+
+/// [`HwpxEncoder::encode_with_diagnostics`] 의 결과 — 산출 바이트 +
+/// 전체 typed 경고 (permissive 경로: 캐시 드롭이 있어도 성공).
+#[derive(Debug)]
+pub struct EncodeOutcome {
+    /// HWPX ZIP 바이트.
+    pub bytes: Vec<u8>,
+    /// 인코드 경고 (캐시 드롭 등).
+    pub warnings: Vec<EncodeWarning>,
+}
 
 /// Encoder behavior options.
 ///
@@ -572,6 +596,32 @@ impl HwpxEncoder {
         image_store: &ImageStore,
         options: EncodeOptions,
     ) -> HwpxResult<Vec<u8>> {
+        let outcome = Self::encode_with_diagnostics(document, style_store, image_store, options)?;
+        // W1b (§1g v5 변경 2): emit_layout_cache 요청 중 캐시 드롭은 무음
+        // 성공 금지 — 데이터 손실을 진단 없이 넘기지 않는다 (breaking,
+        // 0.14.0). 경고 보존 경로는 `encode_with_diagnostics`.
+        if options.emit_layout_cache {
+            if let Some(EncodeWarning::LayoutCacheDropped { path, reason }) =
+                outcome.warnings.first()
+            {
+                return Err(crate::error::HwpxError::LayoutCacheDropped {
+                    path: path.to_string(),
+                    reason: reason.clone(),
+                });
+            }
+        }
+        Ok(outcome.bytes)
+    }
+
+    /// [`Self::encode_with_options`] 의 진단 보존 변형 — 캐시 드롭이
+    /// 있어도 성공하고 typed 경고([`EncodeWarning`])를 함께 반환한다
+    /// (convert carry 파이프라인이 경고를 `ConvertWarning` 으로 전파).
+    pub fn encode_with_diagnostics(
+        document: &Document<Validated>,
+        style_store: &HwpxStyleStore,
+        image_store: &ImageStore,
+        options: EncodeOptions,
+    ) -> HwpxResult<EncodeOutcome> {
         let sections = document.sections();
         let sec_cnt = sections.len() as u32;
 
@@ -601,6 +651,10 @@ impl HwpxEncoder {
             embedded_ole_offset += result.embedded_oles.len();
             section_results.push(result);
         }
+        let mut warnings: Vec<EncodeWarning> = Vec::new();
+        for r in &mut section_results {
+            warnings.append(&mut r.warnings);
+        }
 
         // Single move-consuming pass: extract all four fields without cloning
         // (previously xml/charts/embedded_oles were `.iter().clone()`d).
@@ -624,7 +678,7 @@ impl HwpxEncoder {
         // Step 4: Package into ZIP with images, charts, master pages, and
         // embedded-chart OLE blobs. Document.metadata flows into content.hpf
         // <opf:metadata> (Wave 12o Phase 1).
-        PackageWriter::write_hwpx(
+        let bytes = PackageWriter::write_hwpx(
             document.metadata(),
             &header_xml,
             &section_xmls,
@@ -632,7 +686,8 @@ impl HwpxEncoder {
             &charts,
             &master_pages,
             &embedded_oles,
-        )
+        )?;
+        Ok(EncodeOutcome { bytes, warnings })
     }
 
     /// Encodes a validated document and writes it to a file.

--- a/crates/hwpforge-smithy-hwpx/src/encoder/mod.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/mod.rs
@@ -601,8 +601,12 @@ impl HwpxEncoder {
         // 성공 금지 — 데이터 손실을 진단 없이 넘기지 않는다 (breaking,
         // 0.14.0). 경고 보존 경로는 `encode_with_diagnostics`.
         if options.emit_layout_cache {
-            if let Some(EncodeWarning::LayoutCacheDropped { path, reason }) =
-                outcome.warnings.first()
+            // 독립 리뷰 Low: first() 는 미래 variant 가 앞에 끼는 순간
+            // 데이터-손실 신호를 삼킨다 — find 로 전수 검색.
+            if let Some(EncodeWarning::LayoutCacheDropped { path, reason }) = outcome
+                .warnings
+                .iter()
+                .find(|w| matches!(w, EncodeWarning::LayoutCacheDropped { .. }))
             {
                 return Err(crate::error::HwpxError::LayoutCacheDropped {
                     path: path.to_string(),

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -519,6 +519,7 @@ fn build_runs(
                     connect_lines: Vec::new(),
                     containers: Vec::new(),
                     textarts: Vec::new(),
+                    child_order: Vec::new(),
                 });
             }
         }
@@ -1036,6 +1037,7 @@ fn build_runs(
             composes,
             containers: Vec::new(),
             textarts: Vec::new(),
+            child_order: Vec::new(),
         });
     }
 
@@ -1065,6 +1067,7 @@ fn build_runs(
                     connect_lines: Vec::new(),
                     containers: Vec::new(),
                     textarts: Vec::new(),
+                    child_order: Vec::new(),
                 },
             );
         }

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -235,11 +235,17 @@ impl EncoderLedger {
         self.builder.push_span(wire, core);
     }
 
-    /// utf16 문자열의 가시 재생 span — 접힘 필드 본문 등 wire 는 소비하되
-    /// Core 기여가 0 인 경우 `core_scale=0`, 1:1 이면 1.
+    /// 접힘 필드(begin 8 + 본문 + end 8) 의 (n, 0) span.
+    ///
+    /// 독립 리뷰 Low 상환: 본문 tab 은 wire 8유닛이다 (디코더 in_field
+    /// Tab=(8,0) 과 대칭) — utf16 1:1 로 세면 필드가 tab 당 7유닛
+    /// 좁아져 이후 lineseg 가 무음 표류한다.
     fn folded_field(&mut self, body: &str) {
-        let body_units = body.encode_utf16().count() as u32;
-        self.span(16 + body_units, 0);
+        let mut wire: u32 = 16; // begin + end
+        for u in body.encode_utf16() {
+            wire += if u == u16::from(b'\t') { 8 } else { 1 };
+        }
+        self.span(wire, 0);
     }
 
     /// 혼합 텍스트(탭/줄바꿈 sentinel 포함)의 문자 단위 재생.
@@ -546,9 +552,24 @@ fn build_paragraph(
                     None
                 }
                 Ok(map) => {
+                    // 자가검증 (독립 리뷰 hardening — 디코더·HWP5 choke 와
+                    // 3중 대칭): ledger 의 Core 총길이 == 문단 가시 텍스트.
+                    // 누락된 zero-core span(미계측 방출 사이트)을 방어한다.
+                    let expected_core: u32 = para
+                        .runs
+                        .iter()
+                        .filter_map(|r| r.content.plain_text())
+                        .map(|t| t.encode_utf16().count() as u32)
+                        .sum();
                     let mut items = Vec::with_capacity(cache.lines.len());
-                    let mut dropped = false;
-                    for l in &cache.lines {
+                    let mut dropped = map.core_end() != expected_core;
+                    if dropped {
+                        sink.cache_dropped(format!(
+                            "ledger/emission core length mismatch (map {} vs paragraph {expected_core})",
+                            map.core_end()
+                        ));
+                    }
+                    for l in cache.lines.iter().take_while(|_| !dropped) {
                         match map.to_wire(l.textpos) {
                             Ok(textpos) => items.push(HxLineSeg {
                                 textpos,
@@ -1244,7 +1265,9 @@ fn build_runs(
             }
             _ => {
                 // Future RunContent variants are silently skipped
-                // (non_exhaustive enum)
+                // (non_exhaustive enum) — 방출 스킵 = 기하 stale (§1g v5
+                // R3#6, 독립 리뷰 Low 상환: Control `_` arm 과 대칭).
+                ledger.mark_cache_inadmissible("unencodable run content skipped");
                 continue;
             }
         }

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section.rs
@@ -150,6 +150,8 @@ fn encode_table_margin(value: TableMargin) -> HxTableMargin {
 pub(crate) struct SectionEncodeResult {
     /// The section XML string.
     pub xml: String,
+    /// 인코드 경고 (캐시 드롭 등 — W1b).
+    pub warnings: Vec<super::EncodeWarning>,
     /// Chart entries: (ZIP path, OOXML chart XML content).
     pub charts: Vec<(String, String)>,
     /// Master page entries: (ZIP path, masterpage XML content).
@@ -176,9 +178,99 @@ pub(crate) struct SectionEncodeResult {
 ///
 /// Returns [`HwpxError::XmlSerialize`] if quick-xml serialization fails,
 /// or [`HwpxError::InvalidStructure`] if table nesting exceeds the limit.
+/// 인코드 경고 sink + 현재 문단 경로 (W1b — 디코더 `DecodeCtx` 대칭).
+pub(crate) struct EncodeSink {
+    pub(crate) warnings: Vec<super::EncodeWarning>,
+    path: Vec<crate::decoder::PathSeg>,
+}
+
+impl EncodeSink {
+    pub(crate) fn new(section_index: usize) -> Self {
+        Self { warnings: Vec::new(), path: vec![crate::decoder::PathSeg::Section(section_index)] }
+    }
+
+    pub(crate) fn enter(&mut self, seg: crate::decoder::PathSeg) {
+        self.path.push(seg);
+    }
+
+    pub(crate) fn leave(&mut self) {
+        self.path.pop();
+    }
+
+    fn cache_dropped(&mut self, reason: String) {
+        self.warnings.push(super::EncodeWarning::LayoutCacheDropped {
+            path: crate::decoder::ParagraphPath(self.path.clone()),
+            reason,
+        });
+    }
+}
+
+/// 방출-통합 wire ledger (W1b §1g v5 변경 4) — `build_runs` 가 각 방출
+/// 사이트에서 span 을 기여한다. 모든 스킵/재배치/placeholder-미상 방출은
+/// [`mark_cache_inadmissible`] 단일 choke 를 지나며, `false→true` 복구는
+/// 불가능하다 (monotonic AND).
+///
+/// [`mark_cache_inadmissible`]: EncoderLedger::mark_cache_inadmissible
+pub(crate) struct EncoderLedger {
+    builder: crate::wire_text_map::WireMapBuilder,
+    inadmissible: Option<String>,
+}
+
+impl EncoderLedger {
+    fn new(injected_leading_ctrls: usize) -> Self {
+        let mut builder = crate::wire_text_map::WireMapBuilder::new();
+        // 직렬화 후 문자열 주입되는 선행 ctrl (colPr/머리말/꼬리말/쪽번호)
+        // — 트리 밖 (8,0) 유닛 (전부 영-core 라 상호 순서 무관).
+        for _ in 0..injected_leading_ctrls {
+            builder.push_span(8, 0);
+        }
+        Self { builder, inadmissible: None }
+    }
+
+    fn identity(&mut self, units: u32) {
+        self.builder.advance_identity(units);
+    }
+
+    fn span(&mut self, wire: u32, core: u32) {
+        self.builder.push_span(wire, core);
+    }
+
+    /// utf16 문자열의 가시 재생 span — 접힘 필드 본문 등 wire 는 소비하되
+    /// Core 기여가 0 인 경우 `core_scale=0`, 1:1 이면 1.
+    fn folded_field(&mut self, body: &str) {
+        let body_units = body.encode_utf16().count() as u32;
+        self.span(16 + body_units, 0);
+    }
+
+    /// 혼합 텍스트(탭/줄바꿈 sentinel 포함)의 문자 단위 재생.
+    fn mixed_text(&mut self, s: &str) {
+        for u in s.encode_utf16().collect::<Vec<u16>>() {
+            if u == u16::from(b'\t') {
+                self.span(8, 1);
+            } else {
+                self.identity(1);
+            }
+        }
+    }
+
+    /// cache-inadmissible 방출 표시 — 단일 choke, 첫 사유 보존.
+    fn mark_cache_inadmissible(&mut self, reason: &str) {
+        if self.inadmissible.is_none() {
+            self.inadmissible = Some(reason.to_string());
+        }
+    }
+
+    fn finish(self) -> Result<crate::wire_text_map::WireTextMap, String> {
+        if let Some(reason) = self.inadmissible {
+            return Err(reason);
+        }
+        self.builder.finish().map_err(|e| e.to_string())
+    }
+}
+
 pub(crate) fn encode_section(
     section: &Section,
-    _section_index: usize,
+    section_index: usize,
     chart_offset: usize,
     masterpage_offset: usize,
     embedded_ole_offset: usize,
@@ -189,6 +281,7 @@ pub(crate) fn encode_section(
     // Replacement list for run-level XML fragments that serde cannot express
     // directly, such as interleaved hyperlink controls and mixed-content `<hp:t>`.
     let mut run_xml_replacements: Vec<(String, String)> = Vec::new();
+    let mut sink = EncodeSink::new(section_index);
     let hx_section = build_section(
         section,
         &mut chart_entries,
@@ -197,6 +290,7 @@ pub(crate) fn encode_section(
         chart_offset,
         embedded_ole_offset,
         options,
+        &mut sink,
     )?;
     let inner_xml = quick_xml::se::to_string(&hx_section)
         .map_err(|e| HwpxError::XmlSerialize { detail: e.to_string() })?;
@@ -211,7 +305,13 @@ pub(crate) fn encode_section(
     let mut enriched = enrich_sec_pr(inner_content, section, masterpage_offset);
 
     // Inject header/footer/page number controls after colPr
-    inject_header_footer_pagenum(&mut enriched, section, &mut run_xml_replacements, options)?;
+    inject_header_footer_pagenum(
+        &mut enriched,
+        section,
+        &mut run_xml_replacements,
+        options,
+        &mut sink,
+    )?;
 
     // Replace hyperlink placeholder runs with real interleaved XML.
     // Serde cannot express the ctrl-text-ctrl interleaving required by
@@ -223,6 +323,7 @@ pub(crate) fn encode_section(
 
     Ok(SectionEncodeResult {
         xml: wrap_section_xml(&enriched),
+        warnings: sink.warnings,
         charts: chart_entries,
         master_pages,
         embedded_oles,
@@ -332,41 +433,40 @@ fn build_section(
     chart_offset: usize,
     embedded_ole_offset: usize,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxSection> {
-    // opt-in 캐시 방출 시 첫 문단의 스트림 유닛 역가산분: 인코더가 첫
-    // 문단에 주입하는 secPr(8) + colPr ctrl(8 — enrich 가 항상 추가) +
-    // 머리말/꼬리말/쪽번호 ctrl(각 8, inject_header_footer_pagenum).
-    // 디코더 정규화(convert_paragraph 의 leading_ctrl_units)와 왕복 대칭 —
-    // 주입 구성이 바뀌면 tests/layout_cache_roundtrip.rs 가 깨진다.
-    let first_para_stream_units: u32 = 8
-        * (2 + section.headers.len()
-            + section.footers.len()
-            + usize::from(section.page_number.is_some())) as u32;
-    let paragraphs = section
-        .paragraphs
-        .iter()
-        .enumerate()
-        .map(|(idx, para)| {
-            let inject_sec_pr = idx == 0;
-            let page_settings = if inject_sec_pr { Some(&section.page_settings) } else { None };
-            build_paragraph(
-                para,
-                inject_sec_pr,
-                page_settings,
-                section.text_direction,
-                idx,
-                0,
-                chart_entries,
-                embedded_oles,
-                hyperlink_entries,
-                chart_offset,
-                embedded_ole_offset,
-                options,
-                if inject_sec_pr { first_para_stream_units } else { 0 },
-            )
-            // (signature already plumbs embedded chart OLE state through)
-        })
-        .collect::<HwpxResult<Vec<_>>>()?;
+    // W1b: 첫 문단에 직렬화 후 문자열 주입되는 선행 ctrl 수 — colPr(1,
+    // enrich 가 항상 추가) + 머리말/꼬리말/쪽번호 (각 1,
+    // inject_header_footer_pagenum). secPr 는 typed 트리에 있어 ledger 가
+    // 직접 본다. 전부 영-core (8,0) 이라 상호 순서는 map 에 무관.
+    let injected_leading_ctrls: usize = 1
+        + section.headers.len()
+        + section.footers.len()
+        + usize::from(section.page_number.is_some());
+    let mut paragraphs = Vec::with_capacity(section.paragraphs.len());
+    for (idx, para) in section.paragraphs.iter().enumerate() {
+        let inject_sec_pr = idx == 0;
+        let page_settings = if inject_sec_pr { Some(&section.page_settings) } else { None };
+        sink.enter(crate::decoder::PathSeg::BodyParagraph(idx));
+        let built = build_paragraph(
+            para,
+            inject_sec_pr,
+            page_settings,
+            section.text_direction,
+            idx,
+            0,
+            chart_entries,
+            embedded_oles,
+            hyperlink_entries,
+            chart_offset,
+            embedded_ole_offset,
+            options,
+            if inject_sec_pr { injected_leading_ctrls } else { 0 },
+            sink,
+        );
+        sink.leave();
+        paragraphs.push(built?);
+    }
 
     Ok(HxSection { paragraphs })
 }
@@ -390,8 +490,10 @@ fn build_paragraph(
     chart_offset: usize,
     embedded_ole_offset: usize,
     options: EncodeOptions,
-    cache_stream_offset: u32,
+    injected_leading_ctrls: usize,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxParagraph> {
+    let mut ledger = EncoderLedger::new(injected_leading_ctrls);
     let mut runs = build_runs(
         &para.runs,
         inject_sec_pr,
@@ -404,6 +506,8 @@ fn build_paragraph(
         chart_offset,
         embedded_ole_offset,
         options,
+        &mut ledger,
+        sink,
     )?;
 
     // Inject <hp:titleMark ignore="false"/> into the first run when the
@@ -411,6 +515,9 @@ fn build_paragraph(
     if para.heading_level.is_some() {
         if let Some(first_run) = runs.first_mut() {
             first_run.title_mark = Some(HxTitleMark { ignore: false });
+            // titleMark 는 run 트리 후주입이라 wire 위치가 map 에 반영되지
+            // 않는다 — heading+캐시 조합은 드롭 (W1b 한계, 백로그).
+            ledger.mark_cache_inadmissible("titleMark injection position not cache-mapped");
         }
     }
 
@@ -426,24 +533,49 @@ fn build_paragraph(
     // secPr/colPr/header/footer/pageNum ctrl 유닛 — build_section 이 계산)을
     // 되더해 방출한다. 디코더 정규화와 정확히 왕복 대칭.
     // 편집 표면은 절대 켜지 않는다 — EncodeOptions::emit_layout_cache 문서 참조.
+    // W1b: Core 가시 좌표 → wire 좌표 역변환은 **방출-통합 ledger** 가
+    // 소유한다 (별도 match 복제 금지 — §1g v5 변경 4). to_wire(0)=0
+    // canonicalization 으로 첫 lineseg 는 native 불변식(항상 0)을 따른다.
+    // 실패(축약점 모호·inadmissible 방출 등) = 캐시 미방출 + 경고.
     let linesegarray = if options.emit_layout_cache {
-        para.layout_cache.as_ref().map(|cache| HxLineSegArray {
-            items: cache
-                .lines
-                .iter()
-                .map(|l| HxLineSeg {
-                    textpos: l.textpos + cache_stream_offset,
-                    vertpos: l.vertpos,
-                    vertsize: l.vertsize,
-                    textheight: l.textheight,
-                    baseline: l.baseline,
-                    spacing: l.spacing,
-                    horzpos: l.horzpos,
-                    horzsize: l.horzsize,
-                    flags: l.flags,
-                })
-                .collect(),
-        })
+        match &para.layout_cache {
+            None => None,
+            Some(cache) => match ledger.finish() {
+                Err(reason) => {
+                    sink.cache_dropped(reason);
+                    None
+                }
+                Ok(map) => {
+                    let mut items = Vec::with_capacity(cache.lines.len());
+                    let mut dropped = false;
+                    for l in &cache.lines {
+                        match map.to_wire(l.textpos) {
+                            Ok(textpos) => items.push(HxLineSeg {
+                                textpos,
+                                vertpos: l.vertpos,
+                                vertsize: l.vertsize,
+                                textheight: l.textheight,
+                                baseline: l.baseline,
+                                spacing: l.spacing,
+                                horzpos: l.horzpos,
+                                horzsize: l.horzsize,
+                                flags: l.flags,
+                            }),
+                            Err(e) => {
+                                sink.cache_dropped(format!("core textpos {}: {e}", l.textpos));
+                                dropped = true;
+                                break;
+                            }
+                        }
+                    }
+                    if dropped {
+                        None
+                    } else {
+                        Some(HxLineSegArray { items })
+                    }
+                }
+            },
+        }
     } else {
         None
     };
@@ -483,6 +615,8 @@ fn build_runs(
     chart_offset: usize,
     embedded_ole_offset: usize,
     options: EncodeOptions,
+    ledger: &mut EncoderLedger,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<Vec<HxRun>> {
     let mut result = Vec::new();
     let mut sec_pr_injected = false;
@@ -499,6 +633,7 @@ fn build_runs(
         if inject_sec_pr && !sec_pr_injected && run.content.is_control() {
             if let Some(ps) = page_settings {
                 sec_pr_injected = true;
+                ledger.span(8, 0);
                 result.push(HxRun {
                     char_pr_id_ref: 0,
                     sec_pr: Some(build_sec_pr(ps, text_direction)),
@@ -529,6 +664,9 @@ fn build_runs(
         } else {
             None
         };
+        if sec_pr.is_some() {
+            ledger.span(8, 0);
+        }
 
         let char_pr_id_ref = run.char_shape_id.get() as u32;
 
@@ -549,6 +687,7 @@ fn build_runs(
 
         match &run.content {
             RunContent::Text(s) => {
+                ledger.mixed_text(s);
                 if requires_inline_text_markup(s) {
                     let marker = next_marker("HWPTXT", char_pr_id_ref as usize);
                     let marker_xml = format!(r#"<hp:t>{marker}</hp:t>"#);
@@ -560,6 +699,14 @@ fn build_runs(
                 }
             }
             RunContent::InlineText(it) => {
+                for seg in &it.segments {
+                    match seg {
+                        hwpforge_core::inline::InlineSegment::Plain(s) => ledger.mixed_text(s),
+                        hwpforge_core::inline::InlineSegment::Tab(_) => ledger.span(8, 1),
+                        // 미래 inline 종류 — 소비량 미상 (fail-closed).
+                        _ => ledger.mark_cache_inadmissible("unknown inline segment kind"),
+                    }
+                }
                 // Always route through the marker-substitution path
                 // because InlineText carries `<hp:tab>` mixed content
                 // that the plain-string serializer cannot represent.
@@ -570,68 +717,114 @@ fn build_runs(
                 texts.push(HxText::new(marker));
             }
             RunContent::Table(t) => {
-                tables.push(build_table(t, depth, hyperlink_entries, options)?);
+                ledger.span(8, 0);
+                tables.push(build_table(t, depth, hyperlink_entries, options, sink)?);
             }
             RunContent::Image(img) => {
-                pictures.push(build_picture(img, depth, hyperlink_entries, options)?);
+                ledger.span(8, 0);
+                pictures.push(build_picture(img, depth, hyperlink_entries, options, sink)?);
             }
             RunContent::Control(ctrl) => {
                 match ctrl.as_ref() {
                     Control::Footnote { .. } | Control::Endnote { .. } => {
                         if let Some(hx_ctrl) =
-                            encode_control_to_ctrl(ctrl, depth, hyperlink_entries, options)?
+                            encode_control_to_ctrl(ctrl, depth, hyperlink_entries, options, sink)?
                         {
+                            ledger.span(8, 0);
                             ctrls.push(hx_ctrl);
+                        } else {
+                            ledger.mark_cache_inadmissible("unencodable note control skipped");
                         }
                     }
                     Control::TextBox { .. } => {
+                        ledger.span(8, 0);
                         rects.push(encode_textbox_to_rect(
                             ctrl,
                             depth,
                             hyperlink_entries,
                             options,
+                            sink,
                         )?);
                     }
                     Control::Rect { .. } => {
-                        rects.push(encode_rect_to_hx(ctrl, depth, hyperlink_entries, options)?);
+                        ledger.span(8, 0);
+                        rects.push(encode_rect_to_hx(
+                            ctrl,
+                            depth,
+                            hyperlink_entries,
+                            options,
+                            sink,
+                        )?);
                     }
                     Control::Line { .. } => {
-                        lines.push(encode_line_to_hx(ctrl, depth, hyperlink_entries, options)?);
+                        ledger.span(8, 0);
+                        lines.push(encode_line_to_hx(
+                            ctrl,
+                            depth,
+                            hyperlink_entries,
+                            options,
+                            sink,
+                        )?);
                     }
                     Control::Ellipse { .. } => {
+                        ledger.span(8, 0);
                         ellipses.push(encode_ellipse_to_hx(
                             ctrl,
                             depth,
                             hyperlink_entries,
                             options,
+                            sink,
                         )?);
                     }
                     Control::Polygon { .. } => {
+                        ledger.span(8, 0);
                         polygons.push(encode_polygon_to_hx(
                             ctrl,
                             depth,
                             hyperlink_entries,
                             options,
+                            sink,
                         )?);
                     }
                     Control::Arc { .. } => {
-                        ellipses.push(encode_arc_to_hx(ctrl, depth, hyperlink_entries, options)?);
+                        ledger.span(8, 0);
+                        ellipses.push(encode_arc_to_hx(
+                            ctrl,
+                            depth,
+                            hyperlink_entries,
+                            options,
+                            sink,
+                        )?);
                     }
                     Control::Curve { .. } => {
-                        curves.push(encode_curve_to_hx(ctrl, depth, hyperlink_entries, options)?);
+                        ledger.span(8, 0);
+                        curves.push(encode_curve_to_hx(
+                            ctrl,
+                            depth,
+                            hyperlink_entries,
+                            options,
+                            sink,
+                        )?);
                     }
                     Control::ConnectLine { .. } => {
+                        ledger.span(8, 0);
                         connect_lines.push(encode_connect_line_to_hx(
                             ctrl,
                             depth,
                             hyperlink_entries,
                             options,
+                            sink,
                         )?);
                     }
                     Control::Equation { .. } => {
+                        ledger.span(8, 0);
                         equations.push(encode_equation_to_hx(ctrl)?);
                     }
                     Control::Chart { .. } => {
+                        // 디코더가 chart 를 문단 꼬리로 재배치 (W1a 문서화)
+                        // — raw 위치 손실을 cache equality 로 세탁하지 않는다
+                        // (§1g v5 R3#6).
+                        ledger.mark_cache_inadmissible("chart emission reorders content");
                         let chart_idx = chart_offset + chart_entries.len() + 1;
                         let chart_ref = format!("Chart/chart{chart_idx}.xml");
                         let chart_xml = generate_chart_xml(ctrl)?;
@@ -646,6 +839,7 @@ fn build_runs(
                         horz_offset,
                         vert_offset,
                     } => {
+                        ledger.mark_cache_inadmissible("chart emission reorders content");
                         // Allocate stable per-document ids for the new chart
                         // XML file and the OLE blob. Both lists are
                         // section-global; we add `*_offset` to keep ids
@@ -697,6 +891,7 @@ fn build_runs(
                                 ),
                             });
                         };
+                        ledger.folded_field(text);
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPHL", field_id);
                         let real_xml =
@@ -719,6 +914,7 @@ fn build_runs(
                         align,
                         metadata,
                     } => {
+                        ledger.span(8, 0);
                         dutmals.push(encode_dutmal_to_hx(
                             main_text,
                             sub_text,
@@ -735,6 +931,7 @@ fn build_runs(
                         compose_type,
                         char_pr_ids,
                     } => {
+                        ledger.span(8, 0);
                         composes.push(encode_compose_to_hx(
                             compose_text,
                             circle_type,
@@ -748,14 +945,20 @@ fn build_runs(
                     | Control::PageHiding { .. }
                     | Control::Bookmark { bookmark_type: BookmarkType::Point, .. } => {
                         if let Some(hx_ctrl) =
-                            encode_control_to_ctrl(ctrl, depth, hyperlink_entries, options)?
+                            encode_control_to_ctrl(ctrl, depth, hyperlink_entries, options, sink)?
                         {
+                            ledger.span(8, 0);
                             ctrls.push(hx_ctrl);
+                        } else {
+                            // NewNumberKind::Unknown 등 — 방출 스킵 = 기하
+                            // stale (§1g v5 R3#6 일반 불변식).
+                            ledger.mark_cache_inadmissible("unencodable control skipped");
                         }
                     }
                     Control::Bookmark { name, bookmark_type }
                         if *bookmark_type == BookmarkType::SpanStart =>
                     {
+                        ledger.span(8, 0);
                         let field_id = hyperlink_entries.len();
                         bookmark_span_ids.insert(name.clone(), field_id);
                         let marker = next_marker("HWPBM", field_id);
@@ -771,6 +974,7 @@ fn build_runs(
                         if *bookmark_type == BookmarkType::SpanEnd =>
                     {
                         if let Some(&field_id) = bookmark_span_ids.get(name) {
+                            ledger.span(8, 0);
                             let marker = next_marker("HWPBE", field_id);
                             let real_xml =
                                 build_bookmark_span_end_run_xml(char_pr_id_ref, field_id);
@@ -779,13 +983,21 @@ fn build_runs(
                             );
                             hyperlink_entries.push((marker_run_xml, real_xml));
                             texts.push(HxText::new(marker));
+                        } else {
+                            // 무짝 SpanEnd 방출 스킵 — choke 경유 (v5 변경 4).
+                            ledger.mark_cache_inadmissible("unmatched bookmark span end");
                         }
-                        // Silently skip if no matching SpanStart found
                     }
                     Control::Field { field_type, hint_text, help_text, name, display_text } => {
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPFD", field_id);
                         let hint = hint_text.as_deref().unwrap_or("");
+                        // 본문 = 미채움이면 힌트 (E1/gotcha #30 계약과 동일).
+                        ledger.folded_field(if display_text.is_empty() {
+                            hint
+                        } else {
+                            display_text
+                        });
                         let real_xml = build_field_run_xml(
                             field_type,
                             hint,
@@ -814,6 +1026,7 @@ fn build_runs(
                     // arm further below which emits Hancom-native
                     // `type="PATH"` with `Format=` param and a distinct fieldid.
                     Control::UnknownSummary { token, display_text } => {
+                        ledger.folded_field(display_text);
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPFD", field_id);
                         // Wave 12p task #124: unknown token — assume Hancom
@@ -835,6 +1048,7 @@ fn build_runs(
                         texts.push(HxText::new(marker));
                     }
                     Control::DateCodeField { is_time_mode, display_text, .. } => {
+                        ledger.folded_field(display_text);
                         // LOSSY: %dte → SUMMERY mapping; raw_trailer is discarded.
                         // Round-trip through HWPX comes back as `Field(ModifiedTime)`
                         // or `Field(CreatedTime)` — proven by
@@ -864,6 +1078,7 @@ fn build_runs(
                         texts.push(HxText::new(marker));
                     }
                     Control::PathField { command, display_text } => {
+                        ledger.folded_field(display_text);
                         // Wave 12n Step 6 — LOSSLESS emit. The prior SUMMERY
                         // surrogate (mapped %pat → type="SUMMERY") triggered the
                         // Hancom "low security level — content recovered"
@@ -894,8 +1109,10 @@ fn build_runs(
                         // architect review CRITICAL: TotalPages/Unknown must not
                         // collapse to CurrentPage).
                         let Some(real_xml) = build_autonum_run_xml(char_pr_id_ref, *kind) else {
+                            ledger.mark_cache_inadmissible("unencodable control skipped");
                             continue;
                         };
+                        ledger.span(8, 0);
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPFD", field_id);
                         let marker_run_xml = format!(
@@ -922,6 +1139,7 @@ fn build_runs(
                         } else {
                             display_text.as_str()
                         };
+                        ledger.folded_field(visible_text);
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPXR", field_id);
                         let real_xml = build_crossref_run_xml(
@@ -940,10 +1158,18 @@ fn build_runs(
                         texts.push(HxText::new(marker));
                     }
                     Control::Memo { content, anchor_runs, metadata } => {
+                        if anchor_runs.iter().any(|r| r.content.plain_text().is_none()) {
+                            // 비텍스트 anchor run 은 방출에서 버려짐
+                            // (memo.rs) — 기하 stale.
+                            ledger.mark_cache_inadmissible("memo anchor drops non-text runs");
+                        }
+                        let anchor_text: String =
+                            anchor_runs.iter().filter_map(|r| r.content.plain_text()).collect();
+                        ledger.folded_field(&anchor_text);
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPME", field_id);
                         let sublist_xml =
-                            encode_memo_sublist(content, depth, hyperlink_entries, options)?;
+                            encode_memo_sublist(content, depth, hyperlink_entries, options, sink)?;
                         let anchor_xml = build_memo_anchor_xml(anchor_runs);
                         let real_xml = build_memo_run_xml(
                             &sublist_xml,
@@ -959,6 +1185,7 @@ fn build_runs(
                         texts.push(HxText::new(marker));
                     }
                     Control::Group { .. } => {
+                        ledger.span(8, 0);
                         // Group (묶음 객체) → <hp:container>. Serde cannot
                         // express the heterogeneous, z-ordered child shapes
                         // inside the container, so we build the full fragment
@@ -970,6 +1197,7 @@ fn build_runs(
                             0,
                             hyperlink_entries,
                             options,
+                            sink,
                         )?;
                         let field_id = hyperlink_entries.len();
                         let marker = next_marker("HWPGRP", field_id);
@@ -983,6 +1211,7 @@ fn build_runs(
                         texts.push(HxText::new(marker));
                     }
                     Control::TextArt { .. } => {
+                        ledger.span(8, 0);
                         // TextArt (글맵시) → <hp:textart>. Serde cannot express
                         // the fixed corner-point block + <hp:textartPr> shape
                         // and the scaMatrix entries are derived, so we build the
@@ -1001,11 +1230,14 @@ fn build_runs(
                         texts.push(HxText::new(marker));
                     }
                     Control::Unknown { .. } => {
-                        // Unknown controls are silently skipped
+                        // Unknown controls are silently skipped — 기하 stale
+                        // (§1g v5 R3#6: skipped emission 은 캐시 무효).
+                        ledger.mark_cache_inadmissible("unencodable control skipped");
                         continue;
                     }
                     _ => {
-                        // Future Control variants silently skipped
+                        // Future Control variants silently skipped — 동일.
+                        ledger.mark_cache_inadmissible("unencodable control skipped");
                         continue;
                     }
                 }
@@ -1084,32 +1316,35 @@ fn encode_control_to_ctrl(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<Option<HxCtrl>> {
     match ctrl {
-        Control::Footnote { inst_id, paragraphs } => Ok(Some(HxCtrl {
-            foot_note: Some(HxFootNote {
-                inst_id: inst_id.map(hwpforge_core::ObjectId::value),
-                sub_list: encode_paragraphs_to_sublist(
-                    paragraphs,
-                    depth,
-                    hyperlink_entries,
-                    options,
-                )?,
-            }),
-            ..Default::default()
-        })),
-        Control::Endnote { inst_id, paragraphs } => Ok(Some(HxCtrl {
-            end_note: Some(HxFootNote {
-                inst_id: inst_id.map(hwpforge_core::ObjectId::value),
-                sub_list: encode_paragraphs_to_sublist(
-                    paragraphs,
-                    depth,
-                    hyperlink_entries,
-                    options,
-                )?,
-            }),
-            ..Default::default()
-        })),
+        Control::Footnote { inst_id, paragraphs } => {
+            sink.enter(crate::decoder::PathSeg::Footnote);
+            let sub_list_result =
+                encode_paragraphs_to_sublist(paragraphs, depth, hyperlink_entries, options, sink);
+            sink.leave();
+            Ok(Some(HxCtrl {
+                foot_note: Some(HxFootNote {
+                    inst_id: inst_id.map(hwpforge_core::ObjectId::value),
+                    sub_list: sub_list_result?,
+                }),
+                ..Default::default()
+            }))
+        }
+        Control::Endnote { inst_id, paragraphs } => {
+            sink.enter(crate::decoder::PathSeg::Endnote);
+            let sub_list_result =
+                encode_paragraphs_to_sublist(paragraphs, depth, hyperlink_entries, options, sink);
+            sink.leave();
+            Ok(Some(HxCtrl {
+                end_note: Some(HxFootNote {
+                    inst_id: inst_id.map(hwpforge_core::ObjectId::value),
+                    sub_list: sub_list_result?,
+                }),
+                ..Default::default()
+            }))
+        }
         Control::Bookmark { name, bookmark_type: BookmarkType::Point } => Ok(Some(HxCtrl {
             bookmark: Some(HxBookmark { name: name.clone() }),
             ..Default::default()
@@ -1169,8 +1404,9 @@ pub(crate) fn encode_paragraphs_to_sublist(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxSubList> {
-    build_sublist(paragraphs, depth, "TOP", hyperlink_entries, options)
+    build_sublist(paragraphs, depth, "TOP", hyperlink_entries, options, sink)
 }
 
 /// Encodes a `Vec<Paragraph>` into `HxSubList` with an explicit vertical
@@ -1182,8 +1418,9 @@ pub(crate) fn encode_paragraphs_to_sublist_with_align(
     vert_align: &str,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxSubList> {
-    build_sublist(paragraphs, depth, vert_align, hyperlink_entries, options)
+    build_sublist(paragraphs, depth, vert_align, hyperlink_entries, options, sink)
 }
 
 fn build_sublist(
@@ -1192,6 +1429,7 @@ fn build_sublist(
     vert_align: &str,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxSubList> {
     let mut sub_chart_entries = Vec::new();
     let mut sub_embedded_oles: Vec<(String, Vec<u8>)> = Vec::new();
@@ -1199,7 +1437,8 @@ fn build_sublist(
         .iter()
         .enumerate()
         .map(|(idx, para)| {
-            build_paragraph(
+            sink.enter(crate::decoder::PathSeg::NestedParagraph(idx));
+            let result = build_paragraph(
                 para,
                 false,
                 None,
@@ -1213,7 +1452,10 @@ fn build_sublist(
                 0,
                 options,
                 0, // 서브리스트 문단(셀·머리말 등)엔 인코더 주입 컨트롤이 없다
-            )
+                sink,
+            );
+            sink.leave();
+            result
         })
         .collect::<HwpxResult<Vec<_>>>()?;
 
@@ -1261,6 +1503,7 @@ pub(crate) fn build_hx_caption(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxCaption> {
     let side = match caption.side {
         CaptionSide::Left => "LEFT",
@@ -1272,8 +1515,11 @@ pub(crate) fn build_hx_caption(
 
     let width = caption.width.map(|w| w.as_i32()).unwrap_or(parent_width);
     let gap = caption.gap.as_i32();
-    let sub_list =
-        encode_paragraphs_to_sublist(&caption.paragraphs, depth, hyperlink_entries, options)?;
+    sink.enter(crate::decoder::PathSeg::Caption);
+    let sub_list_result =
+        encode_paragraphs_to_sublist(&caption.paragraphs, depth, hyperlink_entries, options, sink);
+    sink.leave();
+    let sub_list = sub_list_result?;
 
     // parent_width comes from HwpUnit::as_i32(), guaranteed non-negative
     Ok(HxCaption { side, full_sz: 0, width, gap, last_width: parent_width as u32, sub_list })
@@ -1796,9 +2042,14 @@ mod tests {
     #[test]
     fn nesting_depth_exceeded() {
         let hx_table = Table::new(vec![]);
-        let err =
-            build_table(&hx_table, MAX_NESTING_DEPTH, &mut Vec::new(), EncodeOptions::default())
-                .unwrap_err();
+        let err = build_table(
+            &hx_table,
+            MAX_NESTING_DEPTH,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap_err();
         match &err {
             HwpxError::InvalidStructure { detail } => {
                 assert!(detail.contains("nesting depth"));
@@ -1819,7 +2070,14 @@ mod tests {
             1024,
         );
         let table = Table::new(vec![TableRow::new(vec![cell])]);
-        let err = build_table(&table, 0, &mut Vec::new(), EncodeOptions::default()).unwrap_err();
+        let err = build_table(
+            &table,
+            0,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap_err();
         match &err {
             HwpxError::InvalidStructure { detail } => {
                 assert!(detail.contains("covered area"), "unexpected detail: {detail}");
@@ -1836,7 +2094,14 @@ mod tests {
             HwpUnit::new(500).unwrap(),
             ImageFormat::Jpeg,
         );
-        let hx = build_picture(&img, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
+        let hx = build_picture(
+            &img,
+            0,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(
             hx.img.unwrap().binary_item_id_ref,
             "image",
@@ -1864,7 +2129,14 @@ mod tests {
             horz_offset: HwpUnit::new(3400).unwrap(),
         });
 
-        let hx = build_picture(&img, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
+        let hx = build_picture(
+            &img,
+            0,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(hx.text_wrap, "SQUARE");
         assert_eq!(hx.text_flow, "RIGHT_ONLY");
         let pos = hx.pos.expect("position should be present");
@@ -1885,7 +2157,14 @@ mod tests {
             HwpUnit::new(5000).unwrap(),
             ImageFormat::Png,
         );
-        let hx = build_picture(&img, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
+        let hx = build_picture(
+            &img,
+            0,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         let pos = hx.pos.expect("picture position should exist");
 
         assert_eq!(hx.text_wrap, "TOP_AND_BOTTOM");

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/header_footer.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/header_footer.rs
@@ -112,6 +112,7 @@ pub(super) fn inject_header_footer_pagenum(
     section: &Section,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<()> {
     // Find insertion point: after the last </hp:ctrl> that contains colPr
     // (or after </hp:secPr> if no colPr).
@@ -125,13 +126,19 @@ pub(super) fn inject_header_footer_pagenum(
 
     // Header — emit each `<hp:header>` element preserving the HWPX
     // multi-cardinality wire shape (ADR-002).
-    for header in &section.headers {
-        injection.push_str(&build_header_xml(header, "header", hyperlink_entries, options)?);
+    for (i, header) in section.headers.iter().enumerate() {
+        sink.enter(crate::decoder::PathSeg::Header(i));
+        let xml_result = build_header_xml(header, "header", hyperlink_entries, options, sink);
+        sink.leave();
+        injection.push_str(&xml_result?);
     }
 
     // Footer — same cardinality model.
-    for footer in &section.footers {
-        injection.push_str(&build_header_xml(footer, "footer", hyperlink_entries, options)?);
+    for (i, footer) in section.footers.iter().enumerate() {
+        sink.enter(crate::decoder::PathSeg::Footer(i));
+        let xml_result = build_header_xml(footer, "footer", hyperlink_entries, options, sink);
+        sink.leave();
+        injection.push_str(&xml_result?);
     }
 
     // Page number
@@ -179,6 +186,7 @@ pub(super) fn build_header_xml(
     tag_name: &str,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<String> {
     use std::fmt::Write as _;
 
@@ -206,6 +214,7 @@ pub(super) fn build_header_xml(
         vert_align,
         hyperlink_entries,
         options,
+        sink,
     )?;
     sub_list.text_width = u32::try_from(hf.text_width.as_i32()).unwrap_or(0);
     sub_list.text_height = u32::try_from(hf.text_height.as_i32()).unwrap_or(0);
@@ -332,8 +341,14 @@ mod tests {
             (ApplyPageType::Odd, "ODD"),
         ] {
             let hf = HeaderFooter::new(Vec::new(), apply);
-            let xml =
-                build_header_xml(&hf, "header", &mut entries, EncodeOptions::default()).unwrap();
+            let xml = build_header_xml(
+                &hf,
+                "header",
+                &mut entries,
+                EncodeOptions::default(),
+                &mut EncodeSink::new(0),
+            )
+            .unwrap();
             assert!(xml.contains(&format!(r#"applyPageType="{want}""#)), "{want}: {xml}");
             assert!(xml.starts_with("<hp:ctrl><hp:header"));
         }
@@ -347,7 +362,14 @@ mod tests {
         hf.vert_align = hwpforge_foundation::VerticalAlign::Bottom;
         hf.text_width = hwpforge_foundation::HwpUnit::new(42520).unwrap();
         hf.text_height = hwpforge_foundation::HwpUnit::new(4252).unwrap();
-        let xml = build_header_xml(&hf, "footer", &mut entries, EncodeOptions::default()).unwrap();
+        let xml = build_header_xml(
+            &hf,
+            "footer",
+            &mut entries,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert!(xml.contains(r#"vertAlign="BOTTOM""#), "{xml}");
         assert!(xml.contains(r#"textWidth="42520""#), "{xml}");
         assert!(xml.contains(r#"textHeight="4252""#), "{xml}");

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/memo.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/memo.rs
@@ -159,8 +159,13 @@ pub(super) fn encode_memo_sublist(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<String> {
-    let sublist = encode_paragraphs_to_sublist(paragraphs, depth, hyperlink_entries, options)?;
+    sink.enter(crate::decoder::PathSeg::Memo);
+    let sublist_result =
+        encode_paragraphs_to_sublist(paragraphs, depth, hyperlink_entries, options, sink);
+    sink.leave();
+    let sublist = sublist_result?;
     let xml = quick_xml::se::to_string(&sublist)
         .map_err(|e| HwpxError::InvalidStructure { detail: e.to_string() })?;
     // Fix root element: <HxSubList ...>...</HxSubList> → <hp:subList ...>...</hp:subList>

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/picture.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/picture.rs
@@ -26,6 +26,7 @@ pub(super) fn build_picture(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxPic> {
     let without_prefix = img.path.strip_prefix("BinData/").unwrap_or(&img.path);
     // Strip extension: "image1.png" → "image1"
@@ -103,7 +104,7 @@ pub(super) fn build_picture(
         caption: img
             .caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options, sink))
             .transpose()?,
     })
 }

--- a/crates/hwpforge-smithy-hwpx/src/encoder/section/table.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/section/table.rs
@@ -11,6 +11,7 @@ pub(super) fn build_table(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxTable> {
     if depth >= MAX_NESTING_DEPTH {
         return Err(HwpxError::InvalidStructure {
@@ -58,6 +59,7 @@ pub(super) fn build_table(
                 depth,
                 hyperlink_entries,
                 options,
+                sink,
             )
         })
         .collect::<HwpxResult<Vec<_>>>()?;
@@ -120,7 +122,7 @@ pub(super) fn build_table(
         caption: table
             .caption
             .as_ref()
-            .map(|c| build_hx_caption(c, table_width, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, table_width, depth, hyperlink_entries, options, sink))
             .transpose()?,
         in_margin: Some(table.in_margin.map(encode_table_margin).unwrap_or(DEFAULT_CELL_MARGIN)),
         rows,
@@ -141,6 +143,7 @@ fn build_table_row(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxTableRow> {
     let row_fallback_height =
         (!row.cells.iter().any(|cell| cell.height.is_some())).then_some(row.height).flatten();
@@ -150,7 +153,8 @@ fn build_table_row(
         .enumerate()
         .map(|(i, cell)| {
             let col_addr = col_addrs.get(i).copied().unwrap_or(i as u32);
-            build_table_cell(
+            sink.enter(crate::decoder::PathSeg::TableCell { row: row_idx as usize, cell: i });
+            let result = build_table_cell(
                 cell,
                 TableCellBuildContext {
                     col_idx: col_addr,
@@ -163,7 +167,10 @@ fn build_table_row(
                 depth,
                 hyperlink_entries,
                 options,
-            )
+                sink,
+            );
+            sink.leave();
+            result
         })
         .collect::<HwpxResult<Vec<_>>>()?;
 
@@ -190,6 +197,7 @@ fn build_table_cell(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxTableCell> {
     Ok(HxTableCell {
         name: String::new(),
@@ -205,6 +213,7 @@ fn build_table_cell(
             encode_table_vertical_align(cell.vertical_align.unwrap_or(TableVerticalAlign::Center)),
             hyperlink_entries,
             options,
+            sink,
         )?),
         cell_addr: Some(HxCellAddr { col_addr: ctx.col_idx, row_addr: ctx.row_idx }),
         cell_span: Some(HxCellSpan {
@@ -255,7 +264,14 @@ mod tests {
         let table = one_cell_table()
             .with_out_margin(margin(283, 284, 240, 241))
             .with_in_margin(margin(510, 511, 141, 142));
-        let hx = build_table(&table, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
+        let hx = build_table(
+            &table,
+            0,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         let out = hx.out_margin.expect("outMargin");
         assert_eq!((out.left, out.right, out.top, out.bottom), (283, 284, 240, 241));
         let inm = hx.in_margin.expect("inMargin");
@@ -270,8 +286,14 @@ mod tests {
     #[test]
     fn default_emission_is_unchanged_without_core_margins() {
         // None(우리 API 저작) = 기존 고정값 그대로 — 바이트 불변 계약.
-        let hx =
-            build_table(&one_cell_table(), 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
+        let hx = build_table(
+            &one_cell_table(),
+            0,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(hx.out_margin.expect("outMargin"), DEFAULT_OUT_MARGIN);
         assert_eq!(hx.in_margin.expect("inMargin"), DEFAULT_CELL_MARGIN);
         assert_eq!(
@@ -285,7 +307,14 @@ mod tests {
         // sz height 는 decode-only 캐시 — 인코더는 항상 자체 정책(0)을 쓴다.
         let table = one_cell_table()
             .with_layout_cache(TableLayoutCache::new(Some(HwpUnit::new(2831).unwrap()), true));
-        let hx = build_table(&table, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
+        let hx = build_table(
+            &table,
+            0,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(hx.sz.expect("sz").height, 0, "decode-only cache must not reach the wire");
     }
 
@@ -293,7 +322,14 @@ mod tests {
     fn explicit_cell_margin_still_wins_over_in_margin() {
         let mut table = one_cell_table().with_in_margin(margin(510, 510, 141, 141));
         table.rows[0].cells[0] = table.rows[0].cells[0].clone().with_margin(margin(10, 20, 30, 40));
-        let hx = build_table(&table, 0, &mut Vec::new(), EncodeOptions::default()).unwrap();
+        let hx = build_table(
+            &table,
+            0,
+            &mut Vec::new(),
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         let cell = &hx.rows[0].cells[0];
         assert_eq!(cell.has_margin, 1);
         let cm = cell.cell_margin.as_ref().expect("cellMargin");

--- a/crates/hwpforge-smithy-hwpx/src/encoder/shapes.rs
+++ b/crates/hwpforge-smithy-hwpx/src/encoder/shapes.rs
@@ -40,8 +40,11 @@ use crate::schema::section::{
 };
 
 use super::escape_xml;
-use super::section::{build_hx_caption, encode_paragraphs_to_sublist_with_align, generate_instid};
+use super::section::{
+    build_hx_caption, encode_paragraphs_to_sublist_with_align, generate_instid, EncodeSink,
+};
 use super::EncodeOptions;
+use crate::decoder::PathSeg;
 
 // ── Shape-common helpers ─────────────────────────────────────────
 
@@ -292,6 +295,7 @@ pub(crate) fn encode_textbox_to_rect(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxRect> {
     let (paragraphs, width, height, horz_offset, vert_offset, caption, style, text_vertical_align) =
         match ctrl {
@@ -324,13 +328,17 @@ pub(crate) fn encode_textbox_to_rect(
     const MARGIN: i32 = 283;
     let last_width = width_hwp.max(0) as u32;
 
-    let sub_list = encode_paragraphs_to_sublist_with_align(
+    sink.enter(PathSeg::TextBox);
+    let sub_list_result = encode_paragraphs_to_sublist_with_align(
         paragraphs,
         depth,
         &text_vertical_align.to_string(),
         hyperlink_entries,
         options,
-    )?;
+        sink,
+    );
+    sink.leave();
+    let sub_list = sub_list_result?;
     let sc = build_shape_common(width_hwp, height_hwp, style.as_ref());
 
     Ok(HxRect {
@@ -369,7 +377,7 @@ pub(crate) fn encode_textbox_to_rect(
         out_margin: Some(HxTableMargin { left: 0, right: 0, top: 0, bottom: 0 }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, width_hwp, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, width_hwp, depth, hyperlink_entries, options, sink))
             .transpose()?,
 
         draw_text: Some(HxDrawText {
@@ -402,6 +410,7 @@ pub(crate) fn encode_rect_to_hx(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxRect> {
     let (width, height, horz_offset, vert_offset, caption, style) = match ctrl {
         Control::Rect { width, height, horz_offset, vert_offset, caption, style } => {
@@ -448,7 +457,7 @@ pub(crate) fn encode_rect_to_hx(
         out_margin: Some(HxTableMargin { left: 0, right: 0, top: 0, bottom: 0 }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, width_hwp, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, width_hwp, depth, hyperlink_entries, options, sink))
             .transpose()?,
         // Pure rect: no embedded text content.
         draw_text: None,
@@ -466,6 +475,7 @@ pub(crate) fn encode_line_to_hx(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxLine> {
     let (start, end, width, height, horz_offset, vert_offset, caption, style) = match ctrl {
         Control::Line { start, end, width, height, horz_offset, vert_offset, caption, style } => {
@@ -511,7 +521,7 @@ pub(crate) fn encode_line_to_hx(
         shape_comment: Some(HxShapeComment { text: "선입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options, sink))
             .transpose()?,
         start_pt: Some(HxPoint { x: start.x, y: start.y }),
         end_pt: Some(HxPoint { x: end.x, y: end.y }),
@@ -524,6 +534,7 @@ pub(crate) fn encode_ellipse_to_hx(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxEllipse> {
     let (
         center,
@@ -573,13 +584,17 @@ pub(crate) fn encode_ellipse_to_hx(
     let draw_text = if paragraphs.is_empty() {
         None
     } else {
-        let sub_list = encode_paragraphs_to_sublist_with_align(
+        sink.enter(PathSeg::TextBox);
+        let sub_list_result = encode_paragraphs_to_sublist_with_align(
             paragraphs,
             depth,
             &text_vertical_align.to_string(),
             hyperlink_entries,
             options,
-        )?;
+            sink,
+        );
+        sink.leave();
+        let sub_list = sub_list_result?;
         Some(HxDrawText {
             last_width: 0,
             name: String::new(),
@@ -624,7 +639,7 @@ pub(crate) fn encode_ellipse_to_hx(
         shape_comment: Some(HxShapeComment { text: "타원입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options, sink))
             .transpose()?,
         draw_text,
         center: Some(HxPoint { x: center.x, y: center.y }),
@@ -643,6 +658,7 @@ pub(crate) fn encode_polygon_to_hx(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxPolygon> {
     let (
         vertices,
@@ -686,13 +702,17 @@ pub(crate) fn encode_polygon_to_hx(
     let draw_text = if paragraphs.is_empty() {
         None
     } else {
-        let sub_list = encode_paragraphs_to_sublist_with_align(
+        sink.enter(PathSeg::TextBox);
+        let sub_list_result = encode_paragraphs_to_sublist_with_align(
             paragraphs,
             depth,
             &text_vertical_align.to_string(),
             hyperlink_entries,
             options,
-        )?;
+            sink,
+        );
+        sink.leave();
+        let sub_list = sub_list_result?;
         Some(HxDrawText {
             last_width: 0,
             name: String::new(),
@@ -736,7 +756,7 @@ pub(crate) fn encode_polygon_to_hx(
         shape_comment: Some(HxShapeComment { text: "다각형입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options, sink))
             .transpose()?,
         draw_text,
         points,
@@ -751,6 +771,7 @@ pub(crate) fn encode_arc_to_hx(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxEllipse> {
     let (
         arc_type,
@@ -841,7 +862,7 @@ pub(crate) fn encode_arc_to_hx(
         shape_comment: Some(HxShapeComment { text: "호입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options, sink))
             .transpose()?,
         draw_text: None,
         center: Some(HxPoint { x: center.x, y: center.y }),
@@ -860,6 +881,7 @@ pub(crate) fn encode_curve_to_hx(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxCurve> {
     let (points, segment_types, width, height, horz_offset, vert_offset, caption, style) =
         match ctrl {
@@ -930,7 +952,7 @@ pub(crate) fn encode_curve_to_hx(
         shape_comment: Some(HxShapeComment { text: "곡선입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options, sink))
             .transpose()?,
         points: vec![], // KS X 6101: coordinates are in <hp:seg> elements, not <hc:pt>
         segments,
@@ -943,6 +965,7 @@ pub(crate) fn encode_connect_line_to_hx(
     depth: usize,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<HxConnectLine> {
     let (
         start,
@@ -1041,7 +1064,7 @@ pub(crate) fn encode_connect_line_to_hx(
         shape_comment: Some(HxShapeComment { text: "연결선입니다.".to_string() }),
         caption: caption
             .as_ref()
-            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options))
+            .map(|c| build_hx_caption(c, w, depth, hyperlink_entries, options, sink))
             .transpose()?,
     })
 }
@@ -1257,6 +1280,7 @@ fn encode_group_child_xml(
     group_level: u32,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<Option<String>> {
     // Nested group (Wave B): recurse into a full `<hp:container>` fragment.
     // `encode_group_to_xml` bakes the correct `groupLevel` into the opening
@@ -1268,7 +1292,7 @@ fn encode_group_child_xml(
     // already stripped during their own recursion.
     if let Control::Group { .. } = child {
         let (x, y) = group_child_offset(child);
-        let raw = encode_group_to_xml(child, depth, group_level, hyperlink_entries, options)?;
+        let raw = encode_group_to_xml(child, depth, group_level, hyperlink_entries, options, sink)?;
         let raw = set_group_child_offset(&raw, x, y);
         let raw = set_group_child_translate(&raw, x, y);
         let raw = zero_cur_sz(&raw);
@@ -1278,35 +1302,35 @@ fn encode_group_child_xml(
     }
     let raw = match child {
         Control::TextBox { .. } => serialize_with_root(
-            &encode_textbox_to_rect(child, depth, hyperlink_entries, options)?,
+            &encode_textbox_to_rect(child, depth, hyperlink_entries, options, sink)?,
             "hp:rect",
         )?,
         Control::Rect { .. } => serialize_with_root(
-            &encode_rect_to_hx(child, depth, hyperlink_entries, options)?,
+            &encode_rect_to_hx(child, depth, hyperlink_entries, options, sink)?,
             "hp:rect",
         )?,
         Control::Line { .. } => serialize_with_root(
-            &encode_line_to_hx(child, depth, hyperlink_entries, options)?,
+            &encode_line_to_hx(child, depth, hyperlink_entries, options, sink)?,
             "hp:line",
         )?,
         Control::Ellipse { .. } => serialize_with_root(
-            &encode_ellipse_to_hx(child, depth, hyperlink_entries, options)?,
+            &encode_ellipse_to_hx(child, depth, hyperlink_entries, options, sink)?,
             "hp:ellipse",
         )?,
         Control::Arc { .. } => serialize_with_root(
-            &encode_arc_to_hx(child, depth, hyperlink_entries, options)?,
+            &encode_arc_to_hx(child, depth, hyperlink_entries, options, sink)?,
             "hp:ellipse",
         )?,
         Control::Polygon { .. } => serialize_with_root(
-            &encode_polygon_to_hx(child, depth, hyperlink_entries, options)?,
+            &encode_polygon_to_hx(child, depth, hyperlink_entries, options, sink)?,
             "hp:polygon",
         )?,
         Control::Curve { .. } => serialize_with_root(
-            &encode_curve_to_hx(child, depth, hyperlink_entries, options)?,
+            &encode_curve_to_hx(child, depth, hyperlink_entries, options, sink)?,
             "hp:curve",
         )?,
         Control::ConnectLine { .. } => serialize_with_root(
-            &encode_connect_line_to_hx(child, depth, hyperlink_entries, options)?,
+            &encode_connect_line_to_hx(child, depth, hyperlink_entries, options, sink)?,
             "hp:connectLine",
         )?,
         Control::TextArt { .. } => encode_text_art_to_xml(child)?,
@@ -1345,6 +1369,7 @@ pub(crate) fn encode_group_to_xml(
     group_level: u32,
     hyperlink_entries: &mut Vec<(String, String)>,
     options: EncodeOptions,
+    sink: &mut EncodeSink,
 ) -> HwpxResult<String> {
     let (children, width, height, horz_offset, vert_offset, inst_id) = match ctrl {
         Control::Group { children, width, height, horz_offset, vert_offset, inst_id } => {
@@ -1365,13 +1390,21 @@ pub(crate) fn encode_group_to_xml(
     common.push_str(&serialize_with_root(&sc.rotation_info, "hp:rotationInfo")?);
     common.push_str(&serialize_with_root(&sc.rendering_info, "hp:renderingInfo")?);
 
-    // Children in z-order, each at the next group level.
+    // Children in z-order, each at the next group level. `emitted_idx` only
+    // advances for children that actually produce XML — dropped controls
+    // (Equation/EmbeddedChart/… — see `encode_group_child_xml`) never
+    // acquire a `GroupChild` path segment, so nested cache-drop warnings
+    // index against the emitted sequence, not the source child list.
     let mut children_xml = String::new();
+    let mut emitted_idx = 0usize;
     for child in children {
-        if let Some(xml) =
-            encode_group_child_xml(child, depth, group_level + 1, hyperlink_entries, options)?
-        {
+        sink.enter(PathSeg::GroupChild(emitted_idx));
+        let child_result =
+            encode_group_child_xml(child, depth, group_level + 1, hyperlink_entries, options, sink);
+        sink.leave();
+        if let Some(xml) = child_result? {
             children_xml.push_str(&xml);
+            emitted_idx += 1;
         }
     }
 
@@ -1566,8 +1599,15 @@ mod tests {
             inst_id: None,
         };
         let mut entries = Vec::new();
-        let xml =
-            encode_group_to_xml(&group, 0, 0, &mut entries, EncodeOptions::default()).unwrap();
+        let xml = encode_group_to_xml(
+            &group,
+            0,
+            0,
+            &mut entries,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
 
         assert!(xml.contains("<hp:container"), "missing container: {xml}");
         assert_eq!(xml.matches("<hp:rect").count(), 2, "expected 2 rect children");
@@ -1674,8 +1714,15 @@ mod tests {
             inst_id: None,
         };
         let mut entries = Vec::new();
-        let xml =
-            encode_group_to_xml(&outer, 0, 0, &mut entries, EncodeOptions::default()).unwrap();
+        let xml = encode_group_to_xml(
+            &outer,
+            0,
+            0,
+            &mut entries,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
 
         // Two nested containers: outer groupLevel=0, inner groupLevel=1.
         assert_eq!(xml.matches("<hp:container").count(), 2, "expected 2 containers: {xml}");
@@ -1910,7 +1957,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert_eq!(result.has_arc_pr, 1, "Arc must have hasArcPr=1");
     }
 
@@ -1933,7 +1982,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert_eq!(result.arc_type, "PIE");
     }
 
@@ -1956,7 +2007,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert_eq!(result.center.as_ref().unwrap().x, 100);
         assert_eq!(result.center.as_ref().unwrap().y, 200);
         assert_eq!(result.ax1.as_ref().unwrap().x, 300);
@@ -1986,7 +2039,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert_eq!(result.sz.as_ref().unwrap().width, 7000);
         assert_eq!(result.sz.as_ref().unwrap().height, 4000);
         // Non-zero offset → treat_as_char=0
@@ -2013,7 +2068,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "호입니다.");
     }
 
@@ -2036,7 +2093,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_arc_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert!(result.draw_text.is_none(), "Arc should have no draw_text");
     }
 
@@ -2055,7 +2114,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_curve_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert!(result.segments.is_empty());
         assert!(result.points.is_empty(), "KS X 6101: coords go in segments, not points");
     }
@@ -2077,7 +2143,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_curve_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.segments.len(), 2);
         let seg0 = &result.segments[0];
         assert_eq!(seg0.seg_type, "CURVE");
@@ -2106,7 +2179,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_curve_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert!(result.segments.is_empty(), "single point → no segments");
     }
 
@@ -2129,7 +2209,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_curve_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.segments.len(), 3);
         assert_eq!(result.segments[0].seg_type, "LINE");
         // Remaining use default CurveSegmentType::Curve
@@ -2150,7 +2237,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_curve_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "곡선입니다.");
     }
 
@@ -2167,7 +2261,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_curve_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_curve_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.pos.as_ref().unwrap().treat_as_char, 1);
     }
 
@@ -2188,8 +2289,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         let cp = result.control_points.as_ref().unwrap();
         // 1 intermediate + start + end = 3 total
         assert_eq!(cp.points.len(), 3);
@@ -2216,8 +2323,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         let cp = result.control_points.as_ref().unwrap();
         // Only start + end = 2
         assert_eq!(cp.points.len(), 2);
@@ -2240,8 +2353,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.connect_type, "CURVED");
     }
 
@@ -2261,8 +2380,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert!(result.fill_brush.is_none(), "connect lines must have no fill_brush");
     }
 
@@ -2285,8 +2410,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.numbering_type, "PICTURE");
         assert_eq!(result.text_wrap, "IN_FRONT_OF_TEXT");
         let pos = result.pos.as_ref().expect("connect line should carry a pos block");
@@ -2311,8 +2442,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.numbering_type, "NONE");
         assert_eq!(result.text_wrap, "TOP_AND_BOTTOM");
         let pos = result.pos.as_ref().expect("connect line should carry a pos block");
@@ -2335,8 +2472,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.start_pt.as_ref().unwrap().x, 111);
         assert_eq!(result.start_pt.as_ref().unwrap().y, 222);
         assert_eq!(result.end_pt.as_ref().unwrap().x, 333);
@@ -2358,8 +2501,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "연결선입니다.");
     }
 
@@ -2378,8 +2527,14 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result =
-            encode_connect_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_connect_line_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.pos.as_ref().unwrap().treat_as_char, 0);
     }
 
@@ -2398,7 +2553,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert!(result.fill_brush.is_none(), "lines have no fill brush per golden");
     }
 
@@ -2415,7 +2572,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "선입니다.");
     }
 
@@ -2432,7 +2591,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert_eq!(result.start_pt.as_ref().unwrap().x, 50);
         assert_eq!(result.start_pt.as_ref().unwrap().y, 100);
         assert_eq!(result.end_pt.as_ref().unwrap().x, 500);
@@ -2452,7 +2613,9 @@ mod tests {
             style: None,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_line_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert_eq!(result.numbering_type, "PICTURE");
         assert_eq!(result.text_wrap, "IN_FRONT_OF_TEXT");
         let pos = result.pos.as_ref().unwrap();
@@ -2480,7 +2643,14 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_ellipse_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "타원입니다.");
     }
 
@@ -2500,7 +2670,14 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_ellipse_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.has_arc_pr, 0, "Ellipse must have hasArcPr=0");
     }
 
@@ -2520,7 +2697,14 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_ellipse_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert!(result.draw_text.is_none());
     }
 
@@ -2548,7 +2732,14 @@ mod tests {
         // so existing top-aligned shapes are byte-unchanged.
         let ctrl = ellipse_with_valign(VerticalAlign::Top);
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_ellipse_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         let dt = result.draw_text.expect("ellipse with text must emit drawText");
         assert_eq!(dt.sub_list.vert_align, "TOP");
     }
@@ -2557,7 +2748,14 @@ mod tests {
     fn encode_ellipse_center_emits_center_sublist() {
         let ctrl = ellipse_with_valign(VerticalAlign::Center);
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_ellipse_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         let dt = result.draw_text.expect("ellipse with text must emit drawText");
         assert_eq!(dt.sub_list.vert_align, "CENTER");
     }
@@ -2566,7 +2764,14 @@ mod tests {
     fn encode_ellipse_bottom_emits_bottom_sublist() {
         let ctrl = ellipse_with_valign(VerticalAlign::Bottom);
         let mut hl = empty_hyperlinks();
-        let result = encode_ellipse_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_ellipse_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         let dt = result.draw_text.expect("ellipse with text must emit drawText");
         assert_eq!(dt.sub_list.vert_align, "BOTTOM");
     }
@@ -2593,7 +2798,14 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_polygon_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.points.len(), 4);
         assert_eq!(result.points[0].x, 0);
         assert_eq!(result.points[0].y, 100);
@@ -2620,7 +2832,14 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_polygon_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.shape_comment.as_ref().unwrap().text, "다각형입니다.");
     }
 
@@ -2643,7 +2862,14 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_polygon_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_polygon_to_hx(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.numbering_type, "PICTURE");
         assert_eq!(result.text_wrap, "IN_FRONT_OF_TEXT");
         let pos = result.pos.as_ref().unwrap();
@@ -2657,7 +2883,9 @@ mod tests {
     fn encode_rect_pure_emits_no_draw_text() {
         let ctrl = Control::rect(HwpUnit::new(8000).unwrap(), HwpUnit::new(4000).unwrap()).unwrap();
         let mut hl = empty_hyperlinks();
-        let result = encode_rect_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result =
+            encode_rect_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         assert!(result.draw_text.is_none(), "pure rect must not emit <hp:drawText>");
         let sz = result.sz.as_ref().unwrap();
         assert_eq!(sz.width, 8000);
@@ -2670,7 +2898,9 @@ mod tests {
     fn encode_rect_serializes_to_hp_rect_element() {
         let ctrl = Control::rect(HwpUnit::new(5000).unwrap(), HwpUnit::new(3000).unwrap()).unwrap();
         let mut hl = empty_hyperlinks();
-        let rect = encode_rect_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let rect =
+            encode_rect_to_hx(&ctrl, 0, &mut hl, EncodeOptions::default(), &mut EncodeSink::new(0))
+                .unwrap();
         let mut buf = String::new();
         let ser = quick_xml::se::Serializer::with_root(&mut buf, Some("hp:rect")).unwrap();
         serde::Serialize::serialize(&rect, ser).unwrap();
@@ -2691,7 +2921,14 @@ mod tests {
             text_vertical_align: VerticalAlign::Top,
         };
         let mut hl = empty_hyperlinks();
-        let result = encode_textbox_to_rect(&ctrl, 0, &mut hl, EncodeOptions::default()).unwrap();
+        let result = encode_textbox_to_rect(
+            &ctrl,
+            0,
+            &mut hl,
+            EncodeOptions::default(),
+            &mut EncodeSink::new(0),
+        )
+        .unwrap();
         assert_eq!(result.numbering_type, "PICTURE");
         assert_eq!(result.text_wrap, "IN_FRONT_OF_TEXT");
         let pos = result.pos.as_ref().unwrap();

--- a/crates/hwpforge-smithy-hwpx/src/error.rs
+++ b/crates/hwpforge-smithy-hwpx/src/error.rs
@@ -79,6 +79,17 @@ pub enum HwpxError {
         /// What went wrong.
         detail: String,
     },
+    /// 캐시 방출(`emit_layout_cache`) 중 하나 이상의 문단 캐시가
+    /// 드롭됨 — legacy `encode_with_options` 는 무음 성공 대신 이 에러를
+    /// 반환한다 (W1b §1g v5 변경 2; 진단 보존 경로는
+    /// `encode_with_diagnostics`).
+    #[error("layout cache dropped at {path}: {reason}")]
+    LayoutCacheDropped {
+        /// 첫 드롭 문단의 경로 (표시용).
+        path: String,
+        /// 드롭 사유.
+        reason: String,
+    },
 
     /// An I/O error occurred (e.g. reading a file from disk).
     #[error("I/O error: {0}")]
@@ -121,6 +132,8 @@ pub enum HwpxErrorCode {
     IndexOutOfBounds = 4005,
     /// Structural issue.
     InvalidStructure = 4006,
+    /// 캐시 방출 중 문단 캐시 드롭 (strict 인코드 실패).
+    LayoutCacheDropped = 4011,
     /// I/O failure.
     Io = 4007,
     /// Propagated Core error.
@@ -148,6 +161,7 @@ impl HwpxError {
             Self::InvalidAttribute { .. } => HwpxErrorCode::InvalidAttribute,
             Self::IndexOutOfBounds { .. } => HwpxErrorCode::IndexOutOfBounds,
             Self::InvalidStructure { .. } => HwpxErrorCode::InvalidStructure,
+            Self::LayoutCacheDropped { .. } => HwpxErrorCode::LayoutCacheDropped,
             Self::Io(_) => HwpxErrorCode::Io,
             Self::Core(_) => HwpxErrorCode::Core,
             Self::Foundation(_) => HwpxErrorCode::Foundation,

--- a/crates/hwpforge-smithy-hwpx/src/fill.rs
+++ b/crates/hwpforge-smithy-hwpx/src/fill.rs
@@ -145,6 +145,105 @@ pub(crate) struct FieldSlot<'a> {
     pub(crate) control: &'a mut Control,
 }
 
+/// 값이 바뀐 필드들의 둘러싼 `<hp:p>` 에서 `<hp:linesegarray>` 를 제거한다.
+///
+/// 이름 유일성은 fill preflight(DuplicateFieldName 거부)가 보장하므로
+/// 필드 이름으로 raw XML 에서 위치를 찾는 것이 무모호하다. 같은 문단의
+/// 다중 slot 은 첫 제거 후 자연히 no-op (문단당 정확히 1개 edit —
+/// §1g v5 변경 5).
+fn strip_linesegarray_for_changed_fields(
+    bytes: &[u8],
+    changed: &[(usize, String)],
+) -> crate::error::HwpxResult<Vec<u8>> {
+    if changed.is_empty() {
+        return Ok(bytes.to_vec());
+    }
+    let mut pkg = crate::patch::RawPackage::read(bytes)?;
+    let mut sections: std::collections::BTreeMap<usize, Vec<&str>> =
+        std::collections::BTreeMap::new();
+    for (section_idx, name) in changed {
+        sections.entry(*section_idx).or_default().push(name.as_str());
+    }
+    for (section_idx, names) in sections {
+        let path = crate::patch::section_path(section_idx);
+        let mut xml = pkg.read_text_entry(&path)?;
+        for name in names {
+            if let Some(stripped) = strip_paragraph_linesegarray_for_field(&xml, name) {
+                xml = stripped;
+            }
+        }
+        pkg.replace_text_entry(&path, xml);
+    }
+    pkg.write()
+}
+
+/// `name` 필드의 fieldBegin 을 찾아 그 문단의 linesegarray 를 제거한 XML 을
+/// 돌려준다. 필드/linesegarray 부재 시 `None` (무캐시 문단 = no-op).
+fn strip_paragraph_linesegarray_for_field(xml: &str, name: &str) -> Option<String> {
+    // fieldBegin 태그 중 name 속성이 일치하는 첫 위치.
+    let needle = format!("name=\"{name}\"");
+    let mut search = 0usize;
+    let field_pos = loop {
+        let at = xml[search..].find("<hp:fieldBegin")? + search;
+        let tag_end = xml[at..].find('>')? + at;
+        if xml[at..tag_end].contains(&needle) {
+            break at;
+        }
+        search = tag_end + 1;
+    };
+    let (p_start, p_end) = enclosing_paragraph_span(xml, field_pos)?;
+    let para = &xml[p_start..p_end];
+    let lsa_rel = para.find("<hp:linesegarray")?;
+    let lsa_start = p_start + lsa_rel;
+    let first_gt = xml[lsa_start..].find('>')? + lsa_start;
+    let lsa_end = if xml.as_bytes().get(first_gt.checked_sub(1)?) == Some(&b'/') {
+        first_gt + 1
+    } else {
+        let close = xml[lsa_start..p_end].find("</hp:linesegarray>")?;
+        lsa_start + close + "</hp:linesegarray>".len()
+    };
+    let mut out = String::with_capacity(xml.len());
+    out.push_str(&xml[..lsa_start]);
+    out.push_str(&xml[lsa_end..]);
+    Some(out)
+}
+
+/// `pos` 를 포함하는 가장 안쪽 `<hp:p …>…</hp:p>` 구간.
+///
+/// 중첩 문단(셀 등)은 안쪽이 먼저 닫히므로, pos 이후 처음 닫히는 열림이
+/// 곧 innermost 다.
+fn enclosing_paragraph_span(xml: &str, pos: usize) -> Option<(usize, usize)> {
+    let bytes = xml.as_bytes();
+    let mut stack: Vec<usize> = Vec::new();
+    let mut i = 0usize;
+    loop {
+        let open = xml[i..].find("<hp:p").map(|o| i + o);
+        let close = xml[i..].find("</hp:p>").map(|o| i + o);
+        let take_open = match (open, close) {
+            (None, None) => return None,
+            (Some(_), None) => true,
+            (None, Some(_)) => false,
+            (Some(o), Some(c)) => o < c,
+        };
+        if take_open {
+            let o = open.expect("checked");
+            // `<hp:pic` 등 배제 — 다음 문자가 공백/`>` 인 경우만 문단.
+            if matches!(bytes.get(o + 5), Some(b' ') | Some(b'>')) {
+                stack.push(o);
+            }
+            i = o + 5;
+        } else {
+            let c = close.expect("checked");
+            if let Some(s) = stack.pop() {
+                if s < pos && pos < c {
+                    return Some((s, c + "</hp:p>".len()));
+                }
+            }
+            i = c + "</hp:p>".len();
+        }
+    }
+}
+
 impl HwpxFiller {
     /// 문서의 모든 누름틀을 문서 순서로 나열한다 (발견가능성 표면).
     ///
@@ -241,6 +340,7 @@ impl HwpxFiller {
         let original_sections: Vec<Section> = decoded.document.sections().to_vec();
         let mut filled: Vec<FilledField> = Vec::new();
         let mut touched: Vec<usize> = Vec::new();
+        let mut changed_fields: Vec<(usize, String)> = Vec::new();
         for (section_idx, section) in decoded.document.sections_mut().iter_mut().enumerate() {
             visit_section_fields(section, section_idx, &mut |slot| {
                 if let Control::Field {
@@ -251,11 +351,17 @@ impl HwpxFiller {
                 } = &mut *slot.control
                 {
                     if let Some(value) = values.get(name.as_str()) {
+                        if value == display_text {
+                            // 동일 값 = 완전 no-op — mutate/FilledField/
+                            // touched/캐시 무효화 전부 생략 (§1g v5 변경 5).
+                            return;
+                        }
                         filled.push(FilledField {
                             name: name.clone(),
                             section: slot.section,
                             previous: std::mem::replace(display_text, value.clone()),
                         });
+                        changed_fields.push((slot.section, name.clone()));
                         if !touched.contains(&slot.section) {
                             touched.push(slot.section);
                         }
@@ -282,6 +388,12 @@ impl HwpxFiller {
                 Some(&preservation),
             )?;
         }
+
+        // W1b (§1g v5 변경 5): 값이 바뀐 필드의 둘러싼 문단에서
+        // linesegarray 를 제거한다 — 동일 UTF-16 길이라도 글자 폭이 다르면
+        // 줄바꿈/기하가 stale 이므로 "길이 변경 시"가 아니라 **값 변경 시
+        // 무조건**이다. 문단당 정확히 1회 제거 (이후 재조판은 한글 몫).
+        bytes = strip_linesegarray_for_changed_fields(&bytes, &changed_fields)?;
 
         Ok(FillOutcome { bytes, filled })
     }

--- a/crates/hwpforge-smithy-hwpx/src/lib.rs
+++ b/crates/hwpforge-smithy-hwpx/src/lib.rs
@@ -73,20 +73,21 @@ mod structural;
 mod style_lookup_bridge;
 pub mod style_store;
 mod table_inventory;
+mod wire_text_map;
 
 pub use cell_edit::{
     apply_set_cells, CellEditError, CellEditResult, CellResolution, CellSpec, CellTarget,
     HwpxCellEditor, SetCellOutcome, SetCellResult,
 };
 pub use decoder::package::{PackageEntryInfo, PackageReader};
-pub use decoder::{DecodeWarning, HwpxDecoder, HwpxDocument};
+pub use decoder::{DecodeWarning, HwpxDecoder, HwpxDocument, ParagraphPath, PathSeg};
 pub use default_styles::{DefaultStyleEntry, HancomStyleSet};
 pub use diff::{
     CellTextChange, DocumentDiff, FieldChange, FieldChangeKind, HwpxDiffer, PackageDiff,
     ParagraphChange, ParagraphChangeKind, RawChange, SemanticDiff, StructureChange,
     COMPARISON_NOTE, RAW_CAP,
 };
-pub use encoder::{EncodeOptions, HwpxEncoder};
+pub use encoder::{EncodeOptions, EncodeOutcome, EncodeWarning, HwpxEncoder};
 pub use error::{HwpxError, HwpxErrorCode, HwpxResult};
 pub use exchange::{
     ExportedDocument, ExportedSection, PreservedTextSlot, SectionPreservation, TextLocator,

--- a/crates/hwpforge-smithy-hwpx/src/patch.rs
+++ b/crates/hwpforge-smithy-hwpx/src/patch.rs
@@ -31,8 +31,8 @@ use crate::exchange::{
 };
 use crate::inline_text::encode_inline_text_xml;
 use crate::schema::section::{
-    HxCaption, HxFieldBegin, HxFootNote, HxHeaderFooter, HxParagraph, HxPic, HxRun, HxSection,
-    HxSubList, HxTable, HxTableCell, HxTableRow,
+    HxCaption, HxCtrl, HxFieldBegin, HxFootNote, HxHeaderFooter, HxParagraph, HxPic, HxRun,
+    HxSection, HxSubList, HxTable, HxTableCell, HxTableRow,
 };
 use crate::schema::shapes::{HxConnectLine, HxCurve, HxEllipse, HxLine, HxPolygon, HxRect};
 use crate::{HwpxDecoder, HwpxStyleStore};
@@ -689,9 +689,6 @@ fn collect_raw_run_slots(
     sink: &mut RawSlotSink<'_>,
     allow_section_header_footer: bool,
 ) -> HwpxResult<usize> {
-    let has_field_pair = run.ctrls.iter().any(|ctrl| ctrl.field_begin.is_some())
-        && run.ctrls.iter().any(|ctrl| ctrl.field_end.is_some());
-
     let text_locators = collect_direct_text_elements(xml, run_span.clone())?;
     if text_locators.len() != run.texts.len() {
         return Err(HwpxError::InvalidStructure {
@@ -703,67 +700,229 @@ fn collect_raw_run_slots(
         });
     }
 
-    if !has_field_pair {
-        for (text, locator) in run.texts.iter().zip(text_locators.iter()) {
-            let text_content = text.text();
-            if !text_content.is_empty() {
-                sink.body_slots.push(PreservedTextSlot {
-                    path: format!("{prefix}.runs[{semantic_run_idx}].text"),
-                    original_text: text_content,
-                    has_inline_markup: locator.has_inline_markup,
-                    locator: text_locator(locator),
-                });
+    // W1a: 디코더가 자식을 문서 순서(child_order 사이드카)로 평탄화하므로
+    // raw walker 도 같은 순서로 semantic_run_idx 를 전진시킨다 — 종전
+    // by-kind 재현(texts→tables→pictures→ctrls→shapes)은 인터리브 run 에서
+    // 경로 주소가 어긋난다. field 본문도 순서 기반: begin/end **사이**의
+    // 텍스트가 본문 (gotcha #30 모호성 게이트 철폐 — 디코더와 거울).
+    let kind_spans = |name: &[u8], expect: usize, label: &str| -> HwpxResult<Vec<Range<usize>>> {
+        let spans = collect_direct_child_outer_spans(xml, run_span.clone(), name)?;
+        if spans.len() != expect {
+            return Err(HwpxError::InvalidStructure {
+                detail: format!(
+                    "{label} count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
+                    spans.len(),
+                    expect
+                ),
+            });
+        }
+        Ok(spans)
+    };
+    let table_spans = kind_spans(b"hp:tbl", run.tables.len(), "table")?;
+    let picture_spans = kind_spans(b"hp:pic", run.pictures.len(), "picture")?;
+    let ctrl_spans = kind_spans(b"hp:ctrl", run.ctrls.len(), "ctrl")?;
+    let rect_spans = kind_spans(b"hp:rect", run.rects.len(), "rect")?;
+    let line_spans = kind_spans(b"hp:line", run.lines.len(), "line")?;
+    let ellipse_spans = kind_spans(b"hp:ellipse", run.ellipses.len(), "ellipse")?;
+    let polygon_spans = kind_spans(b"hp:polygon", run.polygons.len(), "polygon")?;
+    let curve_spans = kind_spans(b"hp:curve", run.curves.len(), "curve")?;
+    let connect_line_spans = kind_spans(b"hp:connectLine", run.connect_lines.len(), "connectLine")?;
+
+    let order = if run.child_order.is_empty() {
+        crate::schema::section::legacy_child_order(run)
+    } else {
+        run.child_order.clone()
+    };
+
+    let mut pending_field_begin: Option<&HxFieldBegin> = None;
+    // begin/end 사이 본문 텍스트 추적: (locator 인덱스, 사이 텍스트 개수).
+    // 슬롯은 본문이 정확히 1개 `<hp:t>` 일 때만 만든다 (단일 요소 교체
+    // locator 모델의 한계 — 0/2+ 개는 편집 슬롯 없음, 디코더 display_text
+    // 는 이어붙여 carry).
+    let mut field_body_locator: Option<usize> = None;
+    let mut field_body_count = 0usize;
+    let mut field_body_text = String::new();
+
+    for &(kind, idx) in &order {
+        use crate::schema::section::HxRunChildKind as K;
+        match kind {
+            K::Text => {
+                if pending_field_begin.is_some() {
+                    field_body_locator = Some(idx);
+                    field_body_count += 1;
+                    field_body_text.push_str(&run.texts[idx].text());
+                    continue;
+                }
+                let text_content = run.texts[idx].text();
+                if !text_content.is_empty() {
+                    sink.body_slots.push(PreservedTextSlot {
+                        path: format!("{prefix}.runs[{semantic_run_idx}].text"),
+                        original_text: text_content,
+                        has_inline_markup: text_locators[idx].has_inline_markup,
+                        locator: text_locator(&text_locators[idx]),
+                    });
+                    semantic_run_idx += 1;
+                }
+            }
+            K::Table => {
+                let table_prefix = format!("{prefix}.runs[{semantic_run_idx}].table");
+                collect_raw_table_slots(
+                    xml,
+                    table_spans[idx].clone(),
+                    &run.tables[idx],
+                    &table_prefix,
+                    sink,
+                )?;
                 semantic_run_idx += 1;
             }
+            K::Picture => {
+                if picture_has_semantic_run(&run.pictures[idx]) {
+                    let picture_prefix = format!("{prefix}.runs[{semantic_run_idx}].image");
+                    collect_raw_picture_slots(
+                        xml,
+                        picture_spans[idx].clone(),
+                        &run.pictures[idx],
+                        &picture_prefix,
+                        sink,
+                    )?;
+                    semantic_run_idx += 1;
+                }
+            }
+            K::Ctrl => {
+                semantic_run_idx = collect_raw_ctrl_child_slots(
+                    xml,
+                    ctrl_spans[idx].clone(),
+                    &run.ctrls[idx],
+                    prefix,
+                    semantic_run_idx,
+                    sink,
+                    allow_section_header_footer,
+                    &mut pending_field_begin,
+                    &mut field_body_locator,
+                    &mut field_body_count,
+                    &mut field_body_text,
+                    &text_locators,
+                )?;
+            }
+            K::Rect => {
+                if run.rects[idx].draw_text.is_some() {
+                    let rect_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.textbox");
+                    collect_raw_rect_slots(
+                        xml,
+                        rect_spans[idx].clone(),
+                        &run.rects[idx],
+                        &rect_prefix,
+                        sink,
+                    )?;
+                    semantic_run_idx += 1;
+                }
+            }
+            K::Line => {
+                let line_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.line");
+                collect_raw_line_slots(
+                    xml,
+                    line_spans[idx].clone(),
+                    &run.lines[idx],
+                    &line_prefix,
+                    sink,
+                )?;
+                semantic_run_idx += 1;
+            }
+            K::Ellipse => {
+                let ellipse = &run.ellipses[idx];
+                let control_name = if ellipse.has_arc_pr == 1 { "arc" } else { "ellipse" };
+                let ellipse_prefix =
+                    format!("{prefix}.runs[{semantic_run_idx}].control.{control_name}");
+                collect_raw_ellipse_slots(
+                    xml,
+                    ellipse_spans[idx].clone(),
+                    ellipse,
+                    control_name,
+                    &ellipse_prefix,
+                    sink,
+                )?;
+                semantic_run_idx += 1;
+            }
+            K::Polygon => {
+                let polygon_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.polygon");
+                collect_raw_polygon_slots(
+                    xml,
+                    polygon_spans[idx].clone(),
+                    &run.polygons[idx],
+                    &polygon_prefix,
+                    sink,
+                )?;
+                semantic_run_idx += 1;
+            }
+            K::Curve => {
+                let curve_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.curve");
+                collect_raw_curve_slots(
+                    xml,
+                    curve_spans[idx].clone(),
+                    &run.curves[idx],
+                    &curve_prefix,
+                    sink,
+                )?;
+                semantic_run_idx += 1;
+            }
+            K::ConnectLine => {
+                let connect_line_prefix =
+                    format!("{prefix}.runs[{semantic_run_idx}].control.connect_line");
+                collect_raw_connect_line_slots(
+                    xml,
+                    connect_line_spans[idx].clone(),
+                    &run.connect_lines[idx],
+                    &connect_line_prefix,
+                    sink,
+                )?;
+                semantic_run_idx += 1;
+            }
+            // 디코더가 문서 순서 위치에서 run 을 방출하는 슬롯-없는 종류 —
+            // 인덱스만 전진 (equation/dutmal/compose + W1a 신규: container/
+            // textart — 종전 walker 는 이 둘을 아예 세지 않던 잠복 결함).
+            K::Equation | K::Dutmal | K::Compose | K::Container | K::TextArt => {
+                semantic_run_idx += 1;
+            }
+            // Switch(차트) 는 디코더가 문단 끝에 append — run 꼬리 집계 유지.
+            // secPr/titleMark/Other 는 run 방출 없음.
+            K::Switch | K::SecPr | K::TitleMark | K::Other => {}
         }
     }
-
-    let table_spans = collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:tbl")?;
-    if table_spans.len() != run.tables.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "table count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                table_spans.len(),
-                run.tables.len()
-            ),
-        });
-    }
-    for (table, table_span) in run.tables.iter().zip(table_spans.into_iter()) {
-        let table_prefix = format!("{prefix}.runs[{semantic_run_idx}].table");
-        collect_raw_table_slots(xml, table_span, table, &table_prefix, sink)?;
+    // trailing self-closing fieldBegin (BOOKMARK span start) — 디코더 거울.
+    if pending_field_begin.take().is_some_and(|fb| fb.field_type == "BOOKMARK") {
         semantic_run_idx += 1;
     }
+    // Switch(차트): 디코더가 문단 끝에 append 하므로 종전대로 run 꼬리 집계.
+    semantic_run_idx += run
+        .switches
+        .iter()
+        .filter(|switch_case| {
+            switch_case.case.as_ref().and_then(|case| case.chart.as_ref()).is_some()
+        })
+        .count();
 
-    let picture_spans = collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:pic")?;
-    if picture_spans.len() != run.pictures.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "picture count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                picture_spans.len(),
-                run.pictures.len()
-            ),
-        });
-    }
-    for (picture, picture_span) in run.pictures.iter().zip(picture_spans.into_iter()) {
-        if picture_has_semantic_run(picture) {
-            let picture_prefix = format!("{prefix}.runs[{semantic_run_idx}].image");
-            collect_raw_picture_slots(xml, picture_span, picture, &picture_prefix, sink)?;
-            semantic_run_idx += 1;
-        }
-    }
+    Ok(semantic_run_idx)
+}
 
-    let ctrl_spans = collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:ctrl")?;
-    if ctrl_spans.len() != run.ctrls.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "ctrl count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                ctrl_spans.len(),
-                run.ctrls.len()
-            ),
-        });
-    }
-    let mut pending_field_begin: Option<&HxFieldBegin> = None;
-    for (ctrl, ctrl_span) in run.ctrls.iter().zip(ctrl_spans.into_iter()) {
+/// `<hp:ctrl>` 자식 하나의 raw 슬롯/인덱스 처리 (W1a — 디코더
+/// `convert_ctrl_child` 와 거울상. field 본문은 순서 기반: begin/end 사이
+/// 텍스트가 정확히 1개일 때만 편집 슬롯을 만든다).
+#[allow(clippy::too_many_arguments)]
+fn collect_raw_ctrl_child_slots<'a>(
+    xml: &str,
+    ctrl_span: Range<usize>,
+    ctrl: &'a HxCtrl,
+    prefix: &str,
+    mut semantic_run_idx: usize,
+    sink: &mut RawSlotSink<'_>,
+    allow_section_header_footer: bool,
+    pending_field_begin: &mut Option<&'a HxFieldBegin>,
+    field_body_locator: &mut Option<usize>,
+    field_body_count: &mut usize,
+    field_body_text: &mut String,
+    text_locators: &[TextElementSpan],
+) -> HwpxResult<usize> {
+    {
         if allow_section_header_footer {
             if let Some(header) = &ctrl.header {
                 collect_raw_header_footer_slots(
@@ -801,30 +960,32 @@ fn collect_raw_run_slots(
             semantic_run_idx += 1;
         }
         if let Some(field_begin) = &ctrl.field_begin {
-            pending_field_begin = Some(field_begin);
+            *pending_field_begin = Some(field_begin);
+            *field_body_locator = None;
+            *field_body_count = 0;
+            field_body_text.clear();
         }
         if ctrl.field_end.is_some() {
             if let Some(field_begin) = pending_field_begin.take() {
-                // 누름틀(CLICK_HERE) 본문 <hp:t> 는 디코더가 display_text 로
-                // 흡수하는 채워진 값이다 — semantic 쪽 Field arm 과 거울상으로
-                // 슬롯을 방출한다 (Epic 1). 디코더와 동일한 무모호-귀속
-                // 게이트: run 에 <hp:t> 가 정확히 1개일 때만 슬롯을 만든다
-                // (decoder/section.rs `unambiguous_body`). 복수면 디코더가
-                // display_text 를 비우므로 semantic 쪽도 슬롯을 만들지 않아
-                // 거울이 유지된다 — 한컴 재저장이 라벨 run 을 필드 run 에
-                // 병합한 파일(fixture `fields/clickhere_filled.hwpx`)이
-                // 실존하는 사례.
-                if field_begin.field_type == "CLICK_HERE" && text_locators.len() == 1 {
-                    let body = run.texts[0].text();
-                    if !body.is_empty() {
+                // 누름틀(CLICK_HERE) 본문 = begin/end **사이** 텍스트 (W1a
+                // 문서 순서 — 종전 `<hp:t> 1개` 모호성 게이트 철폐, 디코더와
+                // 거울). 편집 슬롯은 단일 요소 교체 locator 모델이라 사이
+                // 텍스트가 정확히 1개일 때만 만든다 (0/2+ 는 슬롯 없음 —
+                // 디코더 display_text 는 이어붙여 carry).
+                if field_begin.field_type == "CLICK_HERE" && *field_body_count == 1 {
+                    let li = field_body_locator.expect("count==1 이면 locator 존재");
+                    if !field_body_text.is_empty() {
                         sink.body_slots.push(PreservedTextSlot {
                             path: format!("{prefix}.runs[{semantic_run_idx}].control.field"),
-                            original_text: body,
-                            has_inline_markup: text_locators[0].has_inline_markup,
-                            locator: text_locator(&text_locators[0]),
+                            original_text: field_body_text.clone(),
+                            has_inline_markup: text_locators[li].has_inline_markup,
+                            locator: text_locator(&text_locators[li]),
                         });
                     }
                 }
+                *field_body_locator = None;
+                *field_body_count = 0;
+                field_body_text.clear();
                 semantic_run_idx += 1;
             }
         }
@@ -846,131 +1007,6 @@ fn collect_raw_run_slots(
             semantic_run_idx += 1;
         }
     }
-    if let Some(field_begin) = pending_field_begin.take() {
-        if field_begin.field_type == "BOOKMARK" {
-            semantic_run_idx += 1;
-        }
-    }
-
-    let rect_spans = collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:rect")?;
-    if rect_spans.len() != run.rects.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "rect count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                rect_spans.len(),
-                run.rects.len()
-            ),
-        });
-    }
-    for (rect, rect_span) in run.rects.iter().zip(rect_spans.into_iter()) {
-        if rect.draw_text.is_some() {
-            let rect_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.textbox");
-            collect_raw_rect_slots(xml, rect_span, rect, &rect_prefix, sink)?;
-            semantic_run_idx += 1;
-        }
-    }
-
-    let line_spans = collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:line")?;
-    if line_spans.len() != run.lines.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "line count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                line_spans.len(),
-                run.lines.len()
-            ),
-        });
-    }
-    for (line, line_span) in run.lines.iter().zip(line_spans.into_iter()) {
-        let line_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.line");
-        collect_raw_line_slots(xml, line_span, line, &line_prefix, sink)?;
-        semantic_run_idx += 1;
-    }
-
-    let ellipse_spans = collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:ellipse")?;
-    if ellipse_spans.len() != run.ellipses.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "ellipse count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                ellipse_spans.len(),
-                run.ellipses.len()
-            ),
-        });
-    }
-    for (ellipse, ellipse_span) in run.ellipses.iter().zip(ellipse_spans.into_iter()) {
-        let control_name = if ellipse.has_arc_pr == 1 { "arc" } else { "ellipse" };
-        let ellipse_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.{control_name}");
-        collect_raw_ellipse_slots(xml, ellipse_span, ellipse, control_name, &ellipse_prefix, sink)?;
-        semantic_run_idx += 1;
-    }
-
-    let polygon_spans = collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:polygon")?;
-    if polygon_spans.len() != run.polygons.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "polygon count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                polygon_spans.len(),
-                run.polygons.len()
-            ),
-        });
-    }
-    for (polygon, polygon_span) in run.polygons.iter().zip(polygon_spans.into_iter()) {
-        let polygon_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.polygon");
-        collect_raw_polygon_slots(xml, polygon_span, polygon, &polygon_prefix, sink)?;
-        semantic_run_idx += 1;
-    }
-
-    let curve_spans = collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:curve")?;
-    if curve_spans.len() != run.curves.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "curve count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                curve_spans.len(),
-                run.curves.len()
-            ),
-        });
-    }
-    for (curve, curve_span) in run.curves.iter().zip(curve_spans.into_iter()) {
-        let curve_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.curve");
-        collect_raw_curve_slots(xml, curve_span, curve, &curve_prefix, sink)?;
-        semantic_run_idx += 1;
-    }
-
-    let connect_line_spans =
-        collect_direct_child_outer_spans(xml, run_span.clone(), b"hp:connectLine")?;
-    if connect_line_spans.len() != run.connect_lines.len() {
-        return Err(HwpxError::InvalidStructure {
-            detail: format!(
-                "connectLine count mismatch while building preservation metadata for {prefix}: raw={} semantic={}",
-                connect_line_spans.len(),
-                run.connect_lines.len()
-            ),
-        });
-    }
-    for (connect_line, connect_line_span) in
-        run.connect_lines.iter().zip(connect_line_spans.into_iter())
-    {
-        let connect_line_prefix = format!("{prefix}.runs[{semantic_run_idx}].control.connect_line");
-        collect_raw_connect_line_slots(
-            xml,
-            connect_line_span,
-            connect_line,
-            &connect_line_prefix,
-            sink,
-        )?;
-        semantic_run_idx += 1;
-    }
-
-    semantic_run_idx += run.equations.len();
-    semantic_run_idx += run
-        .switches
-        .iter()
-        .filter(|switch_case| {
-            switch_case.case.as_ref().and_then(|case| case.chart.as_ref()).is_some()
-        })
-        .count();
-    semantic_run_idx += run.dutmals.len();
-    semantic_run_idx += run.composes.len();
-
     Ok(semantic_run_idx)
 }
 

--- a/crates/hwpforge-smithy-hwpx/src/patch.rs
+++ b/crates/hwpforge-smithy-hwpx/src/patch.rs
@@ -884,8 +884,8 @@ fn collect_raw_run_slots(
                 semantic_run_idx += 1;
             }
             // Switch(차트) 는 디코더가 문단 끝에 append — run 꼬리 집계 유지.
-            // secPr/titleMark/Other 는 run 방출 없음.
-            K::Switch | K::SecPr | K::TitleMark | K::Other => {}
+            // secPr/titleMark/Other/StrayText 는 run 방출 없음.
+            K::Switch | K::SecPr | K::TitleMark | K::Other | K::StrayText => {}
         }
     }
     // trailing self-closing fieldBegin (BOOKMARK span start) — 디코더 거울.

--- a/crates/hwpforge-smithy-hwpx/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/schema/section.rs
@@ -85,9 +85,13 @@ pub struct HxParagraph {
 /// `<hp:secPr>`, `<hp:ctrl>`, `<hp:t>`, `<hp:tbl>`, `<hp:pic>`,
 /// `<hp:rect>`, `<hp:ellipse>`, etc.
 ///
-/// Phase 3 extracts text, tables, images, and secPr; everything else
-/// is silently skipped by serde (no `deny_unknown_fields`).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// W1a (이미지/글상자 에픽): 역직렬화는 수동 구현 — `$value` 혼합 파싱으로
+/// 종류별 Vec 을 채우면서 **문서 순서 사이드카** [`HxRun::child_order`] 를
+/// 함께 기록한다 (한컴 인터리브 `<t>a</t><pic/><t>b</t>` 의 순서 보존 —
+/// 스파이크 `tests/hxrun_read_spike.rs` 로 quick-xml 0.41 지원 확증).
+/// 직렬화는 derive 유지 (인코더는 1 Core Run → 1 HxRun 정규형 — mixed
+/// 직렬화 불요, Codex 리뷰 #2 채택).
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct HxRun {
     #[serde(rename = "@charPrIDRef", default)]
     pub char_pr_id_ref: u32,
@@ -240,6 +244,245 @@ pub struct HxRun {
     /// `Control::TextArt`.
     #[serde(rename(deserialize = "textart"), default, skip_serializing)]
     pub textarts: Vec<HxTextArt>,
+
+    /// 자식의 **문서 순서** 사이드카: `(종류, 해당 종류 Vec 내 인덱스)` 를
+    /// 파싱 순서대로 기록한다 (W1a). 종류별 Vec 은 기존 소비자 호환을 위해
+    /// 유지되고, 순서가 필요한 소비자(디코더 평탄화·patch raw walker)만
+    /// 이 사이드카를 걷는다. 인코더 생성 run 은 빈 Vec (직렬화 제외).
+    #[serde(skip)]
+    pub child_order: Vec<(HxRunChildKind, usize)>,
+}
+
+/// [`HxRun::child_order`] 의 자식 종류 태그 (W1a).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HxRunChildKind {
+    /// `<hp:secPr>` (Option 필드 — 인덱스는 항상 0).
+    SecPr,
+    /// `<hp:t>`.
+    Text,
+    /// `<hp:tbl>`.
+    Table,
+    /// `<hp:pic>`.
+    Picture,
+    /// `<hp:ctrl>`.
+    Ctrl,
+    /// `<hp:rect>`.
+    Rect,
+    /// `<hp:line>`.
+    Line,
+    /// `<hp:ellipse>`.
+    Ellipse,
+    /// `<hp:polygon>`.
+    Polygon,
+    /// `<hp:curve>`.
+    Curve,
+    /// `<hp:connectLine>`.
+    ConnectLine,
+    /// `<hp:equation>`.
+    Equation,
+    /// `<hp:switch>`.
+    Switch,
+    /// `<hp:titleMark>` (Option 필드 — 인덱스는 항상 0).
+    TitleMark,
+    /// `<hp:dutmal>`.
+    Dutmal,
+    /// `<hp:compose>`.
+    Compose,
+    /// `<hp:container>`.
+    Container,
+    /// `<hp:textart>`.
+    TextArt,
+    /// 미지 요소 (자리 보존용 — 종류별 Vec 에는 미수록).
+    Other,
+}
+
+/// 종전 by-kind 고정 순서를 재현하는 폴백 (child_order 사이드카가 비어 있는
+/// 수동 생성 `HxRun` 전용 — 파싱 경로는 항상 사이드카를 갖는다).
+pub(crate) fn legacy_child_order(hx: &HxRun) -> Vec<(HxRunChildKind, usize)> {
+    use HxRunChildKind as K;
+    let mut order = Vec::new();
+    order.extend((0..hx.texts.len()).map(|i| (K::Text, i)));
+    order.extend((0..hx.tables.len()).map(|i| (K::Table, i)));
+    order.extend((0..hx.pictures.len()).map(|i| (K::Picture, i)));
+    order.extend((0..hx.ctrls.len()).map(|i| (K::Ctrl, i)));
+    order.extend((0..hx.rects.len()).map(|i| (K::Rect, i)));
+    order.extend((0..hx.lines.len()).map(|i| (K::Line, i)));
+    order.extend((0..hx.ellipses.len()).map(|i| (K::Ellipse, i)));
+    order.extend((0..hx.polygons.len()).map(|i| (K::Polygon, i)));
+    order.extend((0..hx.curves.len()).map(|i| (K::Curve, i)));
+    order.extend((0..hx.textarts.len()).map(|i| (K::TextArt, i)));
+    order.extend((0..hx.connect_lines.len()).map(|i| (K::ConnectLine, i)));
+    order.extend((0..hx.containers.len()).map(|i| (K::Container, i)));
+    order.extend((0..hx.equations.len()).map(|i| (K::Equation, i)));
+    order.extend((0..hx.dutmals.len()).map(|i| (K::Dutmal, i)));
+    order.extend((0..hx.composes.len()).map(|i| (K::Compose, i)));
+    order
+}
+
+/// `$value` 혼합 파싱용 중간 enum (W1a — 역직렬화 전용).
+#[derive(Deserialize)]
+enum HxRunChildDe {
+    #[serde(rename = "secPr")]
+    SecPr(Box<HxSecPr>),
+    #[serde(rename = "t")]
+    Text(HxText),
+    #[serde(rename = "tbl")]
+    Table(Box<HxTable>),
+    #[serde(rename = "pic")]
+    Picture(Box<HxPic>),
+    #[serde(rename = "ctrl")]
+    Ctrl(Box<HxCtrl>),
+    #[serde(rename = "rect")]
+    Rect(Box<HxRect>),
+    #[serde(rename = "line")]
+    Line(Box<HxLine>),
+    #[serde(rename = "ellipse")]
+    Ellipse(Box<HxEllipse>),
+    #[serde(rename = "polygon")]
+    Polygon(Box<HxPolygon>),
+    #[serde(rename = "curve")]
+    Curve(Box<HxCurve>),
+    #[serde(rename = "connectLine")]
+    ConnectLine(Box<HxConnectLine>),
+    #[serde(rename = "equation")]
+    Equation(Box<HxEquation>),
+    #[serde(rename = "switch")]
+    Switch(Box<HxRunSwitch>),
+    #[serde(rename = "titleMark")]
+    TitleMark(Box<HxTitleMark>),
+    #[serde(rename = "dutmal")]
+    Dutmal(Box<HxDutmal>),
+    #[serde(rename = "compose")]
+    Compose(Box<HxCompose>),
+    #[serde(rename = "container")]
+    Container(Box<HxContainer>),
+    #[serde(rename = "textart")]
+    TextArt(Box<HxTextArt>),
+    /// run 직속 텍스트 노드 (정상 문서엔 없음 — 방어적 흡수).
+    #[serde(rename = "$text")]
+    StrayText(String),
+    /// 미지 요소 — 파싱 실패 대신 자리만 기록.
+    #[serde(other)]
+    Other,
+}
+
+impl<'de> serde::Deserialize<'de> for HxRun {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct HxRunDe {
+            #[serde(rename = "@charPrIDRef", default)]
+            char_pr_id_ref: u32,
+            #[serde(rename = "$value", default)]
+            children: Vec<HxRunChildDe>,
+        }
+        let de = HxRunDe::deserialize(deserializer)?;
+        let mut run = HxRun {
+            char_pr_id_ref: de.char_pr_id_ref,
+            sec_pr: None,
+            texts: Vec::new(),
+            tables: Vec::new(),
+            pictures: Vec::new(),
+            ctrls: Vec::new(),
+            rects: Vec::new(),
+            lines: Vec::new(),
+            ellipses: Vec::new(),
+            polygons: Vec::new(),
+            curves: Vec::new(),
+            connect_lines: Vec::new(),
+            equations: Vec::new(),
+            switches: Vec::new(),
+            title_mark: None,
+            dutmals: Vec::new(),
+            composes: Vec::new(),
+            containers: Vec::new(),
+            textarts: Vec::new(),
+            child_order: Vec::new(),
+        };
+        use HxRunChildKind as K;
+        for child in de.children {
+            match child {
+                HxRunChildDe::SecPr(x) => {
+                    run.child_order.push((K::SecPr, 0));
+                    run.sec_pr = Some(*x);
+                }
+                HxRunChildDe::Text(x) => {
+                    run.child_order.push((K::Text, run.texts.len()));
+                    run.texts.push(x);
+                }
+                HxRunChildDe::Table(x) => {
+                    run.child_order.push((K::Table, run.tables.len()));
+                    run.tables.push(*x);
+                }
+                HxRunChildDe::Picture(x) => {
+                    run.child_order.push((K::Picture, run.pictures.len()));
+                    run.pictures.push(*x);
+                }
+                HxRunChildDe::Ctrl(x) => {
+                    run.child_order.push((K::Ctrl, run.ctrls.len()));
+                    run.ctrls.push(*x);
+                }
+                HxRunChildDe::Rect(x) => {
+                    run.child_order.push((K::Rect, run.rects.len()));
+                    run.rects.push(*x);
+                }
+                HxRunChildDe::Line(x) => {
+                    run.child_order.push((K::Line, run.lines.len()));
+                    run.lines.push(*x);
+                }
+                HxRunChildDe::Ellipse(x) => {
+                    run.child_order.push((K::Ellipse, run.ellipses.len()));
+                    run.ellipses.push(*x);
+                }
+                HxRunChildDe::Polygon(x) => {
+                    run.child_order.push((K::Polygon, run.polygons.len()));
+                    run.polygons.push(*x);
+                }
+                HxRunChildDe::Curve(x) => {
+                    run.child_order.push((K::Curve, run.curves.len()));
+                    run.curves.push(*x);
+                }
+                HxRunChildDe::ConnectLine(x) => {
+                    run.child_order.push((K::ConnectLine, run.connect_lines.len()));
+                    run.connect_lines.push(*x);
+                }
+                HxRunChildDe::Equation(x) => {
+                    run.child_order.push((K::Equation, run.equations.len()));
+                    run.equations.push(*x);
+                }
+                HxRunChildDe::Switch(x) => {
+                    run.child_order.push((K::Switch, run.switches.len()));
+                    run.switches.push(*x);
+                }
+                HxRunChildDe::TitleMark(x) => {
+                    run.child_order.push((K::TitleMark, 0));
+                    run.title_mark = Some(*x);
+                }
+                HxRunChildDe::Dutmal(x) => {
+                    run.child_order.push((K::Dutmal, run.dutmals.len()));
+                    run.dutmals.push(*x);
+                }
+                HxRunChildDe::Compose(x) => {
+                    run.child_order.push((K::Compose, run.composes.len()));
+                    run.composes.push(*x);
+                }
+                HxRunChildDe::Container(x) => {
+                    run.child_order.push((K::Container, run.containers.len()));
+                    run.containers.push(*x);
+                }
+                HxRunChildDe::TextArt(x) => {
+                    run.child_order.push((K::TextArt, run.textarts.len()));
+                    run.textarts.push(*x);
+                }
+                HxRunChildDe::StrayText(_) => {
+                    // run 직속 텍스트는 스키마상 없음 — 자리 기록 없이 무시.
+                }
+                HxRunChildDe::Other => {
+                    run.child_order.push((K::Other, 0));
+                }
+            }
+        }
+        Ok(run)
+    }
 }
 
 /// `<hp:textart>` — TextArt (글맵시) decorative warped-text object.

--- a/crates/hwpforge-smithy-hwpx/src/schema/section.rs
+++ b/crates/hwpforge-smithy-hwpx/src/schema/section.rs
@@ -294,6 +294,9 @@ pub enum HxRunChildKind {
     TextArt,
     /// 미지 요소 (자리 보존용 — 종류별 Vec 에는 미수록).
     Other,
+    /// run 직속 stray `$text` — 스키마상 위치가 없어 내용은 드롭하지만
+    /// **존재·위치는 기록**한다 (W1b: 캐시 fail-closed 신호, v4 R3#7).
+    StrayText,
 }
 
 /// 종전 by-kind 고정 순서를 재현하는 폴백 (child_order 사이드카가 비어 있는
@@ -474,7 +477,9 @@ impl<'de> serde::Deserialize<'de> for HxRun {
                     run.textarts.push(*x);
                 }
                 HxRunChildDe::StrayText(_) => {
-                    // run 직속 텍스트는 스키마상 없음 — 자리 기록 없이 무시.
+                    // run 직속 텍스트는 스키마상 없음 — 내용은 버리되
+                    // 위치는 사이드카에 기록한다 (W1b fail-closed 관측).
+                    run.child_order.push((K::StrayText, 0));
                 }
                 HxRunChildDe::Other => {
                     run.child_order.push((K::Other, 0));
@@ -644,6 +649,7 @@ impl HxText {
                 HxTextPart::FwSpace {} => "\u{001F}",
                 HxTextPart::NbSpace {} => "\u{00a0}",
                 HxTextPart::MarkpenBegin {} | HxTextPart::MarkpenEnd {} => "",
+                HxTextPart::TitleMark { .. } => "",
                 HxTextPart::Other => "",
             })
             .collect()
@@ -687,6 +693,7 @@ impl HxText {
 
         let segments = self.parts.iter().filter_map(|p| match p {
             HxTextPart::Text(s) if s.is_empty() => None,
+            HxTextPart::TitleMark { .. } => None,
             HxTextPart::Text(s) => Some(InlineSegment::Plain(s.clone())),
             HxTextPart::Tab { width, leader, tab_type } => {
                 Some(InlineSegment::Tab(InlineTabAttr {
@@ -747,6 +754,16 @@ pub enum HxTextPart {
     /// `<hp:nbSpace/>` — non-breaking space.
     #[serde(rename(serialize = "hp:nbSpace", deserialize = "nbSpace"))]
     NbSpace {},
+    /// `<hp:titleMark ignore="..."/>` — 한컴은 titleMark 를 `<t>` 내부에
+    /// 쓴다 (XSD 위치). HWP5 `0x08` 미러 = **wire 8유닛·가시 0** (W1b
+    /// ledger — Other 로 떨어지면 소비량 미상 fail-closed 가 되므로 typed
+    /// 로 승격, v4 R3#6).
+    #[serde(rename(serialize = "hp:titleMark", deserialize = "titleMark"))]
+    TitleMark {
+        /// TOC 제외 여부 (`false` = 포함).
+        #[serde(rename = "@ignore", default)]
+        ignore: bool,
+    },
     /// `<hp:markpenBegin/>` — highlight marker begin (no text output).
     #[serde(rename(serialize = "hp:markpenBegin", deserialize = "markpenBegin"))]
     MarkpenBegin {},

--- a/crates/hwpforge-smithy-hwpx/src/wire_text_map.rs
+++ b/crates/hwpforge-smithy-hwpx/src/wire_text_map.rs
@@ -1,0 +1,513 @@
+//! Wire↔Core 텍스트 좌표 맵 (W1b) — 이 crate 내부 전용.
+//!
+//! wire 좌표(HWP5 raw 스트림 = 한컴 HWPX linesegarray textpos 규약)와
+//! Core 정준 좌표(`Paragraph::text_content()` UTF-16 축) 사이의 변환을
+//! 담당한다. 설계 정본: `.docs/planning/2026-08-13-image-textbox-epic.md`
+//! §1g v5 (Codex 4라운드 확정 수학 법칙).
+//!
+//! ## 모델
+//!
+//! 문단의 wire 스트림은 **비-1:1 span** (marker `(8,0)`, tab `(8,1)`,
+//! 무음 소비 `(1,0)` 등) 과 그 사이의 **1:1 구간** (일반 텍스트) 으로
+//! 구성된다. 맵은 비-1:1 span 만 보유하며 (1:1 span 은 push 시점에
+//! identity 로 흡수), 총길이 `wire_end`/`core_end` 를 seal 시점에 고정한다.
+//!
+//! ## 법칙 (v5 확정 — proptest 로 잠금)
+//!
+//! - 입력 domain = inclusive `[0, wire_end]` / `[0, core_end]`, 밖은 Err.
+//! - `to_core(0) = 0` · `to_wire(0) = 0` 무조건 성립 (canonicalization —
+//!   native 291파일·13,598 linesegarray 전수에서 첫 lineseg textpos=0
+//!   100% 실측).
+//! - 1:1 **열린 구간에서만** 양방향 합성이 identity.
+//! - 비-1:1 span 의 wire strict interior 는 `to_core = Err`.
+//! - 동일 core 좌표에 wire preimage 2개 이상이면 `to_wire = Err`
+//!   (단 core 0 은 canonicalization 으로 항상 wire 0).
+//!
+//! ⚠️ smithy-hwp5 의 동명 모듈과 **동형** — conformance vector 테스트를
+//! 양쪽에 복제해 drift 를 방지한다 (Core 로의 승격은 계층 누수라 기각,
+//! §1g v2 disposition #2).
+
+use std::fmt;
+
+/// 비-1:1 wire 소비 구간 하나.
+///
+/// `wire_len != core_len` 이 불변식이다 (1:1 은 span 이 아니라 구간).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WireSpan {
+    /// wire 좌표계에서의 시작 위치.
+    pub wire_start: u32,
+    /// wire 유닛 소비량 (≥ 1).
+    pub wire_len: u32,
+    /// Core 축 기여량 (marker=0, tab=1 등).
+    pub core_len: u32,
+}
+
+/// 좌표 변환/맵 구성 실패 사유.
+///
+/// 캐시 fail-closed 경고(`DecodeWarning`/`EncodeWarning`)의 payload 로
+/// 전파된다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CacheMapError {
+    /// 질의 좌표가 `[0, wire_end]` / `[0, core_end]` 밖.
+    OutOfRange {
+        /// 질의 좌표.
+        pos: u32,
+        /// 해당 축의 총길이.
+        end: u32,
+    },
+    /// `to_core` 질의가 비-1:1 span 의 strict interior 에 위치.
+    InsideContraction {
+        /// 질의 wire 좌표.
+        wire: u32,
+    },
+    /// `to_wire` 질의 core 좌표의 wire preimage 가 2개 이상 (core 0 제외).
+    AmbiguousPreimage {
+        /// 질의 core 좌표.
+        core: u32,
+    },
+    /// span 정렬/중첩/불변식 위반 또는 checked 산술 overflow.
+    InvalidSpans,
+}
+
+impl fmt::Display for CacheMapError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutOfRange { pos, end } => {
+                write!(f, "coordinate {pos} outside [0, {end}]")
+            }
+            Self::InsideContraction { wire } => {
+                write!(f, "wire {wire} inside a non-1:1 span interior")
+            }
+            Self::AmbiguousPreimage { core } => {
+                write!(f, "core {core} has multiple wire preimages")
+            }
+            Self::InvalidSpans => write!(f, "span set violates map invariants"),
+        }
+    }
+}
+
+/// seal 된 wire↔Core 좌표 맵.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WireTextMap {
+    /// 비-1:1 span 들 (wire_start 오름차순, 비중첩).
+    spans: Vec<WireSpan>,
+    /// wire 축 총길이.
+    wire_end: u32,
+    /// Core 축 총길이.
+    core_end: u32,
+}
+
+impl WireTextMap {
+    /// wire 축 총길이 (현재 테스트 전용 — lib 소비자가 생기면 게이트 해제).
+    #[cfg(test)]
+    pub(crate) fn wire_end(&self) -> u32 {
+        self.wire_end
+    }
+
+    /// Core 축 총길이.
+    pub(crate) fn core_end(&self) -> u32 {
+        self.core_end
+    }
+
+    /// wire 좌표 → Core 좌표.
+    pub(crate) fn to_core(&self, wire: u32) -> Result<u32, CacheMapError> {
+        if wire > self.wire_end {
+            return Err(CacheMapError::OutOfRange { pos: wire, end: self.wire_end });
+        }
+        let mut wire_cursor = 0u32;
+        let mut core_cursor = 0u32;
+        for span in &self.spans {
+            if wire <= span.wire_start {
+                // 1:1 구간 (span 시작점 포함 — 시작점의 core 값은 구간
+                // 공식과 동일).
+                return Ok(core_cursor + (wire - wire_cursor));
+            }
+            let span_end = span.wire_start + span.wire_len;
+            if wire < span_end {
+                return Err(CacheMapError::InsideContraction { wire });
+            }
+            core_cursor += (span.wire_start - wire_cursor) + span.core_len;
+            wire_cursor = span_end;
+        }
+        Ok(core_cursor + (wire - wire_cursor))
+    }
+
+    /// Core 좌표 → wire 좌표.
+    ///
+    /// core 0 은 canonicalization 으로 항상 wire 0 (실측 불변식).
+    /// 그 외 축약점(preimage ≥ 2)은 `AmbiguousPreimage`.
+    pub(crate) fn to_wire(&self, core: u32) -> Result<u32, CacheMapError> {
+        if core > self.core_end {
+            return Err(CacheMapError::OutOfRange { pos: core, end: self.core_end });
+        }
+        if core == 0 {
+            return Ok(0);
+        }
+        let mut wire_cursor = 0u32;
+        let mut core_cursor = 0u32;
+        for span in &self.spans {
+            let gap_core_end = core_cursor + (span.wire_start - wire_cursor);
+            if core < gap_core_end {
+                // 1:1 열린 구간 — 유일 preimage.
+                return Ok(wire_cursor + (core - core_cursor));
+            }
+            if core == gap_core_end {
+                if span.core_len == 0 {
+                    // 영-core span 경계: span 앞/뒤가 같은 core 로 축약.
+                    return Err(CacheMapError::AmbiguousPreimage { core });
+                }
+                // core 기여가 있는 span (tab 등): span 시작 = 유일 preimage.
+                return Ok(span.wire_start);
+            }
+            let span_core_end = gap_core_end + span.core_len;
+            if core < span_core_end {
+                // span core 기여의 strict interior (core_len ≥ 2 인 경우만
+                // 도달 가능 — 현재 알려진 span 종류엔 없음, 방어적 Err).
+                return Err(CacheMapError::AmbiguousPreimage { core });
+            }
+            core_cursor = span_core_end;
+            wire_cursor = span.wire_start + span.wire_len;
+        }
+        Ok(wire_cursor + (core - core_cursor))
+    }
+}
+
+/// [`WireTextMap`] 증분 구성기.
+///
+/// 변환기(디코더/projection/인코더 방출부)가 **wire 순서대로** 소비를
+/// 기록한다: 1:1 텍스트는 [`advance_identity`], 비-1:1 소비는
+/// [`push_span`]. [`finish`] 가 불변식 검증 후 seal 한다.
+///
+/// field pending(begin~end 사이 core 기여 확정 지연)은 변환기 측 책임 —
+/// 이 빌더는 확정된 소비만 순서대로 받는다 (v5 lifecycle: FieldEnd 에서
+/// wire 순서대로 commit).
+///
+/// [`advance_identity`]: WireMapBuilder::advance_identity
+/// [`push_span`]: WireMapBuilder::push_span
+/// [`finish`]: WireMapBuilder::finish
+#[derive(Debug, Default)]
+pub(crate) struct WireMapBuilder {
+    spans: Vec<WireSpan>,
+    wire_cursor: u32,
+    core_cursor: u32,
+    overflowed: bool,
+}
+
+impl WireMapBuilder {
+    /// 새 빌더 (빈 문단 = 그대로 `finish` 하면 `(0,0)` 맵).
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// 1:1 구간 전진 (일반 텍스트 UTF-16 `units`).
+    pub(crate) fn advance_identity(&mut self, units: u32) {
+        match (self.wire_cursor.checked_add(units), self.core_cursor.checked_add(units)) {
+            (Some(w), Some(c)) => {
+                self.wire_cursor = w;
+                self.core_cursor = c;
+            }
+            _ => self.overflowed = true,
+        }
+    }
+
+    /// 비-1:1 소비 기록 (`wire_len != core_len`).
+    ///
+    /// `wire_len == core_len` 이면 identity 로 흡수한다 (span 최소성).
+    pub(crate) fn push_span(&mut self, wire_len: u32, core_len: u32) {
+        if wire_len == core_len {
+            self.advance_identity(wire_len);
+            return;
+        }
+        if wire_len == 0 {
+            // core 만 늘어나는 span 은 존재하지 않음 (markpen 은 (0,0) —
+            // 어느 축도 소비하지 않으므로 기록 자체가 불필요).
+            self.overflowed = true;
+            return;
+        }
+        let span = WireSpan { wire_start: self.wire_cursor, wire_len, core_len };
+        match (self.wire_cursor.checked_add(wire_len), self.core_cursor.checked_add(core_len)) {
+            (Some(w), Some(c)) => {
+                self.wire_cursor = w;
+                self.core_cursor = c;
+                self.spans.push(span);
+            }
+            _ => self.overflowed = true,
+        }
+    }
+
+    /// 불변식 검증 후 seal.
+    ///
+    /// 검증: overflow 부재 · span 정렬/비중첩 · `wire_len != core_len` ·
+    /// 누적 합 == 커서 (구성 오류 방어).
+    pub(crate) fn finish(self) -> Result<WireTextMap, CacheMapError> {
+        if self.overflowed {
+            return Err(CacheMapError::InvalidSpans);
+        }
+        let mut expect_wire = 0u32;
+        let mut expect_core = 0u32;
+        for span in &self.spans {
+            if span.wire_start < expect_wire || span.wire_len == 0 || span.wire_len == span.core_len
+            {
+                return Err(CacheMapError::InvalidSpans);
+            }
+            expect_core = expect_core
+                .checked_add(span.wire_start - expect_wire)
+                .and_then(|c| c.checked_add(span.core_len))
+                .ok_or(CacheMapError::InvalidSpans)?;
+            expect_wire =
+                span.wire_start.checked_add(span.wire_len).ok_or(CacheMapError::InvalidSpans)?;
+        }
+        // trailing 1:1 구간 반영.
+        let tail = self.wire_cursor.checked_sub(expect_wire).ok_or(CacheMapError::InvalidSpans)?;
+        expect_core = expect_core.checked_add(tail).ok_or(CacheMapError::InvalidSpans)?;
+        if expect_core != self.core_cursor {
+            return Err(CacheMapError::InvalidSpans);
+        }
+        Ok(WireTextMap {
+            spans: self.spans,
+            wire_end: self.wire_cursor,
+            core_end: self.core_cursor,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// conformance vector — smithy-hwp5 의 동명 모듈 테스트와 동일하게
+    /// 유지할 것 (동형성 게이트).
+    fn marker_ledger_p1() -> WireTextMap {
+        // rules-marker-ledger p1: 텍스트 17유닛 + nwno(8,0)×2 + 텍스트.
+        // raw lineseg [0, 76, 132] → core [0, 60, 116].
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(17);
+        b.push_span(8, 0);
+        b.push_span(8, 0);
+        b.advance_identity(148 - 33); // 총 raw 길이 148 가정 (본문 잔여)
+        b.finish().expect("valid map")
+    }
+
+    // ── 빈/퇴화 문단 ────────────────────────────────────────────
+
+    #[test]
+    fn empty_paragraph_succeeds_only_at_zero() {
+        let map = WireMapBuilder::new().finish().expect("empty map");
+        assert_eq!(map.wire_end(), 0);
+        assert_eq!(map.core_end(), 0);
+        assert_eq!(map.to_core(0), Ok(0));
+        assert_eq!(map.to_wire(0), Ok(0));
+        assert_eq!(map.to_core(1), Err(CacheMapError::OutOfRange { pos: 1, end: 0 }));
+        assert_eq!(map.to_wire(1), Err(CacheMapError::OutOfRange { pos: 1, end: 0 }));
+    }
+
+    #[test]
+    fn control_only_paragraph_collapses_to_core_zero() {
+        // (wire_end>0, core_end=0): to_core(0)=0, to_core(wire_end)=0,
+        // to_wire(0)=0 (canonicalization).
+        let mut b = WireMapBuilder::new();
+        b.push_span(8, 0);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.wire_end(), 8);
+        assert_eq!(map.core_end(), 0);
+        assert_eq!(map.to_core(0), Ok(0));
+        assert_eq!(map.to_core(8), Ok(0));
+        assert_eq!(map.to_core(3), Err(CacheMapError::InsideContraction { wire: 3 }));
+        assert_eq!(map.to_wire(0), Ok(0));
+    }
+
+    // ── canonicalization (실측 불변식) ──────────────────────────
+
+    #[test]
+    fn leading_marker_canonicalizes_zero_both_ways() {
+        // HWP5 첫 문단 프렐류드 (secd+cold = 16유닛) 후 텍스트 4유닛.
+        let mut b = WireMapBuilder::new();
+        b.push_span(8, 0);
+        b.push_span(8, 0);
+        b.advance_identity(4);
+        let map = b.finish().expect("valid");
+        // to_core: 0 과 16(양 span 경계) 모두 core 0 — 경계는 합법.
+        assert_eq!(map.to_core(0), Ok(0));
+        assert_eq!(map.to_core(8), Ok(0));
+        assert_eq!(map.to_core(16), Ok(0));
+        // to_wire(0) 은 preimage {0,8,16} 중 canonicalization 으로 0.
+        assert_eq!(map.to_wire(0), Ok(0));
+        assert_eq!(map.to_wire(4), Ok(20));
+    }
+
+    // ── 1:1 열린 구간 왕복 ──────────────────────────────────────
+
+    #[test]
+    fn open_interval_roundtrip_is_identity() {
+        let map = marker_ledger_p1();
+        // 골든: raw [0,76,132] ↔ core [0,60,116].
+        assert_eq!(map.to_core(0), Ok(0));
+        assert_eq!(map.to_core(76), Ok(60));
+        assert_eq!(map.to_core(132), Ok(116));
+        assert_eq!(map.to_wire(60), Ok(76));
+        assert_eq!(map.to_wire(116), Ok(132));
+        // 왕복 항등 (1:1 구간).
+        for w in [1u32, 16, 40, 76, 100, 132, 147] {
+            let c = map.to_core(w).expect("in gap");
+            assert_eq!(map.to_wire(c), Ok(w), "roundtrip at wire {w}");
+        }
+    }
+
+    // ── strict interior / 축약점 ───────────────────────────────
+
+    #[test]
+    fn marker_interior_is_error() {
+        let map = marker_ledger_p1();
+        for w in [18u32, 20, 24, 26, 30, 32] {
+            assert_eq!(
+                map.to_core(w),
+                Err(CacheMapError::InsideContraction { wire: w }),
+                "wire {w}"
+            );
+        }
+        // span 시작/끝 경계는 합법.
+        assert_eq!(map.to_core(17), Ok(17));
+        assert_eq!(map.to_core(25), Ok(17));
+        assert_eq!(map.to_core(33), Ok(17));
+    }
+
+    #[test]
+    fn mid_paragraph_collapse_point_is_ambiguous() {
+        let map = marker_ledger_p1();
+        // core 17 의 preimage = {17, 25, 33} (연속 영-core span) → Err.
+        assert_eq!(map.to_wire(17), Err(CacheMapError::AmbiguousPreimage { core: 17 }));
+    }
+
+    #[test]
+    fn trailing_zero_core_span_makes_core_end_ambiguous() {
+        // 텍스트 4 + marker(8,0) 로 끝나는 문단: core_end=4 의 preimage =
+        // {4, 12} → Err.
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(4);
+        b.push_span(8, 0);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.core_end(), 4);
+        assert_eq!(map.to_wire(4), Err(CacheMapError::AmbiguousPreimage { core: 4 }));
+        assert_eq!(map.to_wire(3), Ok(3));
+    }
+
+    // ── tab (8,1) 비대칭 ────────────────────────────────────────
+
+    #[test]
+    fn tab_span_maps_core_contribution_uniquely() {
+        // "ab" + tab(8,1) + "cd": wire [a=0,b=1,tab=2..10,c=10,d=11],
+        // core [a=0,b=1,\t=2,c=3,d=4].
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(2);
+        b.push_span(8, 1);
+        b.advance_identity(2);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.wire_end(), 12);
+        assert_eq!(map.core_end(), 5);
+        assert_eq!(map.to_core(2), Ok(2)); // tab 시작 경계
+        assert_eq!(map.to_core(10), Ok(3)); // tab 끝 경계
+        assert_eq!(map.to_core(5), Err(CacheMapError::InsideContraction { wire: 5 }));
+        // core 2 (tab 위치) 의 유일 preimage = tab wire 시작.
+        assert_eq!(map.to_wire(2), Ok(2));
+        assert_eq!(map.to_wire(3), Ok(10));
+        assert_eq!(map.to_wire(4), Ok(11));
+    }
+
+    // ── 무음 소비 (1,0) ─────────────────────────────────────────
+
+    #[test]
+    fn single_unit_silent_consumption() {
+        // "a" + 0x1E(1,0) + "b": wire [0,1..2,2], core [0,1].
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(1);
+        b.push_span(1, 0);
+        b.advance_identity(1);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.wire_end(), 3);
+        assert_eq!(map.core_end(), 2);
+        // (1,0) span 은 strict interior 가 없음 — 경계만 존재.
+        assert_eq!(map.to_core(1), Ok(1));
+        assert_eq!(map.to_core(2), Ok(1));
+        assert_eq!(map.to_wire(1), Err(CacheMapError::AmbiguousPreimage { core: 1 }));
+    }
+
+    // ── 빌더 불변식 ─────────────────────────────────────────────
+
+    #[test]
+    fn identity_sized_span_is_absorbed() {
+        let mut b = WireMapBuilder::new();
+        b.push_span(1, 1); // lineBreak 등 — span 아님
+        b.advance_identity(3);
+        let map = b.finish().expect("valid");
+        assert_eq!(map.wire_end(), 4);
+        assert_eq!(map.core_end(), 4);
+        assert_eq!(map.to_wire(2), Ok(2));
+    }
+
+    #[test]
+    fn overflow_is_rejected_at_finish() {
+        let mut b = WireMapBuilder::new();
+        b.advance_identity(u32::MAX);
+        b.push_span(8, 0);
+        assert_eq!(b.finish(), Err(CacheMapError::InvalidSpans));
+    }
+
+    #[test]
+    fn zero_wire_span_is_rejected() {
+        let mut b = WireMapBuilder::new();
+        b.push_span(0, 1);
+        assert_eq!(b.finish(), Err(CacheMapError::InvalidSpans));
+    }
+
+    // ── property: 법칙 잠금 ─────────────────────────────────────
+
+    proptest::proptest! {
+        /// 임의 span 구성에서 1:1 구간 왕복 항등 + 경계 법칙.
+        #[test]
+        fn laws_hold_for_arbitrary_maps(
+            segments in proptest::collection::vec(
+                (0u32..3, 1u32..12, 0u32..2), 0..12,
+            )
+        ) {
+            let mut b = WireMapBuilder::new();
+            for (kind, len, core) in segments {
+                match kind {
+                    0 => b.advance_identity(len),
+                    1 => b.push_span(8, core.min(1)),
+                    _ => b.push_span(1, 0),
+                }
+            }
+            let Ok(map) = b.finish() else { return Ok(()); };
+
+            // 법칙 1: canonicalization.
+            proptest::prop_assert_eq!(map.to_core(0), Ok(0));
+            proptest::prop_assert_eq!(map.to_wire(0), Ok(0));
+
+            // 법칙 2: 전 domain 에서 to_core 는 OutOfRange 를 내지 않고,
+            // 성공 시 core domain 내 값.
+            for w in 0..=map.wire_end() {
+                match map.to_core(w) {
+                    Ok(c) => {
+                        proptest::prop_assert!(c <= map.core_end());
+                        // 법칙 3: to_core 성공 + to_wire 성공이면 왕복 항등
+                        // 또는 canonicalization(0)/경계 축약.
+                        if let Ok(w2) = map.to_wire(c) {
+                            let c2 = map.to_core(w2).expect("canonical wire valid");
+                            proptest::prop_assert_eq!(c2, c);
+                        }
+                    }
+                    Err(CacheMapError::InsideContraction { .. }) => {}
+                    Err(e) => proptest::prop_assert!(false, "unexpected {e:?} at wire {w}"),
+                }
+            }
+
+            // 법칙 4: to_wire 성공값은 wire domain 내 + 재변환 일치.
+            for c in 0..=map.core_end() {
+                if let Ok(w) = map.to_wire(c) {
+                    proptest::prop_assert!(w <= map.wire_end());
+                    proptest::prop_assert_eq!(map.to_core(w), Ok(c));
+                }
+            }
+        }
+    }
+}

--- a/crates/hwpforge-smithy-hwpx/tests/clickhere_fill.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/clickhere_fill.rs
@@ -67,7 +67,11 @@ fn fill_fields(section: &mut Section, value: &str) {
 /// (decoder `unambiguous_body` · patch.rs 거울 게이트). 이 테스트는 그
 /// 다운그레이드 계약과 "모호 필드가 있어도 export 는 성공한다"를 잠근다.
 #[test]
-fn hancom_resaved_merged_run_downgrades_to_unfilled() {
+fn hancom_resaved_merged_run_attributes_body_exactly() {
+    // W1a (이미지/글상자 에픽): HxRun 자식 순서 보존으로 병합 run 의 본문
+    // 귀속이 무모호해졌다 — begin/end **사이** 텍스트가 곧 본문이다.
+    // 종전의 미채움 다운그레이드(gotcha #30)는 철폐: 라벨("이메일: ")은
+    // 필드 앞 일반 텍스트로 살고, 값은 정확히 귀속된다.
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.pop();
     path.pop();
@@ -78,15 +82,15 @@ fn hancom_resaved_merged_run_downgrades_to_unfilled() {
     let section = decoded.document.sections()[0].clone();
     let (name, body) = first_field(&section);
     assert_eq!(name.as_deref(), Some("user_email"), "필드 이름 앵커는 살아야 한다");
-    assert_eq!(body, "", "모호한 본문(병합 run)은 라벨 오귀속 대신 미채움으로 다운그레이드");
+    assert_eq!(body, "hanyul.ryu@example.com", "begin/end 사이 텍스트 = 본문 (정확 귀속)");
 
-    // 모호한 필드가 있어도 preservation export 는 성공해야 한다 — 슬롯이
-    // 없을 뿐 export/patch 워크플로 전체가 죽으면 main 대비 회귀다.
+    // 무모호 귀속이므로 편집 슬롯도 생긴다 (patch/fill 경로 활성).
     let preservation = HwpxPatcher::export_section_preservation(&bytes, 0, &section)
-        .expect("모호 필드가 있어도 export 는 성공해야 한다");
+        .expect("export 는 성공해야 한다");
     assert!(
-        preservation.text_slots.iter().all(|s| !s.path.ends_with(".control.field")),
-        "모호한 필드는 patch 슬롯을 만들지 않는다"
+        preservation.text_slots.iter().any(|s| s.path.ends_with(".control.field")),
+        "병합 run 필드도 이제 patch 슬롯을 갖는다: {:?}",
+        preservation.text_slots.iter().map(|s| &s.path).collect::<Vec<_>>()
     );
 }
 

--- a/crates/hwpforge-smithy-hwpx/tests/fill_api.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/fill_api.rs
@@ -96,13 +96,14 @@ fn list_fields_reports_name_hint_current_and_fillable() {
 }
 
 #[test]
-fn list_fields_marks_merged_run_field_unfillable() {
-    // 한컴 재저장 병합-run fixture — display_text 가 미채움("")으로
-    // 다운그레이드되므로 fillable=false 로 보고되어야 한다.
+fn list_fields_marks_merged_run_field_fillable() {
+    // W1a 자식 순서 보존으로 병합-run 본문 귀속이 무모호해졌다 —
+    // begin/end 사이 값이 current 로 잡히고 fillable=true 다.
     let bytes = fixture_bytes("clickhere_filled.hwpx");
     let fields = HwpxFiller::list_fields(&bytes).expect("list");
     let f = fields.iter().find(|f| f.name.as_deref() == Some("user_email")).expect("field");
-    assert!(!f.fillable, "병합-run 모호 필드는 fillable=false");
+    assert!(f.fillable, "병합-run 필드도 이제 fillable");
+    assert_eq!(f.current, "hanyul.ryu@example.com");
 }
 
 // ── fill 성공 경로 ───────────────────────────────────────────────
@@ -171,13 +172,19 @@ fn fill_rejects_empty_value() {
 }
 
 #[test]
-fn fill_rejects_unfillable_merged_run_field() {
+fn fill_replaces_merged_run_field_body() {
+    // W1a: 병합-run 필드가 채움 가능해졌다 — 값 교체 후 라벨("이메일: ")은
+    // 필드 앞 텍스트로 보존되어야 한다.
     let bytes = fixture_bytes("clickhere_filled.hwpx");
-    let err = HwpxFiller::fill(&bytes, &values(&[("user_email", "x@y.z")])).unwrap_err();
-    assert!(
-        matches!(err, FillError::UnfillableField { ref name, .. } if name == "user_email"),
-        "병합-run 모호 필드는 명확한 에러로 거부: {err:?}"
-    );
+    let outcome = HwpxFiller::fill(&bytes, &values(&[("user_email", "x@y.z")])).expect("fill 성공");
+    assert_eq!(outcome.filled.len(), 1);
+    assert_eq!(outcome.filled[0].previous, "hanyul.ryu@example.com");
+    assert_eq!(field_display(&outcome.bytes, 0, "user_email"), "x@y.z");
+    // 라벨 텍스트 보존 (병합 run 의 필드-앞 텍스트가 지워지면 회귀).
+    let redecoded = hwpforge_smithy_hwpx::HwpxDecoder::decode(&outcome.bytes).expect("redecode");
+    let text: String =
+        redecoded.document.sections()[0].paragraphs.iter().map(|p| p.text_content()).collect();
+    assert!(text.contains("이메일: "), "필드 앞 라벨 보존: {text}");
 }
 
 #[test]

--- a/crates/hwpforge-smithy-hwpx/tests/fill_api.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/fill_api.rs
@@ -197,3 +197,39 @@ fn fill_is_all_or_nothing_when_one_target_fails_preflight() {
         HwpxFiller::fill(&bytes, &values(&[("과제명", "값"), ("없는필드", "값2")])).unwrap_err();
     assert!(matches!(err, FillError::UnknownField { .. }));
 }
+
+#[test]
+fn fill_removes_linesegarray_of_filled_paragraph() {
+    // W1b (§1g v5 변경 5): 값이 바뀌면 길이와 무관하게 해당 문단의
+    // linesegarray 를 제거한다 — stale 좌표를 남기지 않는다.
+    let bytes = fixture_bytes("clickhere_filled.hwpx");
+    let base = HwpxDecoder::decode(&bytes).expect("decode base");
+    let base_has_cache =
+        base.document.sections()[0].paragraphs.iter().any(|p| p.layout_cache.is_some());
+    assert!(base_has_cache, "픽스처 전제: 원본에 캐시가 있어야 제거를 검증한다");
+
+    let outcome = HwpxFiller::fill(&bytes, &values(&[("user_email", "x@y.z")])).expect("fill");
+    let filled_doc = HwpxDecoder::decode(&outcome.bytes).expect("decode filled");
+    let field_para_has_cache = filled_doc.document.sections()[0]
+        .paragraphs
+        .iter()
+        .filter(|p| {
+            p.runs.iter().any(|r| {
+                matches!(&r.content, RunContent::Control(c)
+                    if matches!(c.as_ref(), Control::Field { name: Some(n), .. } if n == "user_email"))
+            })
+        })
+        .any(|p| p.layout_cache.is_some());
+    assert!(!field_para_has_cache, "채워진 문단의 linesegarray 는 제거돼야 한다");
+}
+
+#[test]
+fn fill_same_value_is_complete_noop() {
+    // W1b (§1g v5 변경 5): 현재 값과 동일한 fill 은 완전 no-op —
+    // mutate/FilledField/캐시 무효화 전부 생략, 바이트 동일.
+    let bytes = fixture_bytes("clickhere_filled.hwpx");
+    let outcome = HwpxFiller::fill(&bytes, &values(&[("user_email", "hanyul.ryu@example.com")]))
+        .expect("fill");
+    assert!(outcome.filled.is_empty(), "동일 값은 filled 에 기록되지 않는다");
+    assert_eq!(outcome.bytes, bytes, "바이트가 원본과 동일해야 한다");
+}

--- a/crates/hwpforge-smithy-hwpx/tests/hxrun_read_spike.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/hxrun_read_spike.rs
@@ -1,0 +1,78 @@
+//! W0b 스파이크 (이미지/글상자 에픽 게이트 2 재설계): quick-xml 0.41 의
+//! `@attr + $value` 혼합 자식 **순서 보존** 역직렬화 지원을 잠근다 —
+//! W1a `HxRunRead`(decode 전용 ordered DTO) 전환의 전제 조건.
+//!
+//! 검증 항목 (에픽 계획 §1b W0b):
+//! 1. `<run charPrIDRef>` 속성과 `$value` enum 병용 (in-tree 선례 없음)
+//! 2. `<t>a</t><pic/><t>b</t>` 의 문서 순서가 Vec 순서로 보존되는지
+//! 3. 미지 자식 → `#[serde(other)]` 폴백 (파싱 실패 금지)
+//!
+//! 직렬화는 검증하지 않는다 — Codex 리뷰 #2 채택: 인코더는 1 Core Run →
+//! 1 HxRun 정규형을 유지하므로 read/write DTO 분리로 mixed serializer 불요.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct RunReadSpike {
+    #[serde(rename = "@charPrIDRef", default)]
+    char_pr_id_ref: u32,
+    #[serde(rename = "$value", default)]
+    children: Vec<ChildSpike>,
+}
+
+#[derive(Debug, Deserialize)]
+enum ChildSpike {
+    #[serde(rename = "t")]
+    Text(String),
+    #[serde(rename = "pic")]
+    Pic(PicSpike),
+    #[serde(rename = "ctrl")]
+    Ctrl(CtrlSpike),
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+struct PicSpike {
+    #[serde(rename = "@id", default)]
+    id: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CtrlSpike {}
+
+#[test]
+fn attr_plus_value_enum_preserves_document_order() {
+    // 핵심 케이스: 현행 HxRun(종류별 Vec)이 잃어버리는 인터리브 순서.
+    let xml = r#"<run charPrIDRef="7"><t>a</t><pic id="p1"/><t>b</t></run>"#;
+    let run: RunReadSpike = quick_xml::de::from_str(xml).expect("deserialize");
+    assert_eq!(run.char_pr_id_ref, 7, "@attr 병용");
+    assert_eq!(run.children.len(), 3);
+    assert!(matches!(&run.children[0], ChildSpike::Text(t) if t == "a"));
+    assert!(matches!(&run.children[1], ChildSpike::Pic(p) if p.id == "p1"));
+    assert!(matches!(&run.children[2], ChildSpike::Text(t) if t == "b"));
+}
+
+#[test]
+fn unknown_children_fall_back_without_error() {
+    // 미지 요소(미래 스키마·미지원 종류)는 Other 로 흡수 — 순서 자리는 유지.
+    let xml =
+        r#"<run charPrIDRef="1"><t>x</t><futureElem attr="1"><inner/></futureElem><t>y</t></run>"#;
+    let run: RunReadSpike = quick_xml::de::from_str(xml).expect("deserialize");
+    assert_eq!(run.children.len(), 3);
+    assert!(matches!(&run.children[1], ChildSpike::Other));
+    assert!(matches!(&run.children[2], ChildSpike::Text(t) if t == "y"));
+}
+
+#[test]
+fn nested_element_content_is_consumed_within_its_slot() {
+    // ctrl 처럼 내부 자식이 있는 요소도 자기 슬롯에서 소비되고 이후 순서가
+    // 이어져야 한다 (스텁 struct 가 내부를 무시해도 커서가 안 깨질 것).
+    let xml =
+        r#"<run><ctrl><newNum num="7" numType="PAGE"/></ctrl><t>본문</t><pic id="p2"/></run>"#;
+    let run: RunReadSpike = quick_xml::de::from_str(xml).expect("deserialize");
+    assert_eq!(run.children.len(), 3);
+    assert!(matches!(&run.children[0], ChildSpike::Ctrl(_)));
+    assert!(matches!(&run.children[1], ChildSpike::Text(t) if t == "본문"));
+    assert!(matches!(&run.children[2], ChildSpike::Pic(p) if p.id == "p2"));
+}

--- a/crates/hwpforge-smithy-hwpx/tests/layout_cache_roundtrip.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/layout_cache_roundtrip.rs
@@ -124,3 +124,168 @@ fn optin_emits_linesegarray_and_roundtrips_all_containers() {
     assert_eq!(get("셀 본문").lines, vec![seg(0, 0)], "표 셀 캐시 보존");
     assert_eq!(get("머리말").lines, vec![seg(0, 800)], "머리말 캐시 보존");
 }
+
+// ── W1b 매트릭스: marker/tab/field 왕복 + 실패 의미 잠금 ────────────
+
+fn roundtrip(doc: Document<Draft>) -> hwpforge_smithy_hwpx::EncodeOutcome {
+    let store = style_store_for_preset("default").expect("preset");
+    let validated = doc.validate().expect("validate");
+    HwpxEncoder::encode_with_diagnostics(
+        &validated,
+        &store,
+        &ImageStore::new(),
+        EncodeOptions::default().with_emit_layout_cache(true),
+    )
+    .expect("encode")
+}
+
+fn decoded_caches(bytes: &[u8]) -> Vec<Option<Vec<u32>>> {
+    let decoded = HwpxDecoder::decode(bytes).expect("decode");
+    decoded.document.sections()[0]
+        .paragraphs
+        .iter()
+        .map(|p| p.layout_cache.as_ref().map(|c| c.lines.iter().map(|l| l.textpos).collect()))
+        .collect()
+}
+
+#[test]
+fn marker_paragraph_roundtrips_visible_coordinates() {
+    // 중간 각주 marker(8,0) 를 낀 2줄 문단 — Core 가시 tp [0, 4] 가
+    // encode(가시→wire) → decode(wire→가시) 왕복에서 항등이어야 한다.
+    use hwpforge_core::control::Control;
+    let mut para = Paragraph::with_runs(
+        vec![
+            Run::text("가나다", CharShapeIndex::new(0)),
+            Run::control(
+                Control::footnote(vec![Paragraph::with_runs(
+                    vec![Run::text("각주", CharShapeIndex::new(0))],
+                    ParaShapeIndex::new(0),
+                )]),
+                CharShapeIndex::new(0),
+            ),
+            Run::text("라마바", CharShapeIndex::new(0)),
+        ],
+        ParaShapeIndex::new(0),
+    );
+    para.layout_cache = Some(LayoutCache::new(vec![seg(0, 0), seg(4, 1600)]));
+    let mut doc = Document::new();
+    doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+
+    let outcome = roundtrip(doc);
+    assert!(outcome.warnings.is_empty(), "무경고: {:?}", outcome.warnings);
+    // wire 방출 실측: 첫 lineseg 는 native 불변식대로 0, 둘째는
+    // secPr(8)+colPr(8) 주입 + 텍스트 3 + marker 8 + 1 = 20+8+... —
+    // 재디코드 가시 좌표 항등만 잠근다 (wire 값은 ledger 소유).
+    assert_eq!(decoded_caches(&outcome.bytes)[0], Some(vec![0, 4]));
+}
+
+#[test]
+fn tab_paragraph_roundtrips_visible_coordinates() {
+    // tab (8,1) 비대칭 — 가시 [0, 3] ("ab\t" 뒤 줄) 왕복 항등.
+    let mut para = Paragraph::with_runs(
+        vec![Run::text("ab\tcd", CharShapeIndex::new(0))],
+        ParaShapeIndex::new(0),
+    );
+    para.layout_cache = Some(LayoutCache::new(vec![seg(0, 0), seg(3, 1600)]));
+    let mut doc = Document::new();
+    doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+
+    let outcome = roundtrip(doc);
+    assert!(outcome.warnings.is_empty(), "무경고: {:?}", outcome.warnings);
+    assert_eq!(decoded_caches(&outcome.bytes)[0], Some(vec![0, 3]));
+}
+
+#[test]
+fn field_paragraph_roundtrips_when_lines_avoid_body() {
+    // ClickHere 필드(본문 접힘 (16+n,0)) — 줄 경계가 본문 밖이면 왕복 항등.
+    use hwpforge_core::control::Control;
+    let mut para = Paragraph::with_runs(
+        vec![
+            Run::text("라벨: ", CharShapeIndex::new(0)),
+            Run::control(
+                Control::Field {
+                    field_type: hwpforge_foundation::FieldType::ClickHere,
+                    hint_text: Some("이름".into()),
+                    help_text: None,
+                    name: Some("이름".into()),
+                    display_text: "홍길동".into(),
+                },
+                CharShapeIndex::new(0),
+            ),
+            Run::text(" 끝", CharShapeIndex::new(0)),
+        ],
+        ParaShapeIndex::new(0),
+    );
+    // 줄2 = " 끝" 내부 (core 5) — core 4 는 필드 축약점(begin 앞/end 뒤
+    // 동좌표)이라 모호 → 드롭이 정답 (아래 별도 테스트).
+    para.layout_cache = Some(LayoutCache::new(vec![seg(0, 0), seg(5, 1600)]));
+    let mut doc = Document::new();
+    doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+
+    let outcome = roundtrip(doc);
+    assert!(outcome.warnings.is_empty(), "무경고: {:?}", outcome.warnings);
+    assert_eq!(decoded_caches(&outcome.bytes)[0], Some(vec![0, 5]));
+}
+
+#[test]
+fn unencodable_control_drops_cache_with_typed_warning() {
+    // §1g v5 R3#6 일반 불변식: 방출이 스킵되는 컨트롤(Unknown 등)이 있는
+    // 문단은 기하가 stale — typed 경고 + 해당 문단만 linesegarray 부재.
+    use hwpforge_core::control::Control;
+    let mut para = Paragraph::with_runs(
+        vec![
+            Run::text("본문 앞", CharShapeIndex::new(0)),
+            Run::control(
+                Control::Unknown { tag: "zzzz".into(), data: None },
+                CharShapeIndex::new(0),
+            ),
+        ],
+        ParaShapeIndex::new(0),
+    );
+    para.layout_cache = Some(LayoutCache::new(vec![seg(0, 0)]));
+    let mut doc = Document::new();
+    doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+
+    let outcome = roundtrip(doc);
+    assert!(
+        outcome.warnings.iter().any(|w| matches!(
+            w,
+            hwpforge_smithy_hwpx::EncodeWarning::LayoutCacheDropped { reason, .. }
+                if reason.contains("unencodable")
+        )),
+        "드롭 경고: {:?}",
+        outcome.warnings
+    );
+    assert_eq!(decoded_caches(&outcome.bytes)[0], None, "스킵 문단 캐시 미방출");
+}
+
+#[test]
+fn legacy_strict_entrypoint_errors_on_cache_drop() {
+    // §1g v5 변경 2: emit_layout_cache 요청 중 드롭 = legacy 진입점은
+    // 무음 성공 대신 HwpxError::LayoutCacheDropped.
+    use hwpforge_core::control::Control;
+    let mut para = Paragraph::with_runs(
+        vec![Run::control(
+            Control::Unknown { tag: "zzzz".into(), data: None },
+            CharShapeIndex::new(0),
+        )],
+        ParaShapeIndex::new(0),
+    );
+    para.layout_cache = Some(LayoutCache::new(vec![seg(0, 0)]));
+    let mut doc = Document::new();
+    doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+    let store = style_store_for_preset("default").expect("preset");
+    let validated = doc.validate().expect("validate");
+
+    let err = HwpxEncoder::encode_with_options(
+        &validated,
+        &store,
+        &ImageStore::new(),
+        EncodeOptions::default().with_emit_layout_cache(true),
+    )
+    .expect_err("strict 진입점은 에러");
+    assert!(
+        matches!(&err, hwpforge_smithy_hwpx::HwpxError::LayoutCacheDropped { .. }),
+        "got {err:?}"
+    );
+}

--- a/crates/hwpforge-smithy-hwpx/tests/layout_cache_roundtrip.rs
+++ b/crates/hwpforge-smithy-hwpx/tests/layout_cache_roundtrip.rs
@@ -289,3 +289,107 @@ fn legacy_strict_entrypoint_errors_on_cache_drop() {
         "got {err:?}"
     );
 }
+
+// ── 독립 리뷰 Medium 상환: 대칭-버그를 잡는 절대값 oracle ──────────
+
+/// 방출 XML 의 linesegarray textpos 절대값을 §1f 실측 상수로 대조한다.
+///
+/// roundtrip(encode∘decode) 은 **대칭 오류**(예: 양쪽 다 marker 를
+/// 7유닛으로 세는 버그)를 항등으로 통과시킨다 — 이 oracle 의 기대값은
+/// 코드가 아니라 한컴 fixture 실측(§1f: 확장 marker = 8 wire 유닛,
+/// 첫 lineseg = 0)에서 유도된 하드코딩 상수라 그 대칭을 깬다.
+#[test]
+fn emitted_wire_textpos_matches_hancom_measured_constants() {
+    use hwpforge_core::control::Control;
+    let mut para = Paragraph::with_runs(
+        vec![
+            Run::text("가나다", CharShapeIndex::new(0)),
+            Run::control(
+                Control::footnote(vec![Paragraph::with_runs(
+                    vec![Run::text("각주", CharShapeIndex::new(0))],
+                    ParaShapeIndex::new(0),
+                )]),
+                CharShapeIndex::new(0),
+            ),
+            Run::text("라마바", CharShapeIndex::new(0)),
+        ],
+        ParaShapeIndex::new(0),
+    );
+    para.layout_cache = Some(LayoutCache::new(vec![seg(0, 0), seg(4, 1600)]));
+    let mut doc = Document::new();
+    doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+    let store = style_store_for_preset("default").expect("preset");
+    let validated = doc.validate().expect("validate");
+    let bytes = HwpxEncoder::encode_with_options(
+        &validated,
+        &store,
+        &ImageStore::new(),
+        EncodeOptions::default().with_emit_layout_cache(true),
+    )
+    .expect("encode");
+    let xml = section_xml(&bytes);
+    // 한컴 실측 유도 상수: 줄1 = 0 (native 전수 불변식) · 줄2 =
+    // secPr(8)+colPr(8) 주입 + "가나다"(3) + 각주 marker(8) + "라"(1) = 28.
+    assert!(xml.contains(r#"textpos="0""#), "line1 wire 0: {xml}");
+    assert!(xml.contains(r#"textpos="28""#), "line2 wire 28 (16+3+8+1): {xml}");
+}
+
+/// 접힘 필드 본문의 tab = wire 8유닛 (독립 리뷰 Low 상환 fixture).
+#[test]
+fn folded_field_body_tab_counts_eight_wire_units() {
+    use hwpforge_core::control::Control;
+    let mut para = Paragraph::with_runs(
+        vec![
+            Run::text("ab", CharShapeIndex::new(0)),
+            Run::control(
+                Control::Field {
+                    field_type: hwpforge_foundation::FieldType::ClickHere,
+                    hint_text: Some("h".into()),
+                    help_text: None,
+                    name: Some("f".into()),
+                    display_text: "x\ty".into(),
+                },
+                CharShapeIndex::new(0),
+            ),
+            Run::text("cd", CharShapeIndex::new(0)),
+        ],
+        ParaShapeIndex::new(0),
+    );
+    para.layout_cache = Some(LayoutCache::new(vec![seg(0, 0), seg(3, 1600)]));
+    let mut doc = Document::new();
+    doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+    let outcome = roundtrip(doc);
+    assert!(outcome.warnings.is_empty(), "무경고: {:?}", outcome.warnings);
+    // 왕복 항등 + 절대값: 줄2 core 3("d") → wire = 16(주입) + "ab"(2)
+    // + 필드(16 + x(1)+tab(8)+y(1) = 26) + "c"(1) = 45.
+    assert_eq!(decoded_caches(&outcome.bytes)[0], Some(vec![0, 3]));
+    let xml = section_xml(&outcome.bytes);
+    assert!(xml.contains(r#"textpos="45""#), "tab=8 절대값 (16+2+26+1): {xml}");
+}
+
+/// 실물 한컴 fixture 골든 — 리뷰 영역 fixture 존재 시에만 실행 (930KB
+/// 라 커밋 금지 규칙 대상; 부재 환경(CI)에선 skip 로그 후 통과).
+#[test]
+fn real_hancom_marker_ledger_fixture_decodes_to_measured_triples() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/hwp5_review/rules-marker-ledger-base.hwpx");
+    let Ok(bytes) = std::fs::read(&path) else {
+        eprintln!("skip: {} 부재 (리뷰 영역 미보유 환경)", path.display());
+        return;
+    };
+    let decoded = HwpxDecoder::decode(&bytes).expect("decode");
+    let caches: Vec<Vec<u32>> = decoded.document.sections()[0]
+        .paragraphs
+        .iter()
+        .filter_map(|p| p.layout_cache.as_ref())
+        .filter(|c| c.lines.len() >= 2)
+        .map(|c| c.lines.iter().map(|l| l.textpos).collect())
+        .collect();
+    // §1g 수용 기준 골든 (raw [0,76,132]/[0,64,117]/[0,62,117] 에서
+    // 선행 marker 8×n 차감 유도 — Codex 4차 산술 재검증 완료).
+    assert_eq!(
+        caches,
+        vec![vec![0, 60, 116], vec![0, 56, 109], vec![0, 54, 109]],
+        "실물 한컴 fixture 가시 좌표 골든"
+    );
+}

--- a/crates/hwpforge-smithy-pdf/src/source/mod.rs
+++ b/crates/hwpforge-smithy-pdf/src/source/mod.rs
@@ -307,15 +307,20 @@ fn collect_page_events(
     (restarts, hide_marks)
 }
 
-/// 렌더 replay 가 자체 소비하는 0폭 marker 컨트롤인지 (textpos 무영향 —
-/// 한컴 HWPX 실측: `<hp:ctrl>` 은 linesegarray textpos 를 소비하지 않는다).
-/// 선행 비텍스트 fail-closed 가드와 `NonTextRunDropped` 경고에서 제외된다.
+/// 렌더 replay(`collect_page_events`)가 실제 소비하는 0폭 marker 인지.
+///
+/// W1b (§1g v5 변경 1): allowlist 는 **실제 consumer 와 동일한 match** —
+/// `NewNumber` 는 `Page` kind 만 replay 가 소비한다 (각주/그림 번호
+/// 재시작 등 다른 kind 는 소비자가 없으므로 허용하면 무음 드롭).
+/// admission(문단 전체 검사)과 `NonTextRunDropped` 경고에서 제외된다.
 fn is_replay_consumed_marker(content: &RunContent) -> bool {
     matches!(content, RunContent::Control(c)
     if matches!(
         **c,
-        hwpforge_core::control::Control::NewNumber { .. }
-            | hwpforge_core::control::Control::PageHiding { .. }
+        hwpforge_core::control::Control::NewNumber {
+            kind: hwpforge_core::control::NewNumberKind::Page,
+            ..
+        } | hwpforge_core::control::Control::PageHiding { .. }
     ))
 }
 
@@ -539,19 +544,16 @@ fn replay_band_item(
             warnings.push(PdfWarning::ParagraphSkipped { location });
             continue;
         };
-        // fail-closed 가드 (본문 경로와 동일 — 독립 리뷰 M1 상환): 첫 텍스트
-        // run 이전의 비텍스트 run(로고 이미지 등)은 textpos 좌표를 신뢰할 수
-        // 없게 만든다 — 무음 오절단 대신 거부.
-        let first_text = para.runs.iter().position(|r| r.content.plain_text().is_some());
-        if let Some(ft) = first_text {
-            if para.runs[..ft].iter().any(|r| r.content.plain_text().is_none()) {
-                return Err(PdfError::InvalidCache {
-                    detail: format!(
-                        "{location}: leading non-text run before first text run — textpos \
-                         normalization does not cover this control kind (W2 scope)"
-                    ),
-                });
-            }
+        // W1b admission (§1g v5 변경 1): 밴드는 대응 consumer 가 없어
+        // allowlist 가 **비어 있다** — 문단 전체에서 비텍스트 run 은 전부
+        // W2(밴드 이미지 렌더) 전 InvalidCache.
+        if para.runs.iter().any(|r| r.content.plain_text().is_none()) {
+            return Err(PdfError::InvalidCache {
+                detail: format!(
+                    "{location}: non-text run in band paragraph is not renderable \
+                     before W2 (band allowlist is empty)"
+                ),
+            });
         }
 
         let text = para.text_content();
@@ -764,25 +766,23 @@ fn replay_section(
         let first_breaks = prev_v.is_some_and(|p| first_v == 0 || first_v < p);
         check_table_anchor(&mut pending_table_anchor, first_v, first_breaks)?;
 
-        // fail-closed 가드 (독립 리뷰 열린질문): 첫 텍스트 run 이전에 비텍스트
-        // run(컨트롤·이미지)이 있으면 textpos 좌표를 신뢰할 수 없다 — HWPX
-        // 디코더의 선행 컨트롤 정규화는 secPr·ctrl 만 차감하므로(수식·그림
-        // 등은 스트림 유닛 미차감) 무음 오절단 대신 깨끗하게 거부한다.
-        // W2 예외: replay 가 자체 소비하는 0폭 marker(nwno)는 textpos 를
-        // 소비하지 않는다 (F1b 한컴 실측: ctrl 선행 + linesegarray textpos=0).
-        let first_text = para.runs.iter().position(|r| r.content.plain_text().is_some());
-        if let Some(ft) = first_text {
-            if para.runs[..ft]
-                .iter()
-                .any(|r| r.content.plain_text().is_none() && !is_replay_consumed_marker(&r.content))
-            {
-                return Err(PdfError::InvalidCache {
-                    detail: format!(
-                        "{location}: leading non-text run before first text run — textpos \
-                         normalization does not cover this control kind (W2 scope)"
-                    ),
-                });
-            }
+        // W1b admission (§1g v5 변경 1): 검사는 선두 prefix 가 아니라
+        // **문단 전체** — W1b 좌표 정규화로 marker 문단의 textpos 는
+        // 신뢰 가능해졌지만, 미렌더 원자(이미지·각주·수식·미지 컨트롤)는
+        // 위치 무관 W2 전 InvalidCache 다 (trailing 이미지가 0폭으로
+        // 무음 누락되는 경로 차단). 허용 = replay 가 실제 소비하는 0폭
+        // marker(Page 재시작·감추기)뿐.
+        if para
+            .runs
+            .iter()
+            .any(|r| r.content.plain_text().is_none() && !is_replay_consumed_marker(&r.content))
+        {
+            return Err(PdfError::InvalidCache {
+                detail: format!(
+                    "{location}: non-text run is not renderable before W2 \
+                     (only replay-consumed page markers are admitted)"
+                ),
+            });
         }
 
         let text = para.text_content();
@@ -1477,9 +1477,10 @@ mod tests {
     }
 
     #[test]
-    fn new_number_same_page_last_wins_and_non_page_kind_ignored() {
+    fn new_number_same_page_last_wins() {
         use hwpforge_core::control::{Control, NewNumberKind};
-        // 같은 쪽 다중 재시작 = 문서 순서 last-wins; 쪽 외 kind 는 렌더 무시.
+        // 같은 쪽 다중 재시작 = 문서 순서 last-wins (Page kind 만 —
+        // allowlist 원자).
         let mut p = Paragraph::with_runs(
             vec![
                 Run::control(
@@ -1488,10 +1489,6 @@ mod tests {
                 ),
                 Run::control(
                     Control::NewNumber { kind: NewNumberKind::Page, number: 9 },
-                    CharShapeIndex::new(0),
-                ),
-                Run::control(
-                    Control::NewNumber { kind: NewNumberKind::Footnote, number: 2 },
                     CharShapeIndex::new(0),
                 ),
                 Run::text("본문", CharShapeIndex::new(0)),
@@ -1509,7 +1506,34 @@ mod tests {
         let layout = replay(&doc, &PdfOptions::default()).expect("replay");
         let texts: Vec<&str> =
             layout.pages.iter().map(|p| p.page_number.as_ref().unwrap().text.as_str()).collect();
-        assert_eq!(texts, vec!["9", "10"], "last-wins + Footnote kind 무시");
+        assert_eq!(texts, vec!["9", "10"], "last-wins");
+    }
+
+    #[test]
+    fn non_page_new_number_is_rejected_not_silently_ignored() {
+        use hwpforge_core::control::{Control, NewNumberKind};
+        // W1b (§1g v5 변경 1): replay 소비자가 없는 NewNumber kind 는
+        // "무시"가 아니라 InvalidCache — 소비자와 allowlist 의 match 가
+        // 갈라지면 무음 드롭이 부활한다 (R4 Critical).
+        let mut p = Paragraph::with_runs(
+            vec![
+                Run::control(
+                    Control::NewNumber { kind: NewNumberKind::Footnote, number: 2 },
+                    CharShapeIndex::new(0),
+                ),
+                Run::text("본문", CharShapeIndex::new(0)),
+            ],
+            ParaShapeIndex::new(0),
+        );
+        p.layout_cache = Some(LayoutCache::new(vec![seg(0, 0)]));
+        let mut doc = Document::new();
+        doc.add_section(Section::with_paragraphs(vec![p], PageSettings::a4()));
+        let doc = doc.validate().expect("validate");
+        let err = replay(&doc, &PdfOptions::default()).expect_err("must reject");
+        assert!(
+            matches!(&err, PdfError::InvalidCache { detail } if detail.contains("not renderable")),
+            "got {err:?}"
+        );
     }
 
     #[test]
@@ -2092,8 +2116,9 @@ mod tests {
     }
 
     #[test]
-    fn trailing_non_text_run_is_dropped_with_warning() {
-        // 텍스트 뒤의 컨트롤 run 은 경고와 함께 생략 (문단 자체는 렌더).
+    fn trailing_non_text_run_is_rejected_before_w2() {
+        // W1b (§1g v5 변경 1): 검사는 문단 전체 — trailing 각주도 W2 전
+        // InvalidCache 다 (종전 "경고+생략"은 미렌더 원자의 무음 누락).
         let mut para = para_with_cache("본문", vec![seg(0, 0)]);
         para.add_run(Run::control(
             hwpforge_core::control::Control::footnote(vec![Paragraph::with_runs(
@@ -2103,9 +2128,11 @@ mod tests {
             CharShapeIndex::new(0),
         ));
         let doc = doc_of(vec![para]);
-        let layout = replay(&doc, &PdfOptions::default()).expect("replay");
-        assert_eq!(layout.pages[0].lines.len(), 1);
-        assert!(layout.warnings.iter().any(|w| matches!(w, PdfWarning::NonTextRunDropped { .. })));
+        let err = replay(&doc, &PdfOptions::default()).expect_err("must reject");
+        assert!(
+            matches!(&err, PdfError::InvalidCache { detail } if detail.contains("not renderable")),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/hwpforge-smithy-pdf/src/source/mod.rs
+++ b/crates/hwpforge-smithy-pdf/src/source/mod.rs
@@ -666,6 +666,20 @@ fn replay_section(
                     location,
                 });
             }
+            // 이미지 에픽 게이트 2 Critical#5 선행 수리: `[Image, Table]` 등
+            // 비텍스트 혼합 host 는 지금까지 표만 재생하고 나머지 객체를
+            // **무진단 폐기**했다 — 미지원 종류는 fail-closed 로 거부한다.
+            // (재시작/감춤 marker 는 host 쪽 이벤트로 소비되므로 예외.)
+            if para.runs.iter().any(|r| {
+                !matches!(r.content, RunContent::Table(_))
+                    && r.content.plain_text().is_none()
+                    && !is_replay_consumed_marker(&r.content)
+            }) {
+                return Err(PdfError::UnsupportedContent {
+                    kind: "non-text content in table-host paragraph",
+                    location,
+                });
+            }
             let Some(cache) = para.layout_cache.as_ref().filter(|c| !c.is_empty()) else {
                 return Err(PdfError::MissingLayoutCache { count: 1, first: location });
             };
@@ -1635,6 +1649,43 @@ mod tests {
         );
         // 이벤트는 적용되지 않는다 (앵커 불가 — 기존 번호 유지).
         assert_eq!(layout.pages[0].page_number.as_ref().unwrap().text, "1");
+    }
+
+    #[test]
+    fn table_host_with_image_fails_closed_instead_of_silent_discard() {
+        // 이미지 에픽 게이트 2 Critical#5: [Image, Table] host 는 이전엔 표만
+        // 그리고 이미지를 경고 없이 버렸다 — fail-closed 로 잠근다.
+        use hwpforge_core::image::{Image, ImageFormat};
+        use hwpforge_core::table::Table;
+        let img = Image::new(
+            "BinData/x.png".to_string(),
+            HwpUnit::from_pt(10.0).expect("unit"),
+            HwpUnit::from_pt(10.0).expect("unit"),
+            ImageFormat::Png,
+        );
+        let mut p = Paragraph::with_runs(
+            vec![
+                Run::image(img, CharShapeIndex::new(0)),
+                Run::table(
+                    Table::new(vec![TableRow::new(vec![cell_with_cache("셀")])]),
+                    CharShapeIndex::new(0),
+                ),
+            ],
+            ParaShapeIndex::new(0),
+        );
+        p.layout_cache = Some(LayoutCache::new(vec![seg(0, 0)]));
+        let doc = doc_of(vec![para_with_cache("본문", vec![seg(0, 0)]), p]);
+        let err = replay(&doc, &PdfOptions::default()).expect_err("must fail closed");
+        assert!(
+            matches!(
+                err,
+                PdfError::UnsupportedContent {
+                    kind: "non-text content in table-host paragraph",
+                    ..
+                }
+            ),
+            "{err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약

이미지/글상자 에픽 W1a+W1b: HxRun 자식 문서 순서 보존(사이드카)과 **줄 조판 캐시 좌표계 통일** — Core `LayoutCache.textpos` 를 가시 텍스트(`text_content()`) 좌표 하나로 정준화하고, 세 경계(HWPX 디코더·HWP5 승격·인코더)가 wire↔Core ledger 로 정규화/역변환한다.

근거 실측(에픽 문서 §1f): 한컴 HWPX linesegarray textpos = HWP5 raw 스트림 좌표 그대로이며, 확장 marker 는 종류 무관 8유닛을 소비한다 — 종전 "선두 컨트롤만 균일 차감" 정규화는 중간 marker(각주·새번호·그림·수식) 문단을 무음 오절단했다 (판별 fixture 로 재현).

## 변경

- **W1a** (`e6f8b4d`): `HxRun.child_order` 순서 사이드카 + 디코더 문서-순서 평탄화 + patch.rs 동시 전환. 순서 기반 field pairing 으로 gotcha #30(병합-run 모호성 다운그레이드) 철폐 — 한컴 재저장 필드가 채움 가능해짐.
- **HWP5** (`40890cc`): 파서가 무음 소비 wire 구간(`SilentWire`)을 기록, projection 이 방출과 나란히 ledger 구축(field 는 방출 결과가 core 폭 결정), promote 시 raw→가시 정규화. 실패 = fail-closed(캐시 미승격 + `Hwp5Warning::LayoutCacheDropped`).
- **HWPX 양방향** (`a04571c`): 디코더는 문단 전체 자식 걷기 ledger(`WireTextMap` — tab (8,1) 비대칭·typed titleMark part·markpen (0,0))로 정규화, 미지 요소는 typed 경로(`ParagraphPath`)와 함께 드롭. 인코더는 방출 걸음 안에서 span 을 기여(`EncoderLedger` — placeholder 조각 포함)하고 `to_wire` 역변환으로 방출. `to_wire(0)=0` 은 native 291파일·13,598 linesegarray 전수 실측 불변식.
- **렌더러**: admission 을 문단 전체·컨텍스트별 allowlist 로 교체 — body 는 replay 소비 원자(쪽 새번호·감추기)만, 미렌더 원자는 W2 전 명시 거부(trailing 이미지 무음 누락 차단).
- **fill/diff**: 동일값 완전 no-op · 값 변경 문단의 stale linesegarray 제거 · diff 는 그 제거를 정직하게 보고.
- **convert/CLI**: `ConvertWarning{Hwp5,HwpxEncode}` 합성 경고로 인코드 진단 전파, `LAYOUT_CACHE_DROPPED` DTO, corpus 측정기(`census_layout_carry`).
- **독립 리뷰 상환** (`88c4b2e`): folded field tab 폭(8유닛) 실버그 수정 · 절대값 oracle(대칭 폭 버그 사각 봉쇄) · 미래 variant 방어 · 인코더 core_end 자가검증(3중 대칭).

## BREAKING

- `encode_with_options(emit_layout_cache=true)` 는 캐시 드롭 시 `HwpxError::LayoutCacheDropped`(E4011) 를 반환한다 — 무음 데이터 손실 폐지. 진단 보존 경로 = 신규 `encode_with_diagnostics`(`EncodeOutcome`).
- `hwp5_to_hwpx*` 반환형이 `Vec<ConvertWarning>` 으로 변경 (convert 는 publish=false).

## 실측 게이트

| 게이트 | 결과 |
| --- | --- |
| 실물 한컴 fixture 골든 (rules-marker-ledger) | Core tp `[0,60,116]`/`[0,56,109]`/`[0,54,109]` 정확 일치 (커밋된 존재-시-실행 골든 + 절대값 oracle) |
| roundtrip 매트릭스 | 10/10 (marker/tab/field 왕복 항등·축약점 모호 드롭·strict 에러·tab=8 필드) |
| make ci | 3,260/3,260 |
| F1b e2e (convert carry→to-pdf) | 물리 2쪽·캐시 드롭 0 |
| corpus 센서스 (2,231건) | 드롭 파일 4.3%·213문단 — 전부 typed 경고, OutOfRange 0 (계정 자기모순 없음) |

설계·리뷰 이력 정본: `.docs/planning/2026-08-13-image-textbox-epic.md` §1g~§1h (적대적 설계 리뷰 4라운드 반영, 독립 코드리뷰 approve-with-fixes 전건 상환).

https://claude.ai/code/session_01XbNfyviW1VmsUnbEysMhD7
