### PR TITLE
fix(release): 0.16.0 트리거 재선언 — core 파일 변경 동반 breaking 커밋

### DIFF
--- a/crates/hwpforge-core/src/placement.rs
+++ b/crates/hwpforge-core/src/placement.rs
@@ -42,6 +42,11 @@ use serde::{Deserialize, Serialize};
 /// to `None`, so the encoder's untouched legacy path emits the historical
 /// inline bytes (mirrors the `Option<ShapeStyle>` collapse pattern in the
 /// HWPX shape-style decoder).
+///
+/// Offsets are signed: Hancom persists negative offsets in HWPX `hp:pos`
+/// as **u32 wrap-around decimal strings** (e.g. `horzOffset="4294965029"`
+/// = −2267, dialog-authored fixture measurement), and in HWP5 as plain
+/// signed `i32`. Codecs must round-trip both encodings losslessly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ObjectPlacement {
     /// Text wrapping mode around the object.


### PR DESCRIPTION
## 요약

W4 (PR #149) 의 Core breaking(ObjectPlacement 공용화)이 두 차례 릴리스 트리거에 실패했다:
1. 원 커밋 `37fcf58` — `feat!(core):` 형식 오류로 `release_commits` 정규식 불일치
2. 1차 재선언 `b8a1d56` (PR #150 동승) — 올바른 형식이었으나 **빈 커밋**이라 release-plz 의 경로 기반 패키지 귀속에 잡히지 않음 (`release_pr_output: {"prs":[]}` 실측)

본 PR 은 **core 파일을 실제로 변경하는** `feat(core)!:` 재선언 커밋으로 트리거를 확정한다. 변경 내용은 오늘 실측한 wire 사실의 rustdoc 기록 — HWPX `hp:pos` 가 음수 offset 을 u32 랩 십진수로 인코드(`horzOffset="4294965029"` = −2267)한다는 것 (개체 속성 대화상자 공동 저작 fixture 실측).

## 기대 효과

머지 시 release-plz 가 hwpforge-core breaking 을 인식 → **0.16.0** Release PR 생성 (0.x 마이너 bump, 사용자 사전 승인). 판정 기준 = `release_pr_output` 비어 있지 않음 + Release PR 실물.

## 검증

- cargo check core 통과, rustdoc 전용 변경 (코드 의미 무변)
- 교훈 2건은 memory·에픽 문서에 기록 (커밋 형식 `type(scope)!:` · 트리거는 파일 변경 동반 필수)