### PR TITLE
fix(bindings-mcp): rmcp 3.1 마이그레이션

### DIFF
--- a/crates/hwpforge-bindings-mcp/Cargo.toml
+++ b/crates/hwpforge-bindings-mcp/Cargo.toml
@@ -23,7 +23,7 @@ hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }
 hwpforge-smithy-hwpx = { path = "../hwpforge-smithy-hwpx", version = "0", features = ["schemars"] }
 hwpforge-smithy-md = { path = "../hwpforge-smithy-md", version = "0" }
 # >=2.0 fixes RUSTSEC advisory GHSA-89vp-x53w-74fx (MCP Host-header validation in <1.4.0); tracks Dependabot #90
-rmcp = { version = "2.0", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hwpforge-bindings-mcp/src/prompts/mod.rs
+++ b/crates/hwpforge-bindings-mcp/src/prompts/mod.rs
@@ -12,67 +12,65 @@ mod report;
 
 /// List all available prompts.
 pub fn list_prompts() -> Result<ListPromptsResult, McpError> {
-    Ok(ListPromptsResult {
-        prompts: vec![
-            Prompt::new(
-                "generate_proposal",
-                Some("한국 정부 RFP 제안서를 마크다운으로 작성하고 HWPX로 변환하는 워크플로우"),
-                Some(vec![
-                    PromptArgument::new("topic")
-                        .with_title("제안서 주제")
-                        .with_description("제안서의 주제 또는 사업명")
-                        .with_required(true),
-                    PromptArgument::new("organization")
-                        .with_title("제안 기관")
-                        .with_description("제안 기관/회사명 (선택)")
-                        .with_required(false),
-                    PromptArgument::new("deadline")
-                        .with_title("제출 기한")
-                        .with_description("제출 기한 (YYYY-MM-DD, 선택)")
-                        .with_required(false),
-                ]),
-            )
-            .with_title("정부 제안서 생성"),
-            Prompt::new(
-                "generate_report",
-                Some("연구/진행/분석 보고서를 마크다운으로 작성하고 HWPX로 변환하는 워크플로우"),
-                Some(vec![
-                    PromptArgument::new("topic")
-                        .with_title("보고서 주제")
-                        .with_description("보고서의 주제")
-                        .with_required(true),
-                    PromptArgument::new("author")
-                        .with_title("저자")
-                        .with_description("보고서 저자 (선택)")
-                        .with_required(false),
-                    PromptArgument::new("report_type")
-                        .with_title("보고서 유형")
-                        .with_description(
-                            "보고서 종류: research/progress/analysis (선택, 기본: research)",
-                        )
-                        .with_required(false),
-                ]),
-            )
-            .with_title("보고서 생성"),
-            Prompt::new(
-                "convert_and_review",
-                Some("기존 HWPX 문서를 JSON round-trip으로 편집하는 단계별 가이드"),
-                Some(vec![
-                    PromptArgument::new("file_path")
-                        .with_title("HWPX 파일 경로")
-                        .with_description("편집할 HWPX 파일의 경로")
-                        .with_required(true),
-                    PromptArgument::new("edit_instructions")
-                        .with_title("편집 지침")
-                        .with_description("구체적인 편집 지침 (선택)")
-                        .with_required(false),
-                ]),
-            )
-            .with_title("문서 편집 워크플로우"),
-        ],
-        next_cursor: None,
-        meta: None,
-    })
+    // rmcp 3.x: with_all_items 가 SEP-2322/2549 신규 필드(result_type=
+    // COMPLETE, ttl_ms/cache_scope=None)를 규약대로 채운다.
+    Ok(ListPromptsResult::with_all_items(vec![
+        Prompt::new(
+            "generate_proposal",
+            Some("한국 정부 RFP 제안서를 마크다운으로 작성하고 HWPX로 변환하는 워크플로우"),
+            Some(vec![
+                PromptArgument::new("topic")
+                    .with_title("제안서 주제")
+                    .with_description("제안서의 주제 또는 사업명")
+                    .with_required(true),
+                PromptArgument::new("organization")
+                    .with_title("제안 기관")
+                    .with_description("제안 기관/회사명 (선택)")
+                    .with_required(false),
+                PromptArgument::new("deadline")
+                    .with_title("제출 기한")
+                    .with_description("제출 기한 (YYYY-MM-DD, 선택)")
+                    .with_required(false),
+            ]),
+        )
+        .with_title("정부 제안서 생성"),
+        Prompt::new(
+            "generate_report",
+            Some("연구/진행/분석 보고서를 마크다운으로 작성하고 HWPX로 변환하는 워크플로우"),
+            Some(vec![
+                PromptArgument::new("topic")
+                    .with_title("보고서 주제")
+                    .with_description("보고서의 주제")
+                    .with_required(true),
+                PromptArgument::new("author")
+                    .with_title("저자")
+                    .with_description("보고서 저자 (선택)")
+                    .with_required(false),
+                PromptArgument::new("report_type")
+                    .with_title("보고서 유형")
+                    .with_description(
+                        "보고서 종류: research/progress/analysis (선택, 기본: research)",
+                    )
+                    .with_required(false),
+            ]),
+        )
+        .with_title("보고서 생성"),
+        Prompt::new(
+            "convert_and_review",
+            Some("기존 HWPX 문서를 JSON round-trip으로 편집하는 단계별 가이드"),
+            Some(vec![
+                PromptArgument::new("file_path")
+                    .with_title("HWPX 파일 경로")
+                    .with_description("편집할 HWPX 파일의 경로")
+                    .with_required(true),
+                PromptArgument::new("edit_instructions")
+                    .with_title("편집 지침")
+                    .with_description("구체적인 편집 지침 (선택)")
+                    .with_required(false),
+            ]),
+        )
+        .with_title("문서 편집 워크플로우"),
+    ]))
 }
 
 /// Get a specific prompt by name with arguments.

--- a/crates/hwpforge-bindings-mcp/src/resources/mod.rs
+++ b/crates/hwpforge-bindings-mcp/src/resources/mod.rs
@@ -139,7 +139,9 @@ pub fn list_resources() -> Result<ListResourcesResult, McpError> {
         })
         .collect();
 
