### PR TITLE
ci: 게이트 재배치 — PR 경량화·머지 큐 최종 게이트화·Release Preflight 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,12 @@
 #   - Reusable preflight for release workflow
 #   - Manual full validation when requested
 #
-# Modes
-#   pr          → full contributor checks (coverage + deny + msrv)
-#   merge_queue → merge safety checks (skip slow duplicate audits)
-#   release     → release preflight (docs build included, no MSRV/coverage/deny)
+# Modes (CI 다이어트 P1 — PR 은 빠른 피드백, 큐가 최종 전체 게이트)
+#   pr          → fast feedback (fmt/clippy/test/audit/lint — coverage,
+#                 deny, msrv, docs build 는 머지 큐로 이동)
+#   merge_queue → final full gate (coverage + deny + msrv + docs build)
+#   release     → pr 과 동일 플래그 (자동 트리거 경로 없음 — P2 로
+#                 release-plz Preflight 호출 제거됨, dispatch 라벨용 존치)
 #   full        → manual full validation
 # =============================================================================
 
@@ -92,23 +94,30 @@ jobs:
             esac
           fi
 
+          # CI 다이어트 (.docs/planning/2026-08-25-ci-diet-proposal.md P1):
+          # PR = 빠른 피드백(fmt/clippy/test/audit/lint), 머지 큐 = 최종
+          # 전체 게이트(coverage/MSRV/deny/docs build). skip 된 required
+          # check 는 GitHub 가 충족으로 취급하므로 PR 의 MSRV/deny skip 은
+          # 안전 (기존 큐가 skip 하고도 머지되던 것과 동일 메커니즘).
           case "$mode" in
             pr)
+              run_coverage=false
+              run_deny=false
+              run_docs_build=false
+              run_msrv=false
+              ;;
+            merge_queue)
               run_coverage=true
               run_deny=true
               run_docs_build=true
               run_msrv=true
               ;;
-            merge_queue)
-              run_coverage=false
-              run_deny=false
-              run_docs_build=true
-              run_msrv=false
-              ;;
             release)
+              # P2: 큐가 방금 게이트한 커밋 — Preflight 는 release-plz.yml
+              # 에서 호출 자체를 제거했고, 이 모드는 수동 dispatch 용 최소만.
               run_coverage=false
               run_deny=false
-              run_docs_build=true
+              run_docs_build=false
               run_msrv=false
               ;;
             full)

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -2,11 +2,11 @@
 # HwpForge Release Automation (release-plz)
 # =============================================================================
 #
-# On push to main:
-#   1. Run reusable release preflight from ci.yml
-#   2. Publish crates / create GitHub Releases when a release PR was merged
-#   3. Create or refresh the next release PR
-#   4. Deploy Pages only when a real release was created
+# On push to main (validation is owned by the merge queue — every commit
+# reaching main just passed ci.yml merge_queue mode; no preflight here, P2):
+#   1. Publish crates / create GitHub Releases when a release PR was merged
+#   2. Create or refresh the next release PR
+#   3. Deploy Pages only when a real release was created
 # =============================================================================
 
 name: Release
@@ -28,18 +28,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  preflight:
-    name: Release Preflight
-    if: github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/ci.yml
-    permissions:
-      contents: read
-    with:
-      mode: release
-
+  # Release Preflight 제거 (CI 다이어트 P2 — .docs/planning/2026-08-25-ci-
+  # diet-proposal.md): main 에 닿는 모든 커밋은 머지 큐가 직전에 전체
+  # 게이트(coverage/MSRV/deny 포함, ci.yml merge_queue 모드)를 통과시킨
+  # 동일 커밋이므로 여기서의 재검증은 중복이었다 (~6분/머지). semver
+  # 검사는 release-plz 자체(semver_check)가 계속 소유한다.
   release-plz-release:
     name: Release
-    needs: [preflight]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
@@ -76,7 +71,6 @@ jobs:
 
   release-plz-pr:
     name: Release PR
-    needs: [preflight]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 요약

CI 다이어트 P1+P2 (설계·실측 = 내부 제안서, 적대 리뷰 approve-with-changes 반영):

- **P1**: coverage(7분)·MSRV·deny·docs build 를 PR 모드 → 머지 큐 모드로 이동 — PR 은 빠른 피드백(wall ≈8→6분), 큐가 main 합류 직전 최종 전체 게이트를 소유. skip 된 required check 는 skipped 체크런으로 충족되므로 안전 (기존 큐가 MSRV/deny 를 skip 하고도 머지되던 실측과 동일 메커니즘 — 리뷰가 과거 main 체크런 이력으로 재확증).
- **P2**: Release Preflight(ci.yml mode=release, ~6분/머지) 제거 — main 에 닿는 커밋은 큐가 방금 게이트한 동일 커밋. semver 검사는 release-plz 소유 유지.
- **동반 설정 집행 (별도, 이미 적용)**: branch protection required checks 에 `Verify › Coverage (≥ 90%)` 추가 — 큐에서 coverage 실패 = 머지 차단 (coverage 는 기존에 required 가 아니어서 게이트였던 적이 없음 — 리뷰 High 정정 반영). enforce_admins 는 보류 (잔존 리스크 문서화).

## 검증

- YAML 파스 OK · preflight 참조 제거 (needs 그래프 정합 — 리뷰 확인) · 이 PR 자체의 CI 가 새 pr-mode 실증 (coverage/MSRV/deny/docs-build 가 skipped 로 표시되면 정상)
- 기대 효과: 기능+릴리스 체인 총 CI wall ≈26분 → ≈14~16분

## 후속 (별도 PR)

P3 경로 필터 (docs-only PR 단락) · P5 sccache — 내부 제안서 §5 순서