### PR TITLE
fix: W6 에픽 마감 — md→hwpx 이미지 BinData 임베드·포맷 정책 잠금·corpus 성적표

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rust-version = "1.88"
 
 [workspace.dependencies]
 # === XML Processing ===
+base64 = "0.22"
 quick-xml = { version = "0.41", features = ["serialize", "overlapped-lists"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/hwpforge-bindings-cli/src/commands/convert.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/convert.rs
@@ -70,7 +70,17 @@ pub fn run(input: &str, output: &PathBuf, preset: &str, json_mode: bool) {
 
     // 이미지 참조를 BinData 로 적재 (W6 §12b — stdin 입력은 base_dir 없음:
     // 상대 경로는 typed 경고로 제외되고 data: URI 만 임베드된다).
-    let base_dir = if input == "-" { None } else { std::path::Path::new(input).parent() };
+    // bare 파일명(`convert a.md`)의 parent() 는 None 이 아니라 빈 경로
+    // `Some("")` — canonicalize 불가라 base 를 통째로 잃는다 (독립 리뷰
+    // B2). 빈 경로 = 현재 디렉터리로 정규화.
+    let base_dir = if input == "-" {
+        None
+    } else {
+        match std::path::Path::new(input).parent() {
+            Some(p) if p.as_os_str().is_empty() => Some(std::path::Path::new(".")),
+            other => other,
+        }
+    };
     let embedded = load_referenced_images(&mut md_doc.document, base_dir);
     let embed_warnings: Vec<String> =
         embedded.warnings.iter().map(std::string::ToString::to_string).collect();

--- a/crates/hwpforge-bindings-cli/src/commands/convert.rs
+++ b/crates/hwpforge-bindings-cli/src/commands/convert.rs
@@ -5,9 +5,8 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use hwpforge_core::image::ImageStore;
 use hwpforge_smithy_hwpx::{HwpxEncoder, HwpxRegistryBridge};
-use hwpforge_smithy_md::MdDecoder;
+use hwpforge_smithy_md::{load_referenced_images, MdDecoder};
 
 use crate::error::{check_file_size, CliError, MAX_STDIN_SIZE};
 
@@ -18,6 +17,9 @@ struct ConvertResult {
     sections: usize,
     paragraphs: usize,
     size_bytes: usize,
+    /// 이미지 임베드에서 제외된 참조들 (W6 §12b — typed 경고의 표시 문자열).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
 }
 
 /// Run the convert command: MD → HWPX.
@@ -58,13 +60,23 @@ pub fn run(input: &str, output: &PathBuf, preset: &str, json_mode: bool) {
     };
 
     // Decode MD → Core
-    let md_doc = match MdDecoder::decode_with_default(&markdown) {
+    let mut md_doc = match MdDecoder::decode_with_default(&markdown) {
         Ok(d) => d,
         Err(e) => {
             CliError::new("MD_DECODE_FAILED", format!("Markdown decode error: {e}"))
                 .exit(json_mode, 2);
         }
     };
+
+    // 이미지 참조를 BinData 로 적재 (W6 §12b — stdin 입력은 base_dir 없음:
+    // 상대 경로는 typed 경고로 제외되고 data: URI 만 임베드된다).
+    let base_dir = if input == "-" { None } else { std::path::Path::new(input).parent() };
+    let embedded = load_referenced_images(&mut md_doc.document, base_dir);
+    let embed_warnings: Vec<String> =
+        embedded.warnings.iter().map(std::string::ToString::to_string).collect();
+    for w in &embed_warnings {
+        eprintln!("[convert] {w}");
+    }
 
     let bridge = match HwpxRegistryBridge::from_registry(&md_doc.style_registry) {
         Ok(bridge) => bridge,
@@ -94,8 +106,7 @@ pub fn run(input: &str, output: &PathBuf, preset: &str, json_mode: bool) {
     let total_paragraphs: usize = validated.sections().iter().map(|s| s.paragraphs.len()).sum();
 
     // Encode Core → HWPX
-    let image_store = ImageStore::new();
-    let bytes = match HwpxEncoder::encode(&validated, bridge.style_store(), &image_store) {
+    let bytes = match HwpxEncoder::encode(&validated, bridge.style_store(), &embedded.store) {
         Ok(b) => b,
         Err(e) => {
             CliError::new("ENCODE_FAILED", format!("HWPX encode error: {e}")).exit(json_mode, 2);
@@ -115,6 +126,7 @@ pub fn run(input: &str, output: &PathBuf, preset: &str, json_mode: bool) {
         sections: validated.section_count(),
         paragraphs: total_paragraphs,
         size_bytes: bytes.len(),
+        warnings: embed_warnings,
     };
 
     if json_mode {

--- a/crates/hwpforge-bindings-cli/tests/cli_integration.rs
+++ b/crates/hwpforge-bindings-cli/tests/cli_integration.rs
@@ -492,6 +492,44 @@ fn convert_md_to_hwpx() {
     assert!(std::fs::metadata(&out).unwrap().len() > 0);
 }
 
+/// W6 §12b B2 게이트: bare 파일명 입력(`convert a.md`)에서도 md 옆 이미지가
+/// 임베드된다 — `parent()` 의 빈 경로가 base 를 잃게 하던 회귀 잠금.
+#[test]
+fn convert_bare_filename_embeds_sibling_image() {
+    let tmp = test_tmp();
+    let png: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3];
+    std::fs::write(tmp.join("i.png"), png).expect("write png");
+    std::fs::write(tmp.join("a.md"), "본문 ![아이콘](i.png) 끝.\n").expect("write md");
+    let output = Command::new(hwpforge_bin())
+        .current_dir(&tmp)
+        .args(["convert", "a.md", "-o", "out.hwpx"])
+        .output()
+        .expect("run hwpforge");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "stderr: {stderr}");
+    assert!(!stderr.contains("not embedded"), "임베드 경고 없어야 함: {stderr}");
+    let bytes = std::fs::read(tmp.join("out.hwpx")).expect("read out");
+    assert!(
+        bytes.windows(b"BinData/image1.png".len()).any(|w| w == b"BinData/image1.png"),
+        "zip 에 BinData 엔트리"
+    );
+}
+
+/// W6 §12b B1 게이트: 해결 불가 참조(원격 URL)가 문단의 유일한 run 이어도
+/// 변환은 성공한다 — 빈 문단 validate 거부로 문서 전체가 죽던 회귀 잠금.
+#[test]
+fn convert_remote_image_only_paragraph_still_succeeds() {
+    let tmp = test_tmp();
+    let md = tmp.join("r.md");
+    std::fs::write(&md, "# 제목\n\n![remote](https://example.com/logo.png)\n\n본문.\n")
+        .expect("write md");
+    let out = tmp.join("r.hwpx");
+    let (_, stderr, code) = run(&["convert", md.to_str().unwrap(), "-o", out.to_str().unwrap()]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stderr.contains("not embedded"), "typed 경고 표면화: {stderr}");
+    assert!(out.exists());
+}
+
 #[test]
 fn convert_json_mode() {
     let tmp = test_tmp();

--- a/crates/hwpforge-bindings-mcp/src/server.rs
+++ b/crates/hwpforge-bindings-mcp/src/server.rs
@@ -311,12 +311,23 @@ impl HwpForgeServer {
 
         match result {
             Ok(data) => {
+                // 임베드 제외 경고는 summary 에도 실어야 한다 — 에이전트가
+                // summary 만 읽고 이미지 누락을 성공으로 오독하지 않도록
+                // (독립 리뷰 M4, W6 §12b).
+                let mut summary = format!(
+                    "Generated {} ({} bytes, {} sections, {} paragraphs)",
+                    data.output_path, data.size_bytes, data.sections, data.paragraphs,
+                );
+                if !data.warnings.is_empty() {
+                    summary.push_str(&format!(
+                        " — {} image reference(s) NOT embedded: {}",
+                        data.warnings.len(),
+                        data.warnings.join(" · "),
+                    ));
+                }
                 let output = ToolOutput::new(
                     &data,
-                    format!(
-                        "Generated {} ({} bytes, {} sections, {} paragraphs)",
-                        data.output_path, data.size_bytes, data.sections, data.paragraphs,
-                    ),
+                    summary,
                     vec![
                         "Use hwpforge_inspect to verify the output",
                         "Use hwpforge_to_json + hwpforge_patch to edit",

--- a/crates/hwpforge-bindings-mcp/src/tools/convert.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/convert.rs
@@ -2,11 +2,10 @@
 
 use serde::Serialize;
 
-use hwpforge_core::image::ImageStore;
 use hwpforge_foundation::FontId;
 use hwpforge_smithy_hwpx::presets::builtin_presets;
 use hwpforge_smithy_hwpx::{HwpxEncoder, HwpxRegistryBridge};
-use hwpforge_smithy_md::MdDecoder;
+use hwpforge_smithy_md::{load_referenced_images, MdDecoder};
 
 use crate::output::{read_file_string, write_output_file, ToolErrorInfo, MAX_INLINE_SIZE};
 
@@ -21,6 +20,9 @@ pub struct ConvertData {
     pub sections: usize,
     /// Total number of paragraphs across all sections.
     pub paragraphs: usize,
+    /// 이미지 임베드에서 제외된 참조들 (W6 §12b — typed 경고의 표시 문자열).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 /// Execute Markdown → HWPX conversion.
@@ -79,6 +81,15 @@ pub fn run_convert(
         )
     })?;
 
+    // 4b. 이미지 참조를 BinData 로 적재 (W6 §12b). 인라인 입력은 base_dir
+    //     이 없다 — 상대 경로 참조는 typed 경고로 제외되고 data: URI 만
+    //     임베드된다 (파일 입력은 md 파일의 부모 디렉터리 기준 + 경로
+    //     탈출 차단).
+    let base_dir = if is_file { std::path::Path::new(markdown).parent() } else { None };
+    let embedded = load_referenced_images(&mut md_doc.document, base_dir);
+    let warnings: Vec<String> =
+        embedded.warnings.iter().map(std::string::ToString::to_string).collect();
+
     // 5. Count sections and paragraphs
     let sections: usize = md_doc.document.sections().len();
     let paragraphs: usize = md_doc.document.sections().iter().map(|s| s.paragraphs.len()).sum();
@@ -111,7 +122,6 @@ pub fn run_convert(
             "Check paragraph list references in the resolved style registry.",
         )
     })?;
-    let image_store = ImageStore::new();
 
     let rebound = bridge.rebind_draft_document(md_doc.document).map_err(|e| {
         ToolErrorInfo::new(
@@ -130,8 +140,8 @@ pub fn run_convert(
     })?;
 
     // 7. Encode to HWPX bytes
-    let hwpx_bytes =
-        HwpxEncoder::encode(&validated, bridge.style_store(), &image_store).map_err(|e| {
+    let hwpx_bytes = HwpxEncoder::encode(&validated, bridge.style_store(), &embedded.store)
+        .map_err(|e| {
             ToolErrorInfo::new(
                 "ENCODE_ERROR",
                 format!("HWPX encoding failed: {e}"),
@@ -144,5 +154,11 @@ pub fn run_convert(
 
     let size_bytes: u64 = hwpx_bytes.len() as u64;
 
-    Ok(ConvertData { output_path: output_path.to_string(), size_bytes, sections, paragraphs })
+    Ok(ConvertData {
+        output_path: output_path.to_string(),
+        size_bytes,
+        sections,
+        paragraphs,
+        warnings,
+    })
 }

--- a/crates/hwpforge-bindings-mcp/src/tools/convert.rs
+++ b/crates/hwpforge-bindings-mcp/src/tools/convert.rs
@@ -85,7 +85,16 @@ pub fn run_convert(
     //     이 없다 — 상대 경로 참조는 typed 경고로 제외되고 data: URI 만
     //     임베드된다 (파일 입력은 md 파일의 부모 디렉터리 기준 + 경로
     //     탈출 차단).
-    let base_dir = if is_file { std::path::Path::new(markdown).parent() } else { None };
+    // bare 파일명의 parent() 는 빈 경로 `Some("")` — 현재 디렉터리로
+    // 정규화 (독립 리뷰 B2).
+    let base_dir = if is_file {
+        match std::path::Path::new(markdown).parent() {
+            Some(p) if p.as_os_str().is_empty() => Some(std::path::Path::new(".")),
+            other => other,
+        }
+    } else {
+        None
+    };
     let embedded = load_referenced_images(&mut md_doc.document, base_dir);
     let warnings: Vec<String> =
         embedded.warnings.iter().map(std::string::ToString::to_string).collect();

--- a/crates/hwpforge-core/src/image.rs
+++ b/crates/hwpforge-core/src/image.rs
@@ -248,6 +248,85 @@ impl ImageFormat {
             None => Self::Unknown(String::new()),
         }
     }
+
+    /// Sniffs an [`ImageFormat`] from the leading magic bytes.
+    ///
+    /// Extension-derived formats ([`Self::from_extension`]) are diagnostic
+    /// hints only — file names cannot be trusted. Byte sniffing is the
+    /// ground truth for admission decisions (e.g. the Markdown → HWPX image
+    /// embed loader only packages bytes whose magic identifies a format
+    /// HWPX `BinData` natively carries).
+    ///
+    /// Returns `None` for empty, truncated, or unrecognized bytes — callers
+    /// must not guess from content. Magic table (mirrors the render-side
+    /// sniffer in `smithy-pdf`, W6 §12b):
+    ///
+    /// - PNG `89 50 4E 47 0D 0A 1A 0A` · JPEG `FF D8 FF` · GIF `GIF87a`/`GIF89a`
+    /// - BMP `BM` + 14-byte header minimum (2-byte magic alone is too weak)
+    /// - EMF record type `01 00 00 00` + `" EMF"` signature at offset 40
+    /// - WMF **placeable only** (`D7 CD C6 9A`) — standard WMF's magic is
+    ///   too weak and would misfire, so it stays unrecognized
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hwpforge_core::image::ImageFormat;
+    ///
+    /// let png = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0];
+    /// assert_eq!(ImageFormat::sniff(&png), Some(ImageFormat::Png));
+    /// assert_eq!(ImageFormat::sniff(b"GIF89a\x00"), Some(ImageFormat::Gif));
+    /// assert_eq!(ImageFormat::sniff(b"not an image"), None);
+    /// assert_eq!(ImageFormat::sniff(&[]), None);
+    /// ```
+    #[must_use]
+    pub fn sniff(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() >= 8 && bytes[..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] {
+            return Some(Self::Png);
+        }
+        if bytes.len() >= 3 && bytes[..3] == [0xFF, 0xD8, 0xFF] {
+            return Some(Self::Jpeg);
+        }
+        if bytes.len() >= 6 && (&bytes[..6] == b"GIF87a" || &bytes[..6] == b"GIF89a") {
+            return Some(Self::Gif);
+        }
+        if bytes.len() >= 14 && &bytes[..2] == b"BM" {
+            return Some(Self::Bmp);
+        }
+        if bytes.len() >= 44 && bytes[..4] == [0x01, 0, 0, 0] && &bytes[40..44] == b" EMF" {
+            return Some(Self::Emf);
+        }
+        if bytes.len() >= 4 && bytes[..4] == [0xD7, 0xCD, 0xC6, 0x9A] {
+            return Some(Self::Wmf);
+        }
+        None
+    }
+
+    /// Canonical file extension for a sniffed format (used to build
+    /// synthetic package keys like `image1.png`).
+    ///
+    /// Returns `None` for [`Self::Unknown`] — unknown formats never get a
+    /// synthetic key (they are not admitted into packages).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hwpforge_core::image::ImageFormat;
+    ///
+    /// assert_eq!(ImageFormat::Jpeg.canonical_extension(), Some("jpg"));
+    /// assert_eq!(ImageFormat::Unknown("svg".into()).canonical_extension(), None);
+    /// ```
+    #[must_use]
+    pub fn canonical_extension(&self) -> Option<&'static str> {
+        match self {
+            Self::Png => Some("png"),
+            Self::Jpeg => Some("jpg"),
+            Self::Gif => Some("gif"),
+            Self::Bmp => Some("bmp"),
+            Self::Wmf => Some("wmf"),
+            Self::Emf => Some("emf"),
+            Self::Unknown(_) => None,
+        }
+    }
 }
 
 impl std::fmt::Display for ImageFormat {
@@ -626,6 +705,63 @@ mod tests {
     #[test]
     fn from_extension_multi_dot() {
         assert_eq!(ImageFormat::from_extension("multi.dot.png"), ImageFormat::Png);
+    }
+
+    // -----------------------------------------------------------------------
+    // ImageFormat::sniff tests (W6 §12b — magic 판별, 추측 금지)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn sniff_known_magics() {
+        let png = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0];
+        assert_eq!(ImageFormat::sniff(&png), Some(ImageFormat::Png));
+        assert_eq!(ImageFormat::sniff(&[0xFF, 0xD8, 0xFF, 0xE0]), Some(ImageFormat::Jpeg));
+        assert_eq!(ImageFormat::sniff(b"GIF87a\x00"), Some(ImageFormat::Gif));
+        assert_eq!(ImageFormat::sniff(b"GIF89a\x00"), Some(ImageFormat::Gif));
+        let mut bmp = Vec::from(&b"BM"[..]);
+        bmp.extend_from_slice(&[0u8; 12]);
+        assert_eq!(ImageFormat::sniff(&bmp), Some(ImageFormat::Bmp));
+        let mut emf = vec![0x01, 0, 0, 0];
+        emf.extend_from_slice(&[0u8; 36]);
+        emf.extend_from_slice(b" EMF");
+        assert_eq!(ImageFormat::sniff(&emf), Some(ImageFormat::Emf));
+        assert_eq!(ImageFormat::sniff(&[0xD7, 0xCD, 0xC6, 0x9A, 0, 0]), Some(ImageFormat::Wmf));
+    }
+
+    #[test]
+    fn sniff_truncated_and_weak_magics_are_none() {
+        assert_eq!(ImageFormat::sniff(&[]), None);
+        // BMP 2바이트 magic 단독은 약함 — 14바이트 헤더 미달 = None.
+        assert_eq!(ImageFormat::sniff(b"BM"), None);
+        // PNG/JPEG/GIF 절단 prefix.
+        assert_eq!(ImageFormat::sniff(&[0x89, b'P']), None);
+        assert_eq!(ImageFormat::sniff(&[0xFF, 0xD8]), None);
+        assert_eq!(ImageFormat::sniff(b"GIF8"), None);
+        // EMF: 레코드 타입만으론 부족 (오프셋 40 시그니처 필요).
+        assert_eq!(ImageFormat::sniff(&[0x01, 0, 0, 0, 0, 0, 0, 0]), None);
+    }
+
+    #[test]
+    fn sniff_never_guesses_from_content() {
+        assert_eq!(ImageFormat::sniff(b"<svg xmlns=\"http\""), None);
+        assert_eq!(ImageFormat::sniff(&[0u8; 64]), None);
+        // RIFF 컨테이너(WAV 등) = None — WebP 포함 미지원 (HWPX BinData
+        // 캐리 대상 아님).
+        let mut wav = Vec::from(&b"RIFF"[..]);
+        wav.extend_from_slice(&[0x10, 0, 0, 0]);
+        wav.extend_from_slice(b"WAVEfmt ");
+        assert_eq!(ImageFormat::sniff(&wav), None);
+    }
+
+    #[test]
+    fn canonical_extension_covers_all_known() {
+        assert_eq!(ImageFormat::Png.canonical_extension(), Some("png"));
+        assert_eq!(ImageFormat::Jpeg.canonical_extension(), Some("jpg"));
+        assert_eq!(ImageFormat::Gif.canonical_extension(), Some("gif"));
+        assert_eq!(ImageFormat::Bmp.canonical_extension(), Some("bmp"));
+        assert_eq!(ImageFormat::Wmf.canonical_extension(), Some("wmf"));
+        assert_eq!(ImageFormat::Emf.canonical_extension(), Some("emf"));
+        assert_eq!(ImageFormat::Unknown("svg".into()).canonical_extension(), None);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/hwpforge-core/src/image.rs
+++ b/crates/hwpforge-core/src/image.rs
@@ -258,14 +258,23 @@ impl ImageFormat {
     /// HWPX `BinData` natively carries).
     ///
     /// Returns `None` for empty, truncated, or unrecognized bytes — callers
-    /// must not guess from content. Magic table (mirrors the render-side
-    /// sniffer in `smithy-pdf`, W6 §12b):
+    /// must not guess from content. Magic table (shares the render-side
+    /// sniffer's rules in `smithy-pdf`, with two deliberate divergences for
+    /// ingestion, W6 §12b·§12-r2):
     ///
     /// - PNG `89 50 4E 47 0D 0A 1A 0A` · JPEG `FF D8 FF` · GIF `GIF87a`/`GIF89a`
-    /// - BMP `BM` + 14-byte header minimum (2-byte magic alone is too weak)
+    /// - BMP `BM` **plus structural header checks** — `bfOffBits`
+    ///   (offset 10) within `14..=len` and a known DIB header size
+    ///   (offset 14 ∈ {12, 40, 52, 56, 64, 108, 124}). The 2-byte magic
+    ///   alone admits arbitrary bytes starting with `BM` into packages
+    ///   (ingestion is stricter than the render sniffer, which only gates
+    ///   an error path).
     /// - EMF record type `01 00 00 00` + `" EMF"` signature at offset 40
     /// - WMF **placeable only** (`D7 CD C6 9A`) — standard WMF's magic is
     ///   too weak and would misfire, so it stays unrecognized
+    /// - WebP is **intentionally absent** (render sniffer knows it): HWPX
+    ///   `BinData` carry of WebP is unverified against Hancom, so ingestion
+    ///   refuses it until a native fixture proves it (§12-r2).
     ///
     /// # Examples
     ///
@@ -289,8 +298,15 @@ impl ImageFormat {
         if bytes.len() >= 6 && (&bytes[..6] == b"GIF87a" || &bytes[..6] == b"GIF89a") {
             return Some(Self::Gif);
         }
-        if bytes.len() >= 14 && &bytes[..2] == b"BM" {
-            return Some(Self::Bmp);
+        if bytes.len() >= 18 && &bytes[..2] == b"BM" {
+            let off_bits = u32::from_le_bytes([bytes[10], bytes[11], bytes[12], bytes[13]]);
+            let dib_size = u32::from_le_bytes([bytes[14], bytes[15], bytes[16], bytes[17]]);
+            let off_ok = off_bits >= 14 && (off_bits as usize) <= bytes.len();
+            let dib_ok = matches!(dib_size, 12 | 40 | 52 | 56 | 64 | 108 | 124);
+            if off_ok && dib_ok {
+                return Some(Self::Bmp);
+            }
+            return None;
         }
         if bytes.len() >= 44 && bytes[..4] == [0x01, 0, 0, 0] && &bytes[40..44] == b" EMF" {
             return Some(Self::Emf);
@@ -718,8 +734,12 @@ mod tests {
         assert_eq!(ImageFormat::sniff(&[0xFF, 0xD8, 0xFF, 0xE0]), Some(ImageFormat::Jpeg));
         assert_eq!(ImageFormat::sniff(b"GIF87a\x00"), Some(ImageFormat::Gif));
         assert_eq!(ImageFormat::sniff(b"GIF89a\x00"), Some(ImageFormat::Gif));
+        // BMP: 유효 구조 헤더 (BITMAPCOREHEADER — bfOffBits=26, DIB=12).
         let mut bmp = Vec::from(&b"BM"[..]);
-        bmp.extend_from_slice(&[0u8; 12]);
+        bmp.extend_from_slice(&[0u8; 8]); // size(4)+reserved(4)
+        bmp.extend_from_slice(&26u32.to_le_bytes()); // bfOffBits
+        bmp.extend_from_slice(&12u32.to_le_bytes()); // DIB header size
+        bmp.extend_from_slice(&[0u8; 8]); // 나머지 코어 헤더
         assert_eq!(ImageFormat::sniff(&bmp), Some(ImageFormat::Bmp));
         let mut emf = vec![0x01, 0, 0, 0];
         emf.extend_from_slice(&[0u8; 36]);
@@ -739,6 +759,23 @@ mod tests {
         assert_eq!(ImageFormat::sniff(b"GIF8"), None);
         // EMF: 레코드 타입만으론 부족 (오프셋 40 시그니처 필요).
         assert_eq!(ImageFormat::sniff(&[0x01, 0, 0, 0, 0, 0, 0, 0]), None);
+    }
+
+    #[test]
+    fn sniff_bmp_requires_structural_header() {
+        // 2바이트 magic 만으론 임의 바이트 반입 가능 (독립 리뷰 M1) —
+        // bfOffBits·DIB 크기 구조 검사로 차단.
+        assert_eq!(ImageFormat::sniff(b"BMsecret-credential-material-here-0123456789"), None);
+        // 구 14바이트 규칙이 수용하던 제로 헤더도 거부 (DIB 0 미지).
+        let mut zeros = Vec::from(&b"BM"[..]);
+        zeros.extend_from_slice(&[0u8; 20]);
+        assert_eq!(ImageFormat::sniff(&zeros), None);
+        // bfOffBits 가 파일 길이를 초과하면 거부.
+        let mut oob = Vec::from(&b"BM"[..]);
+        oob.extend_from_slice(&[0u8; 8]);
+        oob.extend_from_slice(&999u32.to_le_bytes());
+        oob.extend_from_slice(&40u32.to_le_bytes());
+        assert_eq!(ImageFormat::sniff(&oob), None);
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/Cargo.toml
+++ b/crates/hwpforge-smithy-md/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 description = "Markdown codec (decoder + lossy/lossless encoder) for HwpForge"
 
 [dependencies]
+base64 = { workspace = true }
 hwpforge-blueprint = { path = "../hwpforge-blueprint", version = "0" }
 hwpforge-core = { path = "../hwpforge-core", version = "0" }
 hwpforge-foundation = { path = "../hwpforge-foundation", version = "0" }

--- a/crates/hwpforge-smithy-md/src/embed.rs
+++ b/crates/hwpforge-smithy-md/src/embed.rs
@@ -1,0 +1,458 @@
+//! Markdown → HWPX 이미지 임베드 로더 (W6 §12b v2).
+//!
+//! md 디코더는 `![..](src)` 를 `src` 경로 참조만 담긴 [`hwpforge_core::image::Image`]
+//! run 으로 만든다 — 참조된 바이트를 [`ImageStore`] 로 적재해야 인코더가
+//! `BinData/` 로 포장한다 (미적재 = dangling `binaryItemIDRef`).
+//!
+//! **핵심 원칙 — 디스크 조회 경로와 패키지 키의 분리** (적대 리뷰 C1·H2·H3):
+//!
+//! - 디스크 조회는 신뢰 불가 입력이다: `canonicalize` + base_dir 포함
+//!   검사로 경로 탈출(`../..`·절대경로)을 차단하고, **스니핑이 알려진
+//!   이미지 포맷일 때만** 적재한다 (임의 파일 반입 차단).
+//! - 문서에 박히는 키는 항상 **합성 정규명** `imageN.<ext>` 다 — 외부
+//!   통제 문자열이 XML id/manifest 채널(`binaryItemIDRef`·OPF `id`)에
+//!   들어가지 않는다. 동일 실파일 중복 참조는 동일 키로 dedup 된다.
+//! - `data:` URI 는 네트워크 없이 로컬 base64 디코드로 지원한다 —
+//!   base_dir 이 없는 인라인 입력(MCP 텍스트·CLI stdin)에서도 임베드가
+//!   가능한 유일한 경로다. `http(s)` 원격은 경고 후 제외한다 (네트워크
+//!   금지).
+//! - 실패(부재·탈출·원격·미지 바이트 등)는 **이미지 run 을 드롭 + typed
+//!   경고** — dangling 참조를 남기지 않는다 (no-fake-support).
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+
+use base64::Engine as _;
+use hwpforge_core::document::Document;
+use hwpforge_core::image::{ImageFormat, ImageStore};
+use hwpforge_core::run::RunContent;
+
+use crate::encoder::MdWarning;
+
+/// 이미지 파일 1개의 적재 상한 (md 입력 자체의 50 MB 상한과 동일 계열).
+const MAX_IMAGE_BYTES: u64 = 50 * 1024 * 1024;
+
+/// [`load_referenced_images`] 가 이미지 참조를 제외한 사유 (typed —
+/// warning-first, 무음 드롭 금지).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ImageEmbedSkipReason {
+    /// 파일이 존재하지 않거나 경로를 정규화할 수 없음.
+    MissingFile,
+    /// 파일 읽기 실패 (권한 등 I/O 오류).
+    Unreadable,
+    /// 정규화 결과가 base_dir 밖 — 경로 탈출 차단 (C1).
+    PathEscapes,
+    /// `http(s)`/프로토콜-상대 원격 URL — 네트워크 접근 금지.
+    RemoteUrl,
+    /// 상대 경로인데 base_dir 이 없음 (인라인 텍스트·stdin 입력).
+    NoBaseDir,
+    /// 읽은 바이트의 magic 이 알려진 이미지 포맷이 아님 — 임의 바이트
+    /// 반입 차단 (C1).
+    UnsupportedBytes,
+    /// `data:` URI 파싱/base64 디코드 실패 (base64 아닌 payload 포함).
+    InvalidDataUri,
+    /// 파일이 적재 상한(50 MB)을 초과.
+    TooLarge,
+}
+
+impl fmt::Display for ImageEmbedSkipReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::MissingFile => "file not found",
+            Self::Unreadable => "file unreadable",
+            Self::PathEscapes => "path escapes the document directory",
+            Self::RemoteUrl => "remote URL (network access is not allowed)",
+            Self::NoBaseDir => "relative path with no base directory (inline input)",
+            Self::UnsupportedBytes => "bytes are not a recognized image format",
+            Self::InvalidDataUri => "data: URI is not valid base64 image data",
+            Self::TooLarge => "file exceeds the 50 MB embed ceiling",
+        };
+        f.write_str(s)
+    }
+}
+
+/// [`load_referenced_images`] 결과 — 적재된 스토어 + typed 경고 목록.
+#[derive(Debug, Default)]
+pub struct EmbeddedImages {
+    /// 인코더에 넘길 이미지 스토어 (키 = 합성 정규명 = `Image.path`).
+    pub store: ImageStore,
+    /// 제외된 참조들의 typed 경고 (원본 src 절단 포함).
+    pub warnings: Vec<MdWarning>,
+}
+
+/// 문서의 이미지 참조를 해석해 [`ImageStore`] 로 적재하고, 성공한 run 의
+/// `Image.path`/`format` 을 합성 키·스니핑 실포맷으로 재작성한다.
+///
+/// `base_dir` = md 파일의 부모 디렉터리 (파일 입력일 때). 인라인 텍스트/
+/// stdin 입력은 `None` — 이 경우 상대 경로 참조는
+/// [`ImageEmbedSkipReason::NoBaseDir`] 로 제외되고 `data:` URI 만
+/// 임베드된다.
+///
+/// 실패한 참조는 run 이 **드롭**되고 경고로 선언된다 — 결과 문서에는
+/// dangling `binaryItemIDRef` 가 남지 않는다.
+pub fn load_referenced_images(document: &mut Document, base_dir: Option<&Path>) -> EmbeddedImages {
+    let mut out = EmbeddedImages::default();
+    // dedup: 해석된 정체(canonical 경로 문자열 또는 data URI 전문) → 합성 키.
+    let mut seen: HashMap<String, String> = HashMap::new();
+    let mut counter: usize = 0;
+    // base_dir 은 한 번만 정규화 (부재/실패 = None → NoBaseDir 계열).
+    let canonical_base = base_dir.and_then(|d| d.canonicalize().ok());
+
+    document.for_each_paragraph_mut(|para| {
+        para.runs.retain_mut(|run| {
+            let RunContent::Image(img) = &mut run.content else { return true };
+            let src = img.path.clone();
+            match resolve_source(&src, canonical_base.as_deref()) {
+                Ok((identity, bytes)) => {
+                    if let Some(key) = seen.get(&identity) {
+                        img.path.clone_from(key);
+                        return true;
+                    }
+                    let Some(format) = ImageFormat::sniff(&bytes) else {
+                        out.warnings
+                            .push(skip_warning(&src, ImageEmbedSkipReason::UnsupportedBytes));
+                        return false;
+                    };
+                    let ext = format.canonical_extension().expect("sniff never returns Unknown");
+                    counter += 1;
+                    let key = format!("image{counter}.{ext}");
+                    out.store.insert(key.clone(), bytes);
+                    seen.insert(identity, key.clone());
+                    img.path = key;
+                    img.format = format;
+                    true
+                }
+                Err(reason) => {
+                    out.warnings.push(skip_warning(&src, reason));
+                    false
+                }
+            }
+        });
+    });
+    out
+}
+
+/// src 를 분류·해석해 (dedup 정체, 바이트) 를 돌려준다.
+fn resolve_source(
+    src: &str,
+    canonical_base: Option<&Path>,
+) -> Result<(String, Vec<u8>), ImageEmbedSkipReason> {
+    if let Some(rest) = src.strip_prefix("data:") {
+        let bytes = decode_data_uri(rest).ok_or(ImageEmbedSkipReason::InvalidDataUri)?;
+        if bytes.len() as u64 > MAX_IMAGE_BYTES {
+            return Err(ImageEmbedSkipReason::TooLarge);
+        }
+        return Ok((src.to_string(), bytes));
+    }
+    if src.contains("://") || src.starts_with("//") {
+        return Err(ImageEmbedSkipReason::RemoteUrl);
+    }
+    let path = Path::new(src);
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        let Some(base) = canonical_base else {
+            return Err(ImageEmbedSkipReason::NoBaseDir);
+        };
+        base.join(path)
+    };
+    let canonical = candidate.canonicalize().map_err(|_| ImageEmbedSkipReason::MissingFile)?;
+    // 포함 검사 (C1): 절대경로 저작 포함 — 정규화 결과가 base 밖이면 차단.
+    // base 자체가 없으면(절대 src + 인라인 입력) 포함을 증명할 수 없으므로
+    // 동일하게 차단한다.
+    let Some(base) = canonical_base else {
+        return Err(ImageEmbedSkipReason::NoBaseDir);
+    };
+    if !canonical.starts_with(base) {
+        return Err(ImageEmbedSkipReason::PathEscapes);
+    }
+    let meta = std::fs::metadata(&canonical).map_err(|_| ImageEmbedSkipReason::Unreadable)?;
+    if meta.len() > MAX_IMAGE_BYTES {
+        return Err(ImageEmbedSkipReason::TooLarge);
+    }
+    let bytes = std::fs::read(&canonical).map_err(|_| ImageEmbedSkipReason::Unreadable)?;
+    Ok((canonical.to_string_lossy().into_owned(), bytes))
+}
+
+/// `data:` 접두 이후(`<mime>[;base64],<payload>`)를 디코드한다 —
+/// base64 payload 만 지원 (이미지의 비-base64 data URI 는 비현실적).
+fn decode_data_uri(rest: &str) -> Option<Vec<u8>> {
+    let comma = rest.find(',')?;
+    let (meta, payload) = rest.split_at(comma);
+    let payload = &payload[1..];
+    if !meta.ends_with(";base64") {
+        return None;
+    }
+    base64::engine::general_purpose::STANDARD.decode(payload.trim()).ok()
+}
+
+/// src 를 표시용으로 절단해 경고를 만든다 (data URI 전문 방지).
+fn skip_warning(src: &str, reason: ImageEmbedSkipReason) -> MdWarning {
+    const MAX_SRC: usize = 64;
+    let shown = if src.chars().count() > MAX_SRC {
+        let head: String = src.chars().take(MAX_SRC).collect();
+        format!("{head}…")
+    } else {
+        src.to_string()
+    };
+    MdWarning::ImageEmbedSkipped { src: shown, reason }
+}
+
+#[cfg(test)]
+mod tests {
+    use hwpforge_core::image::Image;
+    use hwpforge_core::paragraph::Paragraph;
+    use hwpforge_core::run::Run;
+    use hwpforge_core::section::Section;
+    use hwpforge_core::PageSettings;
+    use hwpforge_foundation::{CharShapeIndex, HwpUnit, ParaShapeIndex};
+
+    use super::*;
+
+    const PNG: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3];
+
+    /// 테스트 전용 임시 디렉터리 (신규 dev-dep 없이 — 유일명 + 자동 삭제).
+    struct TempDir(std::path::PathBuf);
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let p = std::env::temp_dir().join(format!(
+                "hwpforge-embed-{tag}-{}-{}",
+                std::process::id(),
+                std::thread::current().name().unwrap_or("t").replace("::", "-"),
+            ));
+            let _ = std::fs::remove_dir_all(&p);
+            std::fs::create_dir_all(&p).expect("mkdir");
+            Self(p)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+        fn write(&self, rel: &str, bytes: &[u8]) {
+            let p = self.0.join(rel);
+            if let Some(parent) = p.parent() {
+                std::fs::create_dir_all(parent).expect("mkdir parents");
+            }
+            std::fs::write(p, bytes).expect("write");
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn image_run(src: &str) -> Run {
+        let img = Image::new(
+            src,
+            HwpUnit::from_mm(10.0).expect("w"),
+            HwpUnit::from_mm(10.0).expect("h"),
+            ImageFormat::from_extension(src),
+        );
+        Run::image(img, CharShapeIndex::new(0))
+    }
+
+    fn doc_with_srcs(srcs: &[&str]) -> Document {
+        let runs = srcs.iter().map(|s| image_run(s)).collect();
+        let para = Paragraph::with_runs(runs, ParaShapeIndex::new(0));
+        let mut doc = Document::new();
+        doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+        doc
+    }
+
+    fn image_paths(doc: &Document) -> Vec<String> {
+        let mut out = Vec::new();
+        let sections = doc.sections();
+        for s in sections {
+            for p in &s.paragraphs {
+                for r in &p.runs {
+                    if let RunContent::Image(img) = &r.content {
+                        out.push(img.path.clone());
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn relative_path_embeds_with_synthetic_key() {
+        let dir = TempDir::new("rel");
+        dir.write("photo-원본.png", PNG);
+        let mut doc = doc_with_srcs(&["photo-원본.png"]);
+        let out = load_referenced_images(&mut doc, Some(dir.path()));
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        assert_eq!(image_paths(&doc), vec!["image1.png"]);
+        assert_eq!(out.store.get("image1.png"), Some(PNG));
+    }
+
+    #[test]
+    fn subdirectory_src_never_leaks_into_key() {
+        // H2: 서브디렉터리 src 가 그대로 키가 되면 binaryItemIDRef 가 깨짐.
+        let dir = TempDir::new("subdir");
+        dir.write("images/a.png", PNG);
+        let mut doc = doc_with_srcs(&["images/a.png"]);
+        let out = load_referenced_images(&mut doc, Some(dir.path()));
+        assert_eq!(image_paths(&doc), vec!["image1.png"]);
+        assert!(out.store.get("image1.png").is_some());
+    }
+
+    #[test]
+    fn duplicate_spellings_dedup_to_one_entry() {
+        let dir = TempDir::new("dedup");
+        dir.write("x.png", PNG);
+        let mut doc = doc_with_srcs(&["x.png", "./x.png"]);
+        let out = load_referenced_images(&mut doc, Some(dir.path()));
+        assert_eq!(image_paths(&doc), vec!["image1.png", "image1.png"]);
+        assert_eq!(out.store.iter().count(), 1);
+    }
+
+    #[test]
+    fn path_escape_is_dropped_with_typed_warning() {
+        // C1: `..` 탈출 — 실제 존재하는 밖 파일이어도 차단.
+        let outer = TempDir::new("outer");
+        outer.write("secret.png", PNG);
+        let inner = outer.path().join("inner");
+        std::fs::create_dir_all(&inner).expect("mkdir");
+        let mut doc = doc_with_srcs(&["../secret.png"]);
+        let out = load_referenced_images(&mut doc, Some(&inner));
+        assert!(image_paths(&doc).is_empty(), "run 드롭");
+        assert!(matches!(
+            &out.warnings[..],
+            [MdWarning::ImageEmbedSkipped { reason: ImageEmbedSkipReason::PathEscapes, .. }]
+        ));
+        assert_eq!(out.store.iter().count(), 0);
+    }
+
+    #[test]
+    fn absolute_path_outside_base_is_blocked() {
+        let outside = TempDir::new("abs-out");
+        outside.write("f.png", PNG);
+        let base = TempDir::new("abs-base");
+        let abs = outside.path().join("f.png");
+        let mut doc = doc_with_srcs(&[abs.to_str().expect("utf8")]);
+        let out = load_referenced_images(&mut doc, Some(base.path()));
+        assert!(image_paths(&doc).is_empty());
+        assert!(matches!(
+            &out.warnings[..],
+            [MdWarning::ImageEmbedSkipped { reason: ImageEmbedSkipReason::PathEscapes, .. }]
+        ));
+    }
+
+    #[test]
+    fn non_image_bytes_are_rejected() {
+        // C1: 임의 파일 반입 차단 — magic 미달 바이트는 적재 금지.
+        let dir = TempDir::new("bytes");
+        dir.write("fake.png", b"ssh-rsa AAAA fake key material");
+        let mut doc = doc_with_srcs(&["fake.png"]);
+        let out = load_referenced_images(&mut doc, Some(dir.path()));
+        assert!(image_paths(&doc).is_empty());
+        assert!(matches!(
+            &out.warnings[..],
+            [MdWarning::ImageEmbedSkipped { reason: ImageEmbedSkipReason::UnsupportedBytes, .. }]
+        ));
+        assert_eq!(out.store.iter().count(), 0);
+    }
+
+    #[test]
+    fn missing_file_and_remote_and_nobase() {
+        let dir = TempDir::new("misc");
+        let mut doc =
+            doc_with_srcs(&["nope.png", "https://example.com/a.png", "//cdn.example.com/b.png"]);
+        let out = load_referenced_images(&mut doc, Some(dir.path()));
+        assert!(image_paths(&doc).is_empty());
+        let reasons: Vec<_> = out
+            .warnings
+            .iter()
+            .map(|w| match w {
+                MdWarning::ImageEmbedSkipped { reason, .. } => reason.clone(),
+                other => panic!("unexpected: {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            reasons,
+            vec![
+                ImageEmbedSkipReason::MissingFile,
+                ImageEmbedSkipReason::RemoteUrl,
+                ImageEmbedSkipReason::RemoteUrl,
+            ]
+        );
+
+        // 인라인 입력 (base_dir 없음): 상대 경로 = NoBaseDir.
+        let mut doc2 = doc_with_srcs(&["rel.png"]);
+        let out2 = load_referenced_images(&mut doc2, None);
+        assert!(matches!(
+            &out2.warnings[..],
+            [MdWarning::ImageEmbedSkipped { reason: ImageEmbedSkipReason::NoBaseDir, .. }]
+        ));
+    }
+
+    #[test]
+    fn data_uri_embeds_without_base_dir() {
+        // H1: 인라인 입력의 유일한 임베드 경로 — 네트워크 없이 로컬 디코드.
+        let b64 = base64::engine::general_purpose::STANDARD.encode(PNG);
+        let src = format!("data:image/png;base64,{b64}");
+        let mut doc = doc_with_srcs(&[&src]);
+        let out = load_referenced_images(&mut doc, None);
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        assert_eq!(image_paths(&doc), vec!["image1.png"]);
+        assert_eq!(out.store.get("image1.png"), Some(PNG));
+    }
+
+    #[test]
+    fn invalid_data_uri_variants_are_dropped() {
+        for src in
+            ["data:image/png;base64,%%%not-base64%%%", "data:image/png,plainpayload", "data:,x"]
+        {
+            let mut doc = doc_with_srcs(&[src]);
+            let out = load_referenced_images(&mut doc, None);
+            assert!(
+                matches!(
+                    &out.warnings[..],
+                    [MdWarning::ImageEmbedSkipped {
+                        reason: ImageEmbedSkipReason::InvalidDataUri,
+                        ..
+                    }]
+                ),
+                "src={src} → {:?}",
+                out.warnings
+            );
+        }
+    }
+
+    #[test]
+    fn long_data_uri_src_is_truncated_in_warning() {
+        let src = format!("data:image/png;base64,{}", "A".repeat(500));
+        let mut doc = doc_with_srcs(&[&src]);
+        let out = load_referenced_images(&mut doc, None);
+        let MdWarning::ImageEmbedSkipped { src: shown, .. } = &out.warnings[0] else {
+            panic!("expected skip warning");
+        };
+        assert!(shown.chars().count() <= 65, "절단됨: {}", shown.len());
+    }
+
+    #[test]
+    fn text_runs_and_format_hint_untouched() {
+        let dir = TempDir::new("mixed");
+        dir.write("a.jpg", &[0xFF, 0xD8, 0xFF, 0xE0, 1]);
+        let para = Paragraph::with_runs(
+            vec![
+                Run::text("앞 ", CharShapeIndex::new(0)),
+                image_run("a.jpg"),
+                Run::text(" 뒤", CharShapeIndex::new(0)),
+            ],
+            ParaShapeIndex::new(0),
+        );
+        let mut doc = Document::new();
+        doc.add_section(Section::with_paragraphs(vec![para], PageSettings::a4()));
+        let out = load_referenced_images(&mut doc, Some(dir.path()));
+        assert!(out.warnings.is_empty());
+        let sections = doc.sections();
+        let runs = &sections[0].paragraphs[0].runs;
+        assert_eq!(runs.len(), 3, "텍스트 run 보존");
+        let RunContent::Image(img) = &runs[1].content else { panic!("image run") };
+        assert_eq!(img.path, "image1.jpg");
+        assert_eq!(img.format, ImageFormat::Jpeg, "스니핑 실포맷으로 갱신");
+    }
+}

--- a/crates/hwpforge-smithy-md/src/embed.rs
+++ b/crates/hwpforge-smithy-md/src/embed.rs
@@ -46,7 +46,8 @@ pub enum ImageEmbedSkipReason {
     PathEscapes,
     /// `http(s)`/프로토콜-상대 원격 URL — 네트워크 접근 금지.
     RemoteUrl,
-    /// 상대 경로인데 base_dir 이 없음 (인라인 텍스트·stdin 입력).
+    /// 상대 경로인데 해석 가능한 base 디렉터리가 없음 (인라인 텍스트·
+    /// stdin 입력, 또는 base 정규화 실패).
     NoBaseDir,
     /// 읽은 바이트의 magic 이 알려진 이미지 포맷이 아님 — 임의 바이트
     /// 반입 차단 (C1).
@@ -64,7 +65,7 @@ impl fmt::Display for ImageEmbedSkipReason {
             Self::Unreadable => "file unreadable",
             Self::PathEscapes => "path escapes the document directory",
             Self::RemoteUrl => "remote URL (network access is not allowed)",
-            Self::NoBaseDir => "relative path with no base directory (inline input)",
+            Self::NoBaseDir => "relative path with no resolvable base directory",
             Self::UnsupportedBytes => "bytes are not a recognized image format",
             Self::InvalidDataUri => "data: URI is not valid base64 image data",
             Self::TooLarge => "file exceeds the 50 MB embed ceiling",
@@ -91,45 +92,60 @@ pub struct EmbeddedImages {
 /// 임베드된다.
 ///
 /// 실패한 참조는 run 이 **드롭**되고 경고로 선언된다 — 결과 문서에는
-/// dangling `binaryItemIDRef` 가 남지 않는다.
+/// dangling `binaryItemIDRef` 가 남지 않는다. 드롭으로 문단이 비면 빈
+/// 텍스트 run 으로 문단을 보존한다 — `![..](url)` 단독 문단은 md 표준
+/// 형태라, 빈 문단 거부(validate)로 문서 전체가 죽으면 회귀다 (독립
+/// 리뷰 B1).
 pub fn load_referenced_images(document: &mut Document, base_dir: Option<&Path>) -> EmbeddedImages {
     let mut out = EmbeddedImages::default();
-    // dedup: 해석된 정체(canonical 경로 문자열 또는 data URI 전문) → 합성 키.
-    let mut seen: HashMap<String, String> = HashMap::new();
+    // dedup: 해석된 정체(canonical 경로 문자열 또는 data URI 전문) →
+    // (합성 키, 스니핑 포맷) — dedup 경로도 format 을 동일 갱신 (리뷰 L1).
+    let mut seen: HashMap<String, (String, ImageFormat)> = HashMap::new();
     let mut counter: usize = 0;
     // base_dir 은 한 번만 정규화 (부재/실패 = None → NoBaseDir 계열).
     let canonical_base = base_dir.and_then(|d| d.canonicalize().ok());
 
     document.for_each_paragraph_mut(|para| {
+        let mut dropped_char_shape = None;
         para.runs.retain_mut(|run| {
             let RunContent::Image(img) = &mut run.content else { return true };
             let src = img.path.clone();
             match resolve_source(&src, canonical_base.as_deref()) {
                 Ok((identity, bytes)) => {
-                    if let Some(key) = seen.get(&identity) {
+                    if let Some((key, format)) = seen.get(&identity) {
                         img.path.clone_from(key);
+                        img.format = format.clone();
                         return true;
                     }
                     let Some(format) = ImageFormat::sniff(&bytes) else {
                         out.warnings
                             .push(skip_warning(&src, ImageEmbedSkipReason::UnsupportedBytes));
+                        dropped_char_shape = Some(run.char_shape_id);
                         return false;
                     };
                     let ext = format.canonical_extension().expect("sniff never returns Unknown");
                     counter += 1;
                     let key = format!("image{counter}.{ext}");
                     out.store.insert(key.clone(), bytes);
-                    seen.insert(identity, key.clone());
+                    seen.insert(identity, (key.clone(), format.clone()));
                     img.path = key;
                     img.format = format;
                     true
                 }
                 Err(reason) => {
                     out.warnings.push(skip_warning(&src, reason));
+                    dropped_char_shape = Some(run.char_shape_id);
                     false
                 }
             }
         });
+        // B1: 이미지 단독 문단이 드롭으로 비면 빈 텍스트 run 으로 문단
+        // 유효성을 보존한다 (validate 는 run 0 문단을 거부).
+        if para.runs.is_empty() {
+            if let Some(cs) = dropped_char_shape {
+                para.runs.push(hwpforge_core::run::Run::text("", cs));
+            }
+        }
     });
     out
 }
@@ -169,6 +185,10 @@ fn resolve_source(
         return Err(ImageEmbedSkipReason::PathEscapes);
     }
     let meta = std::fs::metadata(&canonical).map_err(|_| ImageEmbedSkipReason::Unreadable)?;
+    // 정규 파일만 (리뷰 L3 — FIFO 는 read 무한 블록, len=0 이라 상한도 통과).
+    if !meta.is_file() {
+        return Err(ImageEmbedSkipReason::Unreadable);
+    }
     if meta.len() > MAX_IMAGE_BYTES {
         return Err(ImageEmbedSkipReason::TooLarge);
     }
@@ -386,6 +406,32 @@ mod tests {
             &out2.warnings[..],
             [MdWarning::ImageEmbedSkipped { reason: ImageEmbedSkipReason::NoBaseDir, .. }]
         ));
+    }
+
+    #[test]
+    fn image_only_paragraph_survives_failed_embed() {
+        // B1 (독립 리뷰 Critical): `![..](url)` 단독 문단은 md 표준 형태 —
+        // 드롭 후 빈 문단이 남아 validate 가 문서 전체를 거부하면 회귀.
+        let mut doc = doc_with_srcs(&["https://example.com/logo.png"]);
+        let out = load_referenced_images(&mut doc, None);
+        assert_eq!(out.warnings.len(), 1);
+        let sections = doc.sections();
+        assert_eq!(sections[0].paragraphs[0].runs.len(), 1, "빈 텍스트 run 으로 문단 보존");
+        assert!(doc.validate().is_ok(), "이미지 단독 문단 드롭 후에도 문서는 유효");
+    }
+
+    #[test]
+    fn bm_prefixed_garbage_is_rejected() {
+        // 독립 리뷰 M1 실증 벡터 — 2바이트 BM magic 을 위장한 임의 파일.
+        let dir = TempDir::new("bm-garbage");
+        dir.write("blob.png", b"BMsecret-credential-material-here-0123456789");
+        let mut doc = doc_with_srcs(&["blob.png"]);
+        let out = load_referenced_images(&mut doc, Some(dir.path()));
+        assert!(matches!(
+            &out.warnings[..],
+            [MdWarning::ImageEmbedSkipped { reason: ImageEmbedSkipReason::UnsupportedBytes, .. }]
+        ));
+        assert_eq!(out.store.iter().count(), 0);
     }
 
     #[test]

--- a/crates/hwpforge-smithy-md/src/encoder/mod.rs
+++ b/crates/hwpforge-smithy-md/src/encoder/mod.rs
@@ -15,8 +15,10 @@ pub use styled::MdOutput;
 /// Markdown encoder entrypoint.
 pub struct MdEncoder;
 
-/// Warning emitted by the lossy markdown encoders (warning-first: what the
-/// output can no longer represent is reported, not silently dropped).
+/// Warning emitted by the markdown bridge in **either direction** — lossy
+/// markdown encoders (HWPX→MD) and the MD→HWPX image embed loader
+/// ([`crate::embed`]). Warning-first: what the output can no longer
+/// represent is reported, not silently dropped.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum MdWarning {
@@ -28,6 +30,16 @@ pub enum MdWarning {
         /// Number of cells in the table with `col_span > 1` or `row_span > 1`.
         merged_cells: usize,
     },
+    /// MD→HWPX (W6 §12b): an image reference could not be embedded — the
+    /// image run is dropped so no dangling `binaryItemIDRef` reaches the
+    /// package, and the exclusion is declared here.
+    ImageEmbedSkipped {
+        /// The markdown source string (truncated for display; `data:` URIs
+        /// are cut at 64 chars).
+        src: String,
+        /// Why the reference was excluded.
+        reason: crate::embed::ImageEmbedSkipReason,
+    },
 }
 
 impl core::fmt::Display for MdWarning {
@@ -38,6 +50,9 @@ impl core::fmt::Display for MdWarning {
                 "table with {merged_cells} merged cell(s) flattened to a plain GFM grid \
                  (use styled mode to keep spans as HTML)"
             ),
+            Self::ImageEmbedSkipped { src, reason } => {
+                write!(f, "image \"{src}\" not embedded ({reason}) — image dropped")
+            }
         }
     }
 }

--- a/crates/hwpforge-smithy-md/src/lib.rs
+++ b/crates/hwpforge-smithy-md/src/lib.rs
@@ -27,6 +27,7 @@
 #![deny(clippy::all)]
 
 mod decoder;
+pub mod embed;
 mod encoder;
 mod eqn;
 pub mod error;
@@ -35,6 +36,7 @@ mod internal_styles;
 mod mapper;
 
 pub use decoder::{MdDecoder, MdDocument};
+pub use embed::{load_referenced_images, EmbeddedImages, ImageEmbedSkipReason};
 pub use encoder::{MdEncoder, MdOutput, MdWarning};
 pub use error::{MdError, MdErrorCode, MdResult};
 pub use frontmatter::Frontmatter;

--- a/crates/hwpforge-smithy-md/tests/md_image_embed_roundtrip.rs
+++ b/crates/hwpforge-smithy-md/tests/md_image_embed_roundtrip.rs
@@ -1,0 +1,118 @@
+//! md→hwpx 이미지 임베드 왕복 게이트 (W6 §12b).
+//!
+//! CLI/MCP convert 가 쓰는 것과 동일한 파이프라인(디코드 → embed 로더 →
+//! 레지스트리 브리지 → 인코드)으로 HWPX 를 만들고, **우리 디코더로 다시
+//! 열어** BinData 가 실제로 포장됐는지(바이트 일치·합성 키·manifest 정합)
+//! 를 실증한다 — "BinData 미포장" 실갭(2026-08-13 실측)의 회귀 게이트.
+
+use hwpforge_core::run::RunContent;
+use hwpforge_smithy_hwpx::{HwpxDecoder, HwpxEncoder, HwpxRegistryBridge};
+use hwpforge_smithy_md::{load_referenced_images, MdDecoder};
+
+const PNG: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 9, 8, 7, 6];
+
+struct TempDir(std::path::PathBuf);
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        let p =
+            std::env::temp_dir().join(format!("hwpforge-embed-e2e-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).expect("mkdir");
+        Self(p)
+    }
+}
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn md_image_embeds_into_bindata_and_roundtrips() {
+    let dir = TempDir::new("roundtrip");
+    std::fs::write(dir.0.join("photo.png"), PNG).expect("write png");
+    let markdown = "# 제목\n\n본문 앞 ![사진](photo.png) 뒤.\n";
+
+    // CLI/MCP convert 와 동일 파이프라인.
+    let mut md_doc = MdDecoder::decode_with_default(markdown).expect("decode");
+    let embedded = load_referenced_images(&mut md_doc.document, Some(&dir.0));
+    assert!(embedded.warnings.is_empty(), "{:?}", embedded.warnings);
+
+    let bridge = HwpxRegistryBridge::from_registry(&md_doc.style_registry).expect("bridge");
+    let rebound = bridge.rebind_draft_document(md_doc.document).expect("rebind");
+    let validated = rebound.validate().expect("validate");
+    let bytes =
+        HwpxEncoder::encode(&validated, bridge.style_store(), &embedded.store).expect("encode");
+
+    // 왕복: 우리 디코더로 BinData 실증.
+    let decoded = HwpxDecoder::decode(&bytes).expect("hwpx decode");
+    assert_eq!(
+        decoded.image_store.get("image1.png"),
+        Some(PNG),
+        "BinData 바이트가 원본과 일치해야 한다"
+    );
+    let mut image_paths = Vec::new();
+    for section in decoded.document.sections() {
+        for para in &section.paragraphs {
+            for run in &para.runs {
+                if let RunContent::Image(img) = &run.content {
+                    image_paths.push(img.path.clone());
+                }
+            }
+        }
+    }
+    // 디코더는 참조를 binaryItemIDRef 유래 canonical 형태(`BinData/<stem>`)로
+    // 복원한다 — 렌더 쪽 resolver 가 store 키(`image1.png`)와 결정적으로
+    // 잇는 기존 계약 (W2a). 여기선 stem 이 합성 키에서 왔음을 잠근다.
+    assert_eq!(image_paths, vec!["BinData/image1"], "합성 키 stem 이 참조로 왕복");
+
+    // 패키지 실물: BinData/ 엔트리 + manifest 등재 (H2 — id 정합).
+    let reader = std::io::Cursor::new(&bytes);
+    let mut zip = zip::ZipArchive::new(reader).expect("zip");
+    let names: Vec<String> =
+        (0..zip.len()).map(|i| zip.by_index(i).unwrap().name().to_string()).collect();
+    assert!(names.iter().any(|n| n == "BinData/image1.png"), "BinData 엔트리: {names:?}");
+    let mut content_hpf = String::new();
+    {
+        use std::io::Read as _;
+        zip.by_name("Contents/content.hpf")
+            .expect("content.hpf")
+            .read_to_string(&mut content_hpf)
+            .expect("read hpf");
+    }
+    assert!(
+        content_hpf.contains(r#"id="image1" href="BinData/image1.png""#),
+        "manifest 등재: {content_hpf}"
+    );
+}
+
+#[test]
+fn failed_reference_produces_valid_document_without_dangling_ref() {
+    // 부재 파일 참조 = run 드롭 + 경고 — 산출 HWPX 에 dangling
+    // binaryItemIDRef 가 없어야 한다.
+    let dir = TempDir::new("dangling");
+    let markdown = "본문 ![없음](missing.png) 계속.\n";
+    let mut md_doc = MdDecoder::decode_with_default(markdown).expect("decode");
+    let embedded = load_referenced_images(&mut md_doc.document, Some(&dir.0));
+    assert_eq!(embedded.warnings.len(), 1);
+
+    let bridge = HwpxRegistryBridge::from_registry(&md_doc.style_registry).expect("bridge");
+    let rebound = bridge.rebind_draft_document(md_doc.document).expect("rebind");
+    let validated = rebound.validate().expect("validate");
+    let bytes =
+        HwpxEncoder::encode(&validated, bridge.style_store(), &embedded.store).expect("encode");
+    let decoded = HwpxDecoder::decode(&bytes).expect("hwpx decode");
+    assert_eq!(decoded.image_store.iter().count(), 0);
+    let section_xml_has_pic = {
+        let reader = std::io::Cursor::new(&bytes);
+        let mut zip = zip::ZipArchive::new(reader).expect("zip");
+        use std::io::Read as _;
+        let mut s = String::new();
+        zip.by_name("Contents/section0.xml")
+            .expect("section")
+            .read_to_string(&mut s)
+            .expect("read");
+        s.contains("<hp:pic")
+    };
+    assert!(!section_xml_has_pic, "드롭된 이미지는 pic 요소를 남기지 않는다");
+}

--- a/crates/hwpforge-smithy-pdf/src/backend/mod.rs
+++ b/crates/hwpforge-smithy-pdf/src/backend/mod.rs
@@ -528,6 +528,50 @@ mod image_tests {
             .any(|w| matches!(w, PdfWarning::UnsupportedImageFormat { format: "bmp", .. })));
     }
 
+    /// W6 §12a 정책 확정 잠금: WMF/EMF 도 BMP 와 동열 — strict = typed
+    /// 에러, degraded = 경고+스킵 (변환 지원은 후속 슬라이스).
+    #[test]
+    fn wmf_and_emf_follow_failure_mode_like_bmp() {
+        let wmf: &[u8] = &[0xD7, 0xCD, 0xC6, 0x9A, 0, 0, 0, 0];
+        let mut emf = vec![0x01u8, 0, 0, 0];
+        emf.extend_from_slice(&[0u8; 36]);
+        emf.extend_from_slice(b" EMF");
+        for (name, bytes, tag) in [("dia.wmf", wmf, "wmf"), ("chart.emf", emf.as_slice(), "emf")] {
+            let item = image_item(name, bytes);
+            let mut warnings = Vec::new();
+            let err = write_pdf(
+                &one_page(vec![PaintItem::Image(item.clone())]),
+                &[],
+                RenderFailureMode::Fatal,
+                &mut warnings,
+            )
+            .expect_err("fatal");
+            assert!(
+                matches!(&err, PdfError::UnsupportedImageFormat { format, .. } if *format == tag),
+                "{name}: {err:?}"
+            );
+
+            let mut warnings = Vec::new();
+            let bytes_out = write_pdf(
+                &one_page(vec![PaintItem::Image(item)]),
+                &[],
+                RenderFailureMode::Degraded,
+                &mut warnings,
+            )
+            .expect("degraded ok");
+            assert!(
+                warnings.iter().any(
+                    |w| matches!(w, PdfWarning::UnsupportedImageFormat { format, .. } if *format == tag)
+                ),
+                "{name}: {warnings:?}"
+            );
+            assert!(
+                !contains(&inflated_pdf_text(&bytes_out), b"/Subtype/Image"),
+                "스킵 = 무이미지"
+            );
+        }
+    }
+
     #[test]
     fn zero_and_negative_geometry_follow_failure_mode() {
         for (w, h) in [(0.0, 40.0), (-1.0, 40.0), (50.0, 0.0), (f64::NAN, 40.0)] {

--- a/crates/hwpforge-smithy-pdf/src/image_sniff.rs
+++ b/crates/hwpforge-smithy-pdf/src/image_sniff.rs
@@ -16,7 +16,12 @@ pub(crate) enum Sniffed {
     Gif,
     /// WebP (`RIFF….WEBP`).
     Webp,
-    /// magic 은 알지만 렌더 불가 (BMP/WMF/EMF — 변환 정책은 W6).
+    /// magic 은 알지만 렌더 불가 (BMP/WMF/EMF).
+    ///
+    /// **W6 확정 정책 (§12a)**: strict = typed
+    /// `PdfError::UnsupportedImageFormat` / `--degraded` = 경고+스킵.
+    /// 포맷 변환(래스터화) 지원은 후속 슬라이스 — 그때까지 이 분기가
+    /// "무음 손실 없는 미지원" 을 소유한다.
     KnownUnsupported(&'static str),
     /// 빈/절단/미지 magic — 확장자로 추측하지 않는다.
     Unknown,


### PR DESCRIPTION
## 배경

이미지/글상자 에픽의 마지막 웨이브 W6 (§1 정의: 포맷 정책·md→hwpx 임베드 수리·corpus 전수 성적표). 설계 적대 리뷰 (파트② reject → v2 재설계) + 독립 구현 리뷰 (reject → 전건 상환) 반영. 상세 = 에픽 문서 §12~§12-r2.

## ② md→hwpx 이미지 BinData 임베드 수리 (실갭)

CLI/MCP convert 가 빈 ImageStore 를 인코더에 넘겨 이미지 참조가 BinData 미포장(dangling binaryItemIDRef)이던 결함 수리:

- **디스크 조회 경로와 패키지 키의 분리**: canonicalize+containment 로 경로 탈출 차단, 스니핑된 알려진 포맷만 적재 (임의 파일 반입 차단 — BM 위장 바이트는 BMP 구조 검사로 거부), 문서 키는 합성 정규명 `imageN.<ext>` (XML id/manifest 채널 보호, 동일 실파일 dedup)
- `data:` URI 로컬 디코드 지원 (base_dir 없는 MCP 인라인·CLI stdin 경로) · http(s) 는 typed 경고+제외
- 실패 참조 = run 드롭 + typed 경고, 단독 문단은 빈 run 으로 보존 (리뷰 B1 — md 표준 형태 회귀 방지) · bare 파일명 base_dir 정규화 (리뷰 B2)
- WebP 는 의도적 제외 (HWPX 캐리 한컴 미실측 — fixture 확보 시 재개)
- 시각 게이트: 생성 hwpx 한컴 오픈 — 마스코트 2위치 실물 렌더·dedup BinData 1개 (사용자 판정 통과)

## ① BMP/WMF/EMF 정책 W6 확정

strict = typed 에러 / `--degraded` = 경고+스킵을 확정 정책으로 rustdoc 명문화 + wmf/emf 양 모드 잠금 테스트 (기존 bmp 만 → 동열 확장).

## ③ corpus 전수 성적표 (에픽 종료 증빙)

baseline 동일 조건 (N=2,247·`--discovery hancom --degraded`·60s 타임아웃):

| 지표 | baseline (2026-08-11) | 현재 |
|---|---|---|
| ok | 71 (3.16%) | **130 (5.79%, +83%)** |
| crash/timeout | 0 | **0 유지** |

다음 지배 갭 = INVALID_CACHE 701 (성분 분석 후속) · 표 스타일/언어축/장평.

## 게이트

- embed 단위 14종 + 왕복 e2e 2종 + CLI 통합 3종 (bare 파일명·원격 단독 문단·기존) · make ci **3,414/3,414**
- 독립 리뷰: 보안(containment·심링크·합성 키) 전건 통과 실측, 기능 회귀 2건(B1·B2) 즉시 상환

## Semver

전부 additive/fix — 비파괴 (core sniff 신설·MdWarning non_exhaustive variant·smithy-md 공개 함수 추가). 머지 시 패치 릴리스 발화 예상.