-    Ok(ListResourcesResult { resources, next_cursor: None, meta: None })
+    // rmcp 3.x: with_all_items 가 SEP-2322/2549 신규 필드(result_type=
+    // COMPLETE, ttl_ms/cache_scope=None)를 규약대로 채운다.
+    Ok(ListResourcesResult::with_all_items(resources))
 }
 
 /// Read a specific template resource by URI.

--- a/crates/hwpforge-bindings-mcp/src/server.rs
+++ b/crates/hwpforge-bindings-mcp/src/server.rs
@@ -1025,8 +1025,10 @@ impl ServerHandler for HwpForgeServer {
         &self,
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, McpError> {
-        resources::read_resource(&request.uri)
+    ) -> Result<ReadResourceResponse, McpError> {
+        // rmcp 3.x MRTR(SEP-2322): 핸들러는 outcome enum 을 반환한다 —
+        // 우리는 항상 완결 응답이므로 Complete 로 승격 (From impl).
+        resources::read_resource(&request.uri).map(Into::into)
     }
 
     async fn list_prompts(
@@ -1041,7 +1043,8 @@ impl ServerHandler for HwpForgeServer {
         &self,
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<GetPromptResult, McpError> {
-        prompts::get_prompt(&request.name, request.arguments.as_ref())
+    ) -> Result<GetPromptResponse, McpError> {
+        // rmcp 3.x MRTR(SEP-2322): 항상 완결 응답 — Complete 로 승격.
+        prompts::get_prompt(&request.name, request.arguments.as_ref()).map(Into::into)
     }
 }


### PR DESCRIPTION
## 배경

dependabot #135 (rmcp 2.0→3.1) 는 단순 bump 라 rmcp 3.x 의 API 변경으로 Clippy 게이트가 컴파일 에러였고, 브랜치도 2주 stale 상태였다. 최신 main 기준으로 bump + 마이그레이션을 수행한 대체 PR. **머지되면 dependabot 이 #135 를 자동 close 한다.**

## 변경

- `read_resource`/`get_prompt` 핸들러 반환을 rmcp 3.x MRTR(SEP-2322) outcome enum (`ReadResourceResponse`/`GetPromptResponse`)으로 승격 — 서버는 항상 완결 응답이므로 `Complete` 변환(`From` impl)만 필요
- `ListPromptsResult`/`ListResourcesResult` 생성을 `with_all_items` 생성자로 교체 — SEP-2322/2549 신규 필드(`result_type=COMPLETE`·`ttl_ms`·`cache_scope`)를 규약 기본값으로 채움
- Cargo.toml: `rmcp = "3.1"` (resolved 3.1.4)

## 게이트

- bindings-mcp 84/84 테스트 통과 · clippy clean
- 공개 API 불변 (rmcp 타입은 우리 공개 표면에 비노출) — `fix` 패치, 머지 시 0.16.2 Release PR 발화 예상